### PR TITLE
M1: Universal Bridge Foundation - Protocol and Transport types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,32 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<!-- HL7 v2.x + MLLP -->
+		<dependency>
+			<groupId>ca.uhn.hapi</groupId>
+			<artifactId>hapi-base</artifactId>
+			<version>2.5.1</version>
+		</dependency>
+		<dependency>
+			<groupId>ca.uhn.hapi</groupId>
+			<artifactId>hapi-structures-v251</artifactId>
+			<version>2.5.1</version>
+		</dependency>
+
+		<!-- Serial communication -->
+		<dependency>
+			<groupId>com.fazecast</groupId>
+			<artifactId>jSerialComm</artifactId>
+			<version>2.11.0</version>
+		</dependency>
+
+		<!-- CSV parsing -->
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-csv</artifactId>
+			<version>1.11.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/org/itech/ahb/model/Protocol.java
+++ b/src/main/java/org/itech/ahb/model/Protocol.java
@@ -1,0 +1,30 @@
+package org.itech.ahb.model;
+
+/**
+ * Represents the message protocol format used by analyzers.
+ * <p>
+ * Protocol defines the structure and syntax of the message content,
+ * independent of how the message is transported.
+ * </p>
+ */
+public enum Protocol {
+    /**
+     * ASTM LIS2-A2 protocol - used by many clinical analyzers
+     */
+    ASTM,
+
+    /**
+     * HL7 v2.x protocol - health level 7 messaging standard
+     */
+    HL7,
+
+    /**
+     * CSV (Comma-Separated Values) - simple tabular format
+     */
+    CSV,
+
+    /**
+     * Unknown/unrecognized protocol
+     */
+    UNKNOWN
+}

--- a/src/main/java/org/itech/ahb/model/Transport.java
+++ b/src/main/java/org/itech/ahb/model/Transport.java
@@ -1,0 +1,36 @@
+package org.itech.ahb.model;
+
+/**
+ * Represents the transport/delivery method used to receive messages from analyzers.
+ * <p>
+ * Transport defines HOW the message is transmitted, independent of the message
+ * protocol format (ASTM, HL7, CSV, etc.).
+ * </p>
+ */
+public enum Transport {
+    /**
+     * Raw TCP socket connection (e.g., ASTM over TCP)
+     */
+    TCP,
+
+    /**
+     * MLLP (Minimal Lower Layer Protocol) - HL7's standard TCP framing
+     * Uses VT (0x0B) start, FS (0x1C) + CR (0x0D) end markers
+     */
+    MLLP,
+
+    /**
+     * Serial port communication (RS-232, RS-485, etc.)
+     */
+    SERIAL,
+
+    /**
+     * File-based communication (watch directory for new files)
+     */
+    FILE,
+
+    /**
+     * HTTP POST endpoint
+     */
+    HTTP
+}

--- a/src/main/java/org/itech/ahb/normalizer/MessageEnvelope.java
+++ b/src/main/java/org/itech/ahb/normalizer/MessageEnvelope.java
@@ -1,0 +1,59 @@
+package org.itech.ahb.normalizer;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import org.itech.ahb.model.Protocol;
+import org.itech.ahb.model.Transport;
+
+import java.time.Instant;
+
+/**
+ * Internal DTO for routing messages from listeners to the normalizer.
+ * <p>
+ * MessageEnvelope wraps the raw message with metadata about how it was received
+ * (transport type, source identifier, protocol) before it gets normalized and
+ * forwarded to OpenELIS.
+ * </p>
+ */
+@Getter
+@Builder
+@ToString
+public class MessageEnvelope {
+    /**
+     * Detected or specified protocol format (ASTM, HL7, CSV, etc.)
+     */
+    private final Protocol protocol;
+
+    /**
+     * Transport method used to receive the message (TCP, MLLP, SERIAL, FILE, HTTP)
+     */
+    private final Transport transport;
+
+    /**
+     * Source identifier (IP address, serial port, file path, etc.)
+     * <p>
+     * Examples:
+     * - TCP/MLLP/HTTP: "192.168.1.10"
+     * - Serial: "/dev/ttyUSB0"
+     * - File: "/mnt/analyzer-import/quantstudio/results-20260205.csv"
+     * </p>
+     */
+    private final String sourceId;
+
+    /**
+     * Raw message content (ASTM, HL7, or CSV string)
+     */
+    private final String rawMessage;
+
+    /**
+     * Timestamp when the message was received by the bridge
+     */
+    @Builder.Default
+    private final Instant receivedAt = Instant.now();
+
+    /**
+     * Optional analyzer identifier (if pre-configured or detected from message headers)
+     */
+    private final String analyzerId;
+}

--- a/src/main/java/org/itech/ahb/normalizer/NormalizedMessage.java
+++ b/src/main/java/org/itech/ahb/normalizer/NormalizedMessage.java
@@ -1,0 +1,69 @@
+package org.itech.ahb.normalizer;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import org.itech.ahb.model.Protocol;
+import org.itech.ahb.model.Transport;
+
+import java.time.Instant;
+
+/**
+ * Standardized message format sent to OpenELIS via HTTP POST.
+ * <p>
+ * NormalizedMessage provides a consistent JSON structure regardless of the
+ * original transport or protocol used by the analyzer. OpenELIS always receives
+ * this same format, whether the analyzer sent via TCP, MLLP, Serial, File, or HTTP.
+ * </p>
+ */
+@Getter
+@Builder
+@ToString
+public class NormalizedMessage {
+    /**
+     * Analyzer identifier (from configuration or message headers)
+     * <p>
+     * Used by OpenELIS to lookup the analyzer configuration and apply
+     * the correct result mappings.
+     * </p>
+     */
+    private final String analyzerId;
+
+    /**
+     * Message protocol format (ASTM, HL7, CSV)
+     */
+    private final Protocol protocol;
+
+    /**
+     * Transport method used to receive the message (TCP, MLLP, SERIAL, FILE, HTTP)
+     */
+    private final Transport transport;
+
+    /**
+     * Raw message content (preserves original format for OpenELIS parsing)
+     */
+    private final String message;
+
+    /**
+     * Source identifier (IP address, serial port, file path)
+     * <p>
+     * Provides additional context for debugging and audit logging.
+     * </p>
+     */
+    private final String sourceId;
+
+    /**
+     * Timestamp when the bridge received the message
+     */
+    private final Instant timestamp;
+
+    /**
+     * Optional message identifier (from ASTM header or HL7 MSH segment)
+     */
+    private final String messageId;
+
+    /**
+     * Optional error message if protocol detection or parsing failed
+     */
+    private final String error;
+}

--- a/src/main/java/org/itech/ahb/util/ProtocolDetector.java
+++ b/src/main/java/org/itech/ahb/util/ProtocolDetector.java
@@ -1,0 +1,95 @@
+package org.itech.ahb.util;
+
+import org.itech.ahb.model.Protocol;
+
+/**
+ * Utility class for auto-detecting message protocol format from message content.
+ * <p>
+ * ProtocolDetector examines message structure and known markers to identify
+ * whether a message is ASTM, HL7, CSV, or unknown format.
+ * </p>
+ */
+public class ProtocolDetector {
+
+    /**
+     * Detects the protocol format from message content.
+     * <p>
+     * Detection logic:
+     * <ul>
+     *   <li>ASTM: Starts with STX (0x02) or "H|\^&amp;" header</li>
+     *   <li>HL7: Starts with "MSH|" segment</li>
+     *   <li>CSV: Contains commas with multiple comma-separated values in first line</li>
+     *   <li>UNKNOWN: None of the above patterns match</li>
+     * </ul>
+     * </p>
+     *
+     * @param message the raw message content to analyze
+     * @return the detected Protocol enum value
+     */
+    public static Protocol detect(String message) {
+        if (message == null || message.isEmpty()) {
+            return Protocol.UNKNOWN;
+        }
+
+        // Remove leading whitespace for cleaner detection
+        String trimmed = message.trim();
+
+        // ASTM detection: STX (0x02) or "H|\^&" header
+        if (!trimmed.isEmpty() && trimmed.charAt(0) == 0x02) {
+            return Protocol.ASTM;
+        }
+        if (trimmed.startsWith("H|\\^&")) {
+            return Protocol.ASTM;
+        }
+
+        // HL7 detection: MSH| segment
+        if (trimmed.startsWith("MSH|")) {
+            return Protocol.HL7;
+        }
+
+        // CSV detection: contains commas and first line has multiple comma-separated values
+        if (trimmed.contains(",")) {
+            String firstLine = trimmed.split("\n")[0];
+            String[] columns = firstLine.split(",");
+            if (columns.length > 3) {  // Require at least 4 columns to be considered CSV
+                return Protocol.CSV;
+            }
+        }
+
+        return Protocol.UNKNOWN;
+    }
+
+    /**
+     * Checks if the message is a valid ASTM format.
+     *
+     * @param message the message to check
+     * @return true if message appears to be ASTM format
+     */
+    public static boolean isASTM(String message) {
+        return detect(message) == Protocol.ASTM;
+    }
+
+    /**
+     * Checks if the message is a valid HL7 format.
+     *
+     * @param message the message to check
+     * @return true if message appears to be HL7 format
+     */
+    public static boolean isHL7(String message) {
+        return detect(message) == Protocol.HL7;
+    }
+
+    /**
+     * Checks if the message is a valid CSV format.
+     *
+     * @param message the message to check
+     * @return true if message appears to be CSV format
+     */
+    public static boolean isCSV(String message) {
+        return detect(message) == Protocol.CSV;
+    }
+
+    private ProtocolDetector() {
+        // Utility class - prevent instantiation
+    }
+}

--- a/src/test/java/org/itech/ahb/normalizer/MessageEnvelopeTest.java
+++ b/src/test/java/org/itech/ahb/normalizer/MessageEnvelopeTest.java
@@ -1,0 +1,125 @@
+package org.itech.ahb.normalizer;
+
+import org.itech.ahb.model.Protocol;
+import org.itech.ahb.model.Transport;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for MessageEnvelope DTO.
+ */
+class MessageEnvelopeTest {
+
+    @Test
+    void testBuilderCreatesValidEnvelope() {
+        String rawMessage = "H|\\^&|||TEST|||...";
+        MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.ASTM)
+                .transport(Transport.TCP)
+                .sourceId("192.168.1.10")
+                .rawMessage(rawMessage)
+                .analyzerId("MINDRAY-BC5380-001")
+                .build();
+
+        assertNotNull(envelope);
+        assertEquals(Protocol.ASTM, envelope.getProtocol());
+        assertEquals(Transport.TCP, envelope.getTransport());
+        assertEquals("192.168.1.10", envelope.getSourceId());
+        assertEquals(rawMessage, envelope.getRawMessage());
+        assertEquals("MINDRAY-BC5380-001", envelope.getAnalyzerId());
+        assertNotNull(envelope.getReceivedAt());
+    }
+
+    @Test
+    void testBuilderSetsTimestampAutomatically() {
+        Instant before = Instant.now();
+
+        MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.HL7)
+                .transport(Transport.MLLP)
+                .sourceId("192.168.1.11")
+                .rawMessage("MSH|^~\\&|TEST|||...")
+                .build();
+
+        Instant after = Instant.now();
+
+        assertNotNull(envelope.getReceivedAt());
+        assertTrue(envelope.getReceivedAt().isAfter(before) || envelope.getReceivedAt().equals(before));
+        assertTrue(envelope.getReceivedAt().isBefore(after) || envelope.getReceivedAt().equals(after));
+    }
+
+    @Test
+    void testEnvelopeWithSerialTransport() {
+        MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.ASTM)
+                .transport(Transport.SERIAL)
+                .sourceId("/dev/ttyUSB0")
+                .rawMessage("H|\\^&|||HORIBA|||...")
+                .analyzerId("HORIBA-PENTRA60-001")
+                .build();
+
+        assertEquals(Transport.SERIAL, envelope.getTransport());
+        assertEquals("/dev/ttyUSB0", envelope.getSourceId());
+    }
+
+    @Test
+    void testEnvelopeWithFileTransport() {
+        String filePath = "/mnt/analyzer-import/quantstudio/results-20260205.csv";
+        MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.CSV)
+                .transport(Transport.FILE)
+                .sourceId(filePath)
+                .rawMessage("SampleID,TestCode,Result\n12345,GLU,95")
+                .analyzerId("QUANTSTUDIO-001")
+                .build();
+
+        assertEquals(Transport.FILE, envelope.getTransport());
+        assertEquals(Protocol.CSV, envelope.getProtocol());
+        assertEquals(filePath, envelope.getSourceId());
+    }
+
+    @Test
+    void testEnvelopeWithHTTPTransport() {
+        MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.HL7)
+                .transport(Transport.HTTP)
+                .sourceId("192.168.1.20")
+                .rawMessage("MSH|^~\\&|ANALYZER|||...")
+                .build();
+
+        assertEquals(Transport.HTTP, envelope.getTransport());
+        assertNull(envelope.getAnalyzerId()); // Not set
+    }
+
+    @Test
+    void testEnvelopeWithoutAnalyzerId() {
+        MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.ASTM)
+                .transport(Transport.TCP)
+                .sourceId("192.168.1.99")
+                .rawMessage("H|\\^&|||UNKNOWN|||...")
+                .build();
+
+        assertNull(envelope.getAnalyzerId());
+    }
+
+    @Test
+    void testToStringDoesNotThrowException() {
+        MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.ASTM)
+                .transport(Transport.TCP)
+                .sourceId("192.168.1.10")
+                .rawMessage("H|\\^&|||TEST|||...")
+                .analyzerId("TEST-001")
+                .build();
+
+        String str = envelope.toString();
+        assertNotNull(str);
+        assertTrue(str.contains("ASTM"));
+        assertTrue(str.contains("TCP"));
+        assertTrue(str.contains("192.168.1.10"));
+    }
+}

--- a/src/test/java/org/itech/ahb/normalizer/NormalizedMessageTest.java
+++ b/src/test/java/org/itech/ahb/normalizer/NormalizedMessageTest.java
@@ -1,0 +1,198 @@
+package org.itech.ahb.normalizer;
+
+import org.itech.ahb.model.Protocol;
+import org.itech.ahb.model.Transport;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for NormalizedMessage DTO.
+ */
+class NormalizedMessageTest {
+
+    @Test
+    void testBuilderCreatesValidNormalizedMessage() {
+        Instant timestamp = Instant.now();
+        String rawMessage = "H|\\^&|||MINDRAY|||...";
+
+        NormalizedMessage message = NormalizedMessage.builder()
+                .analyzerId("MINDRAY-BC5380-001")
+                .protocol(Protocol.ASTM)
+                .transport(Transport.TCP)
+                .message(rawMessage)
+                .sourceId("192.168.1.10")
+                .timestamp(timestamp)
+                .messageId("MSG-12345")
+                .build();
+
+        assertNotNull(message);
+        assertEquals("MINDRAY-BC5380-001", message.getAnalyzerId());
+        assertEquals(Protocol.ASTM, message.getProtocol());
+        assertEquals(Transport.TCP, message.getTransport());
+        assertEquals(rawMessage, message.getMessage());
+        assertEquals("192.168.1.10", message.getSourceId());
+        assertEquals(timestamp, message.getTimestamp());
+        assertEquals("MSG-12345", message.getMessageId());
+        assertNull(message.getError());
+    }
+
+    @Test
+    void testNormalizedMessageWithHL7AndMLLP() {
+        Instant timestamp = Instant.now();
+        String hl7Message = "MSH|^~\\&|SYSMEX|||20260205120000||ORU^R01|MSG001|P|2.5.1";
+
+        NormalizedMessage message = NormalizedMessage.builder()
+                .analyzerId("SYSMEX-XN-001")
+                .protocol(Protocol.HL7)
+                .transport(Transport.MLLP)
+                .message(hl7Message)
+                .sourceId("192.168.1.11")
+                .timestamp(timestamp)
+                .messageId("MSG001")
+                .build();
+
+        assertEquals(Protocol.HL7, message.getProtocol());
+        assertEquals(Transport.MLLP, message.getTransport());
+        assertEquals("MSG001", message.getMessageId());
+    }
+
+    @Test
+    void testNormalizedMessageWithSerialTransport() {
+        Instant timestamp = Instant.now();
+
+        NormalizedMessage message = NormalizedMessage.builder()
+                .analyzerId("HORIBA-PENTRA60-001")
+                .protocol(Protocol.ASTM)
+                .transport(Transport.SERIAL)
+                .message("H|\\^&|||HORIBA|||...")
+                .sourceId("/dev/ttyUSB0")
+                .timestamp(timestamp)
+                .build();
+
+        assertEquals(Transport.SERIAL, message.getTransport());
+        assertEquals("/dev/ttyUSB0", message.getSourceId());
+        assertNull(message.getMessageId()); // Not set
+    }
+
+    @Test
+    void testNormalizedMessageWithFileTransport() {
+        Instant timestamp = Instant.now();
+        String csvContent = "SampleID,TestCode,Result,Units\n12345,GLU,95,mg/dL";
+
+        NormalizedMessage message = NormalizedMessage.builder()
+                .analyzerId("QUANTSTUDIO-001")
+                .protocol(Protocol.CSV)
+                .transport(Transport.FILE)
+                .message(csvContent)
+                .sourceId("/mnt/analyzer-import/quantstudio/results-20260205.csv")
+                .timestamp(timestamp)
+                .build();
+
+        assertEquals(Protocol.CSV, message.getProtocol());
+        assertEquals(Transport.FILE, message.getTransport());
+        assertTrue(message.getSourceId().endsWith(".csv"));
+    }
+
+    @Test
+    void testNormalizedMessageWithHTTPTransport() {
+        Instant timestamp = Instant.now();
+
+        NormalizedMessage message = NormalizedMessage.builder()
+                .analyzerId("ANALYZER-HTTP-001")
+                .protocol(Protocol.HL7)
+                .transport(Transport.HTTP)
+                .message("MSH|^~\\&|ANALYZER|||...")
+                .sourceId("192.168.1.20")
+                .timestamp(timestamp)
+                .build();
+
+        assertEquals(Transport.HTTP, message.getTransport());
+    }
+
+    @Test
+    void testNormalizedMessageWithError() {
+        Instant timestamp = Instant.now();
+
+        NormalizedMessage message = NormalizedMessage.builder()
+                .analyzerId("UNKNOWN-001")
+                .protocol(Protocol.UNKNOWN)
+                .transport(Transport.TCP)
+                .message("Invalid message content")
+                .sourceId("192.168.1.99")
+                .timestamp(timestamp)
+                .error("Protocol detection failed: unknown format")
+                .build();
+
+        assertEquals(Protocol.UNKNOWN, message.getProtocol());
+        assertNotNull(message.getError());
+        assertTrue(message.getError().contains("Protocol detection failed"));
+    }
+
+    @Test
+    void testNormalizedMessageWithoutOptionalFields() {
+        Instant timestamp = Instant.now();
+
+        NormalizedMessage message = NormalizedMessage.builder()
+                .analyzerId("TEST-001")
+                .protocol(Protocol.ASTM)
+                .transport(Transport.TCP)
+                .message("H|\\^&|||TEST|||...")
+                .sourceId("192.168.1.10")
+                .timestamp(timestamp)
+                .build();
+
+        assertNotNull(message.getAnalyzerId());
+        assertNotNull(message.getMessage());
+        assertNull(message.getMessageId());
+        assertNull(message.getError());
+    }
+
+    @Test
+    void testToStringDoesNotThrowException() {
+        Instant timestamp = Instant.now();
+
+        NormalizedMessage message = NormalizedMessage.builder()
+                .analyzerId("TEST-001")
+                .protocol(Protocol.ASTM)
+                .transport(Transport.TCP)
+                .message("H|\\^&|||TEST|||...")
+                .sourceId("192.168.1.10")
+                .timestamp(timestamp)
+                .messageId("MSG-001")
+                .build();
+
+        String str = message.toString();
+        assertNotNull(str);
+        assertTrue(str.contains("TEST-001"));
+        assertTrue(str.contains("ASTM"));
+        assertTrue(str.contains("TCP"));
+    }
+
+    @Test
+    void testAllProtocolsAndTransportsCombinations() {
+        Instant timestamp = Instant.now();
+
+        // Test all valid protocol/transport combinations
+        Protocol[] protocols = {Protocol.ASTM, Protocol.HL7, Protocol.CSV};
+        Transport[] transports = {Transport.TCP, Transport.MLLP, Transport.SERIAL, Transport.FILE, Transport.HTTP};
+
+        for (Protocol protocol : protocols) {
+            for (Transport transport : transports) {
+                NormalizedMessage message = NormalizedMessage.builder()
+                        .analyzerId("TEST-001")
+                        .protocol(protocol)
+                        .transport(transport)
+                        .message("test message")
+                        .sourceId("test-source")
+                        .timestamp(timestamp)
+                        .build();
+
+                assertEquals(protocol, message.getProtocol());
+                assertEquals(transport, message.getTransport());
+            }
+        }
+    }
+}

--- a/src/test/java/org/itech/ahb/util/ProtocolDetectorTest.java
+++ b/src/test/java/org/itech/ahb/util/ProtocolDetectorTest.java
@@ -1,0 +1,129 @@
+package org.itech.ahb.util;
+
+import org.itech.ahb.model.Protocol;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for ProtocolDetector utility class.
+ */
+class ProtocolDetectorTest {
+
+    @Test
+    void testDetectASTM_withSTXCharacter() {
+        String message = "\u0002H|\\^&|||...";
+        assertEquals(Protocol.ASTM, ProtocolDetector.detect(message));
+        assertTrue(ProtocolDetector.isASTM(message));
+    }
+
+    @Test
+    void testDetectASTM_withHeaderMarker() {
+        String message = "H|\\^&|||TEST|||...";
+        assertEquals(Protocol.ASTM, ProtocolDetector.detect(message));
+        assertTrue(ProtocolDetector.isASTM(message));
+    }
+
+    @Test
+    void testDetectHL7_withMSHSegment() {
+        String message = "MSH|^~\\&|TEST|||20260205120000||ORU^R01|MSG001|P|2.5.1";
+        assertEquals(Protocol.HL7, ProtocolDetector.detect(message));
+        assertTrue(ProtocolDetector.isHL7(message));
+    }
+
+    @Test
+    void testDetectHL7_withWhitespace() {
+        String message = "  \nMSH|^~\\&|TEST|||20260205120000||ORU^R01|MSG001|P|2.5.1";
+        assertEquals(Protocol.HL7, ProtocolDetector.detect(message));
+    }
+
+    @Test
+    void testDetectCSV_withMultipleColumns() {
+        String message = "SampleID,TestCode,Result,Units,Timestamp\n" +
+                        "12345,GLU,95,mg/dL,2026-02-05T12:00:00";
+        assertEquals(Protocol.CSV, ProtocolDetector.detect(message));
+        assertTrue(ProtocolDetector.isCSV(message));
+    }
+
+    @Test
+    void testDetectCSV_minimumColumns() {
+        // Requires at least 4 columns (>3)
+        String message = "A,B,C,D";
+        assertEquals(Protocol.CSV, ProtocolDetector.detect(message));
+    }
+
+    @Test
+    void testDetectUnknown_withTooFewCommas() {
+        // Only 3 columns - not enough for CSV
+        String message = "A,B,C";
+        assertEquals(Protocol.UNKNOWN, ProtocolDetector.detect(message));
+    }
+
+    @Test
+    void testDetectUnknown_withNullMessage() {
+        assertEquals(Protocol.UNKNOWN, ProtocolDetector.detect(null));
+    }
+
+    @Test
+    void testDetectUnknown_withEmptyMessage() {
+        assertEquals(Protocol.UNKNOWN, ProtocolDetector.detect(""));
+    }
+
+    @Test
+    void testDetectUnknown_withWhitespaceOnly() {
+        assertEquals(Protocol.UNKNOWN, ProtocolDetector.detect("   \n\t  "));
+    }
+
+    @Test
+    void testDetectUnknown_withUnrecognizedFormat() {
+        String message = "This is just plain text with no structure";
+        assertEquals(Protocol.UNKNOWN, ProtocolDetector.detect(message));
+    }
+
+    @Test
+    void testIsASTM_returnsFalseForHL7() {
+        String message = "MSH|^~\\&|TEST|||20260205120000||ORU^R01|MSG001|P|2.5.1";
+        assertFalse(ProtocolDetector.isASTM(message));
+    }
+
+    @Test
+    void testIsHL7_returnsFalseForASTM() {
+        String message = "H|\\^&|||TEST|||...";
+        assertFalse(ProtocolDetector.isHL7(message));
+    }
+
+    @Test
+    void testIsCSV_returnsFalseForASTM() {
+        String message = "H|\\^&|||TEST|||...";
+        assertFalse(ProtocolDetector.isCSV(message));
+    }
+
+    @Test
+    void testComplexASTMMessage() {
+        String message = "H|\\^&|||MINDRAY^BC-5380|||||||P|1|20260205120000\r" +
+                        "P|1||12345||DOE^JOHN||19800101|M\r" +
+                        "O|1|12345||^^^WBC\\^^^RBC|R||20260205120000\r" +
+                        "R|1|^^^WBC|7.5|10^3/uL||N||F\r" +
+                        "R|2|^^^RBC|4.8|10^6/uL||N||F\r" +
+                        "L|1|N";
+        assertEquals(Protocol.ASTM, ProtocolDetector.detect(message));
+    }
+
+    @Test
+    void testComplexHL7Message() {
+        String message = "MSH|^~\\&|MINDRAY^BC-5380|LAB|OpenELIS|OpenELIS|20260205120000||ORU^R01|MSG001|P|2.5.1\r" +
+                        "PID|1||12345||DOE^JOHN||19800101|M\r" +
+                        "OBR|1||12345|CBC^COMPLETE BLOOD COUNT\r" +
+                        "OBX|1|NM|WBC^White Blood Cell Count||7.5|10^3/uL|4.0-11.0|N|||F\r" +
+                        "OBX|2|NM|RBC^Red Blood Cell Count||4.8|10^6/uL|4.5-5.5|N|||F";
+        assertEquals(Protocol.HL7, ProtocolDetector.detect(message));
+    }
+
+    @Test
+    void testComplexCSVMessage() {
+        String message = "Sample ID,Test Code,Result,Unit,Flag,Timestamp\r\n" +
+                        "12345,WBC,7.5,10^3/uL,N,2026-02-05T12:00:00\r\n" +
+                        "12345,RBC,4.8,10^6/uL,N,2026-02-05T12:00:00";
+        assertEquals(Protocol.CSV, ProtocolDetector.detect(message));
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements **M1: Foundation** for the Universal Analyzer Bridge, establishing core types and protocol detection that enable the bridge to handle multiple analyzer protocols (ASTM, HL7, CSV) over multiple transports (TCP, MLLP, Serial, File, HTTP).

## What Changed

### Core Model Types
- **Protocol enum**: ASTM, HL7, CSV, UNKNOWN
- **Transport enum**: TCP, MLLP, SERIAL, FILE, HTTP

### DTOs
- **MessageEnvelope**: Internal routing wrapper (listener → normalizer)
- **NormalizedMessage**: Standardized output format (bridge → OpenELIS)

### Utilities
- **ProtocolDetector**: Auto-detection based on message content heuristics
  - ASTM: Starts with STX (0x02) or "H|\^&"
  - HL7: Starts with "MSH|"
  - CSV: 4+ comma-separated columns

### Dependencies Added
- **HAPI HL7 v2** (`hapi-base:2.5.1`, `hapi-structures-v251:2.5.1`) - For M2 MLLP listener
- **jSerialComm** (`2.11.0`) - For M3 Serial listener
- **Apache Commons CSV** (`1.11.0`) - For M4 File watcher CSV parsing

## Key Architectural Decision

**Protocol vs Transport Separation**: This foundation clearly separates:
- **Protocol** = Message format (ASTM, HL7, CSV)
- **Transport** = Delivery method (TCP, MLLP, Serial, File, HTTP)

This separation allows any protocol to be received via any transport. For example:
- HL7 messages can arrive via MLLP (most common), Serial, or File
- ASTM messages can arrive via TCP (existing), Serial, or File

## Testing

✅ **33 unit tests, all passing**
- `ProtocolDetectorTest`: 17 tests covering edge cases
- `MessageEnvelopeTest`: 7 tests for all transports
- `NormalizedMessageTest`: 9 tests for all protocol/transport combinations

```
Tests run: 33, Failures: 0, Errors: 0, Skipped: 0
```

## Dependencies

This is a **blocking milestone** - M2-M6 (listeners) depend on these foundation types.

**Parallel work enabled after merge:**
- M2: MLLP Listener (HAPI)
- M3: Serial Listener (jSerialComm)
- M4: File Watcher (WatchService)
- M5: HTTP Input Endpoint
- M6: ASTM Enhancements (Source IP header)

## Test Plan

- [x] All unit tests pass
- [x] Code compiles with new dependencies
- [x] Foundation types support all planned transports
- [ ] CI/CD passes (if configured)

## Related

- Part of Universal Analyzer Bridge implementation
- Supports Madagascar Analyzer Integration (Feature 011)
- See: `/home/ubuntu/.claude/plans/universal-analyzer-bridge.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)