### PR TITLE
feat: Add HTTP input endpoint (M5)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,10 @@ RUN --mount=type=cache,target=/root/.m2,sharing=locked \
 #
 WORKDIR /build
 ADD ./pom.xml /build/pom.xml
-RUN --mount=type=cache,target=/root/.m2 \
-  mvn dependency:go-offline   
+RUN --mount=type=cache,target=/root/.m2,sharing=locked \
+  mvn dependency:go-offline
 ADD ./src /build/src
-RUN --mount=type=cache,target=/root/.m2 \
+RUN --mount=type=cache,target=/root/.m2,sharing=locked \
   mvn clean package -DskipTests
 
 ##

--- a/src/main/java/org/itech/ahb/controller/AnalyzerInputController.java
+++ b/src/main/java/org/itech/ahb/controller/AnalyzerInputController.java
@@ -1,0 +1,206 @@
+package org.itech.ahb.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.itech.ahb.model.Protocol;
+import org.itech.ahb.model.Transport;
+import org.itech.ahb.normalizer.MessageEnvelope;
+import org.itech.ahb.util.ProtocolDetector;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * HTTP input endpoint for analyzers with REST API capabilities.
+ * <p>
+ * This controller accepts raw analyzer messages (ASTM, HL7, or CSV) over HTTP POST
+ * and creates a MessageEnvelope for downstream processing by the message normalizer.
+ * </p>
+ * <p>
+ * Protocol detection:
+ * <ul>
+ *   <li>application/hl7-v2 or x-hl7-v2 → HL7</li>
+ *   <li>text/csv → CSV</li>
+ *   <li>text/plain or other → auto-detect from message content</li>
+ * </ul>
+ * </p>
+ */
+@RestController
+@RequestMapping("/input")
+@Slf4j
+public class AnalyzerInputController {
+
+    /**
+     * Content-Type for HL7 v2 messages (application/hl7-v2 or vendor variations).
+     */
+    private static final String CONTENT_TYPE_HL7_V2 = "application/hl7-v2";
+    private static final String CONTENT_TYPE_HL7_V2_ALT = "x-application/hl7-v2";
+
+    /**
+     * Receives analyzer messages over HTTP POST.
+     * <p>
+     * The endpoint auto-detects the protocol from Content-Type header or message content,
+     * extracts the source IP from the request, and creates a MessageEnvelope for processing.
+     * </p>
+     *
+     * @param requestBody the raw message content (ASTM, HL7, or CSV)
+     * @param contentType the Content-Type header (optional, used for protocol hints)
+     * @param xForwardedFor the X-Forwarded-For header (optional, for proxy scenarios)
+     * @param request the HTTP servlet request (for extracting remote address)
+     * @return ResponseEntity with envelope details or error message
+     */
+    @PostMapping(consumes = MediaType.ALL_VALUE)
+    public ResponseEntity<InputResponse> receiveAnalyzerMessage(
+            @RequestBody(required = false) String requestBody,
+            @RequestHeader(value = "Content-Type", required = false) String contentType,
+            @RequestHeader(value = "X-Forwarded-For", required = false) String xForwardedFor,
+            HttpServletRequest request) {
+
+        log.debug("Received HTTP input request");
+        log.trace("Content-Type: {}", contentType);
+        log.trace("X-Forwarded-For: {}", xForwardedFor);
+
+        // Validate request body
+        if (requestBody == null || requestBody.trim().isEmpty()) {
+            log.warn("Received empty request body");
+            return ResponseEntity.badRequest()
+                    .body(new InputResponse(false, "Request body is required", null, null, null));
+        }
+
+        // Extract source IP
+        String sourceIp = extractSourceIp(xForwardedFor, request);
+        log.debug("Source IP: {}", sourceIp);
+
+        // Detect protocol
+        Protocol protocol = detectProtocol(contentType, requestBody);
+        log.debug("Detected protocol: {}", protocol);
+
+        // Reject UNKNOWN protocol
+        if (protocol == Protocol.UNKNOWN) {
+            log.warn("Unable to detect protocol for message from {}", sourceIp);
+            return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
+                    .body(new InputResponse(false, "Unable to detect message protocol", sourceIp, null, null));
+        }
+
+        // Create MessageEnvelope
+        MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(protocol)
+                .transport(Transport.HTTP)
+                .sourceId(sourceIp)
+                .rawMessage(requestBody)
+                .build();
+
+        log.info("Created MessageEnvelope: protocol={}, transport={}, sourceId={}",
+                envelope.getProtocol(), envelope.getTransport(), envelope.getSourceId());
+
+        // TODO: In M7, this will be forwarded to the MessageNormalizer for routing
+        // For now, we just return success with envelope details
+
+        return ResponseEntity.ok(new InputResponse(
+                true,
+                "Message received successfully",
+                sourceIp,
+                protocol.name(),
+                envelope.getReceivedAt().toString()));
+    }
+
+    /**
+     * Extracts the source IP address from the HTTP request.
+     * <p>
+     * Priority:
+     * <ol>
+     *   <li>X-Forwarded-For header (first IP in chain, for proxied requests)</li>
+     *   <li>X-Real-IP header (common proxy header)</li>
+     *   <li>Remote address from the servlet request</li>
+     * </ol>
+     * </p>
+     *
+     * @param xForwardedFor the X-Forwarded-For header value
+     * @param request the HTTP servlet request
+     * @return the extracted source IP address
+     */
+    String extractSourceIp(String xForwardedFor, HttpServletRequest request) {
+        // Try X-Forwarded-For header first (handles proxy chains)
+        if (xForwardedFor != null && !xForwardedFor.trim().isEmpty()) {
+            // X-Forwarded-For may contain multiple IPs: "client, proxy1, proxy2"
+            // The first IP is the original client
+            String[] ips = xForwardedFor.split(",");
+            String clientIp = ips[0].trim();
+            if (!clientIp.isEmpty()) {
+                return clientIp;
+            }
+        }
+
+        // Try X-Real-IP header (common in nginx)
+        String xRealIp = request.getHeader("X-Real-IP");
+        if (xRealIp != null && !xRealIp.trim().isEmpty()) {
+            return xRealIp.trim();
+        }
+
+        // Fall back to remote address
+        String remoteAddr = request.getRemoteAddr();
+        return remoteAddr != null ? remoteAddr : "unknown";
+    }
+
+    /**
+     * Detects the protocol from Content-Type header or message content.
+     * <p>
+     * Content-Type hints:
+     * <ul>
+     *   <li>application/hl7-v2, x-application/hl7-v2 → HL7</li>
+     *   <li>text/csv → CSV</li>
+     *   <li>text/plain, other, or missing → auto-detect from content</li>
+     * </ul>
+     * </p>
+     *
+     * @param contentType the Content-Type header value
+     * @param messageBody the message content for auto-detection
+     * @return the detected Protocol
+     */
+    Protocol detectProtocol(String contentType, String messageBody) {
+        if (contentType != null) {
+            String ct = contentType.toLowerCase().trim();
+
+            // Extract base content type (before any parameters like charset)
+            int semicolonIndex = ct.indexOf(';');
+            if (semicolonIndex > 0) {
+                ct = ct.substring(0, semicolonIndex).trim();
+            }
+
+            // Check for HL7 content type
+            if (ct.equals(CONTENT_TYPE_HL7_V2) || ct.equals(CONTENT_TYPE_HL7_V2_ALT)
+                    || ct.contains("hl7")) {
+                return Protocol.HL7;
+            }
+
+            // Check for CSV content type
+            if (ct.equals("text/csv") || ct.equals("application/csv")) {
+                return Protocol.CSV;
+            }
+
+            // Check for ASTM content type (non-standard but possible)
+            if (ct.contains("astm")) {
+                return Protocol.ASTM;
+            }
+        }
+
+        // Auto-detect from message content
+        return ProtocolDetector.detect(messageBody);
+    }
+
+    /**
+     * Response DTO for the input endpoint.
+     */
+    public record InputResponse(
+            boolean success,
+            String message,
+            String sourceIp,
+            String protocol,
+            String receivedAt) {
+    }
+}

--- a/src/test/java/org/itech/ahb/controller/AnalyzerInputControllerTest.java
+++ b/src/test/java/org/itech/ahb/controller/AnalyzerInputControllerTest.java
@@ -1,0 +1,421 @@
+package org.itech.ahb.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.itech.ahb.model.Protocol;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for AnalyzerInputController.
+ * Tests HTTP input endpoint for ASTM, HL7, and CSV messages.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class AnalyzerInputControllerTest {
+
+    private AnalyzerInputController controller;
+
+    @Mock
+    private HttpServletRequest mockRequest;
+
+    // Sample messages
+    private static final String SAMPLE_ASTM_MESSAGE = "H|\\^&|||HOST^NAME|||||||LIS2-A2|20260205120000\r" +
+            "P|1||||Doe^John||19850101|M\r" +
+            "O|1|12345||^^^GLU\r" +
+            "R|1|^^^GLU|95|mg/dL||N||F||20260205120000\r" +
+            "L|1|N";
+
+    private static final String SAMPLE_HL7_MESSAGE = "MSH|^~\\&|ANALYZER|LAB|OPENELIS|HOST|20260205120000||ORU^R01|123456|P|2.5.1\r" +
+            "PID|1||12345||Doe^John||19850101|M\r" +
+            "OBR|1|12345||GLU^Glucose\r" +
+            "OBX|1|NM|GLU^Glucose||95|mg/dL||N||F";
+
+    private static final String SAMPLE_CSV_MESSAGE = "SampleID,TestCode,Result,Units,Flags,DateTime\n" +
+            "12345,GLU,95,mg/dL,N,20260205120000\n" +
+            "12346,HGB,14.2,g/dL,N,20260205120100\n" +
+            "12347,WBC,7.5,10^3/uL,,20260205120200";
+
+    @BeforeEach
+    void setUp() {
+        controller = new AnalyzerInputController();
+        lenient().when(mockRequest.getRemoteAddr()).thenReturn("127.0.0.1");
+    }
+
+    @Nested
+    @DisplayName("Protocol Detection via Content-Type")
+    class ContentTypeProtocolDetectionTests {
+
+        @Test
+        @DisplayName("Should detect HL7 from application/hl7-v2 Content-Type")
+        void shouldDetectHL7FromContentType() {
+            ResponseEntity<AnalyzerInputController.InputResponse> response =
+                    controller.receiveAnalyzerMessage(SAMPLE_HL7_MESSAGE, "application/hl7-v2", null, mockRequest);
+
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertTrue(response.getBody().success());
+            assertEquals("HL7", response.getBody().protocol());
+        }
+
+        @Test
+        @DisplayName("Should detect HL7 from x-application/hl7-v2 Content-Type")
+        void shouldDetectHL7FromAltContentType() {
+            ResponseEntity<AnalyzerInputController.InputResponse> response =
+                    controller.receiveAnalyzerMessage(SAMPLE_HL7_MESSAGE, "x-application/hl7-v2", null, mockRequest);
+
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertEquals("HL7", response.getBody().protocol());
+        }
+
+        @Test
+        @DisplayName("Should detect CSV from text/csv Content-Type")
+        void shouldDetectCSVFromContentType() {
+            ResponseEntity<AnalyzerInputController.InputResponse> response =
+                    controller.receiveAnalyzerMessage(SAMPLE_CSV_MESSAGE, "text/csv", null, mockRequest);
+
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertEquals("CSV", response.getBody().protocol());
+        }
+
+        @Test
+        @DisplayName("Should detect CSV from application/csv Content-Type")
+        void shouldDetectCSVFromApplicationCsvContentType() {
+            ResponseEntity<AnalyzerInputController.InputResponse> response =
+                    controller.receiveAnalyzerMessage(SAMPLE_CSV_MESSAGE, "application/csv", null, mockRequest);
+
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertEquals("CSV", response.getBody().protocol());
+        }
+
+        @Test
+        @DisplayName("Should handle Content-Type with charset parameter")
+        void shouldHandleContentTypeWithCharset() {
+            ResponseEntity<AnalyzerInputController.InputResponse> response =
+                    controller.receiveAnalyzerMessage(SAMPLE_HL7_MESSAGE, "application/hl7-v2; charset=utf-8", null, mockRequest);
+
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertEquals("HL7", response.getBody().protocol());
+        }
+
+        @Test
+        @DisplayName("Should detect ASTM from astm content type")
+        void shouldDetectASTMFromContentType() {
+            ResponseEntity<AnalyzerInputController.InputResponse> response =
+                    controller.receiveAnalyzerMessage(SAMPLE_ASTM_MESSAGE, "application/x-astm", null, mockRequest);
+
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertEquals("ASTM", response.getBody().protocol());
+        }
+    }
+
+    @Nested
+    @DisplayName("Protocol Auto-Detection from Message Content")
+    class AutoDetectionTests {
+
+        @Test
+        @DisplayName("Should auto-detect ASTM from message content")
+        void shouldAutoDetectASTM() {
+            ResponseEntity<AnalyzerInputController.InputResponse> response =
+                    controller.receiveAnalyzerMessage(SAMPLE_ASTM_MESSAGE, "text/plain", null, mockRequest);
+
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertEquals("ASTM", response.getBody().protocol());
+        }
+
+        @Test
+        @DisplayName("Should auto-detect HL7 from message content (text/plain)")
+        void shouldAutoDetectHL7() {
+            ResponseEntity<AnalyzerInputController.InputResponse> response =
+                    controller.receiveAnalyzerMessage(SAMPLE_HL7_MESSAGE, "text/plain", null, mockRequest);
+
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertEquals("HL7", response.getBody().protocol());
+        }
+
+        @Test
+        @DisplayName("Should auto-detect CSV from message content (text/plain)")
+        void shouldAutoDetectCSV() {
+            ResponseEntity<AnalyzerInputController.InputResponse> response =
+                    controller.receiveAnalyzerMessage(SAMPLE_CSV_MESSAGE, "text/plain", null, mockRequest);
+
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertEquals("CSV", response.getBody().protocol());
+        }
+
+        @Test
+        @DisplayName("Should auto-detect ASTM starting with STX byte")
+        void shouldAutoDetectASTMWithSTX() {
+            String astmWithSTX = "\u0002" + SAMPLE_ASTM_MESSAGE;
+            ResponseEntity<AnalyzerInputController.InputResponse> response =
+                    controller.receiveAnalyzerMessage(astmWithSTX, "text/plain", null, mockRequest);
+
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertEquals("ASTM", response.getBody().protocol());
+        }
+
+        @Test
+        @DisplayName("Should auto-detect when Content-Type is null")
+        void shouldAutoDetectWithNullContentType() {
+            ResponseEntity<AnalyzerInputController.InputResponse> response =
+                    controller.receiveAnalyzerMessage(SAMPLE_HL7_MESSAGE, null, null, mockRequest);
+
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertEquals("HL7", response.getBody().protocol());
+        }
+    }
+
+    @Nested
+    @DisplayName("Source IP Extraction")
+    class SourceIPExtractionTests {
+
+        @Test
+        @DisplayName("Should extract source IP from X-Forwarded-For header")
+        void shouldExtractFromXForwardedFor() {
+            ResponseEntity<AnalyzerInputController.InputResponse> response =
+                    controller.receiveAnalyzerMessage(SAMPLE_ASTM_MESSAGE, "text/plain", "192.168.1.100", mockRequest);
+
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertEquals("192.168.1.100", response.getBody().sourceIp());
+        }
+
+        @Test
+        @DisplayName("Should extract first IP from X-Forwarded-For chain")
+        void shouldExtractFirstIPFromChain() {
+            ResponseEntity<AnalyzerInputController.InputResponse> response =
+                    controller.receiveAnalyzerMessage(SAMPLE_ASTM_MESSAGE, "text/plain",
+                            "192.168.1.100, 10.0.0.1, 172.16.0.1", mockRequest);
+
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertEquals("192.168.1.100", response.getBody().sourceIp());
+        }
+
+        @Test
+        @DisplayName("Should extract source IP from X-Real-IP when X-Forwarded-For is missing")
+        void shouldExtractFromXRealIP() {
+            when(mockRequest.getHeader("X-Real-IP")).thenReturn("10.20.30.40");
+
+            ResponseEntity<AnalyzerInputController.InputResponse> response =
+                    controller.receiveAnalyzerMessage(SAMPLE_ASTM_MESSAGE, "text/plain", null, mockRequest);
+
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertEquals("10.20.30.40", response.getBody().sourceIp());
+        }
+
+        @Test
+        @DisplayName("Should prioritize X-Forwarded-For over X-Real-IP")
+        void shouldPrioritizeXForwardedFor() {
+            when(mockRequest.getHeader("X-Real-IP")).thenReturn("10.20.30.40");
+
+            ResponseEntity<AnalyzerInputController.InputResponse> response =
+                    controller.receiveAnalyzerMessage(SAMPLE_ASTM_MESSAGE, "text/plain",
+                            "192.168.1.100", mockRequest);
+
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertEquals("192.168.1.100", response.getBody().sourceIp());
+        }
+
+        @Test
+        @DisplayName("Should fall back to remote address when headers are missing")
+        void shouldFallBackToRemoteAddress() {
+            ResponseEntity<AnalyzerInputController.InputResponse> response =
+                    controller.receiveAnalyzerMessage(SAMPLE_ASTM_MESSAGE, "text/plain", null, mockRequest);
+
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertEquals("127.0.0.1", response.getBody().sourceIp());
+        }
+
+        @Test
+        @DisplayName("Should return 'unknown' when no IP source available")
+        void shouldReturnUnknownWhenNoIPAvailable() {
+            when(mockRequest.getRemoteAddr()).thenReturn(null);
+
+            ResponseEntity<AnalyzerInputController.InputResponse> response =
+                    controller.receiveAnalyzerMessage(SAMPLE_ASTM_MESSAGE, "text/plain", null, mockRequest);
+
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertEquals("unknown", response.getBody().sourceIp());
+        }
+    }
+
+    @Nested
+    @DisplayName("Error Handling")
+    class ErrorHandlingTests {
+
+        @Test
+        @DisplayName("Should return 400 for null request body")
+        void shouldRejectNullBody() {
+            ResponseEntity<AnalyzerInputController.InputResponse> response =
+                    controller.receiveAnalyzerMessage(null, "text/plain", null, mockRequest);
+
+            assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertFalse(response.getBody().success());
+            assertEquals("Request body is required", response.getBody().message());
+        }
+
+        @Test
+        @DisplayName("Should return 400 for empty request body")
+        void shouldRejectEmptyBody() {
+            ResponseEntity<AnalyzerInputController.InputResponse> response =
+                    controller.receiveAnalyzerMessage("", "text/plain", null, mockRequest);
+
+            assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertFalse(response.getBody().success());
+            assertEquals("Request body is required", response.getBody().message());
+        }
+
+        @Test
+        @DisplayName("Should return 400 for whitespace-only request body")
+        void shouldRejectWhitespaceBody() {
+            ResponseEntity<AnalyzerInputController.InputResponse> response =
+                    controller.receiveAnalyzerMessage("   \n\t  ", "text/plain", null, mockRequest);
+
+            assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertFalse(response.getBody().success());
+            assertEquals("Request body is required", response.getBody().message());
+        }
+
+        @Test
+        @DisplayName("Should return 422 for unrecognized protocol")
+        void shouldRejectUnknownProtocol() {
+            String unknownMessage = "This is not a valid ASTM, HL7, or CSV message";
+            ResponseEntity<AnalyzerInputController.InputResponse> response =
+                    controller.receiveAnalyzerMessage(unknownMessage, "text/plain", null, mockRequest);
+
+            assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertFalse(response.getBody().success());
+            assertEquals("Unable to detect message protocol", response.getBody().message());
+        }
+    }
+
+    @Nested
+    @DisplayName("Response Structure")
+    class ResponseStructureTests {
+
+        @Test
+        @DisplayName("Should include receivedAt timestamp in response")
+        void shouldIncludeTimestamp() {
+            ResponseEntity<AnalyzerInputController.InputResponse> response =
+                    controller.receiveAnalyzerMessage(SAMPLE_ASTM_MESSAGE, "text/plain", null, mockRequest);
+
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertNotNull(response.getBody().receivedAt());
+            assertFalse(response.getBody().receivedAt().isEmpty());
+        }
+
+        @Test
+        @DisplayName("Should return complete success response")
+        void shouldReturnCompleteSuccessResponse() {
+            ResponseEntity<AnalyzerInputController.InputResponse> response =
+                    controller.receiveAnalyzerMessage(SAMPLE_HL7_MESSAGE, "application/hl7-v2",
+                            "192.168.1.50", mockRequest);
+
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertTrue(response.getBody().success());
+            assertEquals("Message received successfully", response.getBody().message());
+            assertEquals("192.168.1.50", response.getBody().sourceIp());
+            assertEquals("HL7", response.getBody().protocol());
+            assertNotNull(response.getBody().receivedAt());
+        }
+    }
+
+    @Nested
+    @DisplayName("Helper Method Unit Tests")
+    class HelperMethodTests {
+
+        @Test
+        @DisplayName("detectProtocol should return HL7 for hl7 content types")
+        void detectProtocolHL7ContentType() {
+            assertEquals(Protocol.HL7, controller.detectProtocol("application/hl7-v2", ""));
+            assertEquals(Protocol.HL7, controller.detectProtocol("x-application/hl7-v2", ""));
+            assertEquals(Protocol.HL7, controller.detectProtocol("text/hl7", ""));
+        }
+
+        @Test
+        @DisplayName("detectProtocol should return CSV for csv content types")
+        void detectProtocolCSVContentType() {
+            assertEquals(Protocol.CSV, controller.detectProtocol("text/csv", ""));
+            assertEquals(Protocol.CSV, controller.detectProtocol("application/csv", ""));
+        }
+
+        @Test
+        @DisplayName("detectProtocol should return ASTM for astm content types")
+        void detectProtocolASTMContentType() {
+            assertEquals(Protocol.ASTM, controller.detectProtocol("application/x-astm", ""));
+            assertEquals(Protocol.ASTM, controller.detectProtocol("text/astm", ""));
+        }
+
+        @Test
+        @DisplayName("detectProtocol should auto-detect from content when content type is text/plain")
+        void detectProtocolAutoDetect() {
+            assertEquals(Protocol.ASTM, controller.detectProtocol("text/plain", SAMPLE_ASTM_MESSAGE));
+            assertEquals(Protocol.HL7, controller.detectProtocol("text/plain", SAMPLE_HL7_MESSAGE));
+            assertEquals(Protocol.CSV, controller.detectProtocol("text/plain", SAMPLE_CSV_MESSAGE));
+        }
+
+        @Test
+        @DisplayName("detectProtocol should auto-detect when content type is null")
+        void detectProtocolNullContentType() {
+            assertEquals(Protocol.ASTM, controller.detectProtocol(null, SAMPLE_ASTM_MESSAGE));
+            assertEquals(Protocol.HL7, controller.detectProtocol(null, SAMPLE_HL7_MESSAGE));
+        }
+
+        @Test
+        @DisplayName("extractSourceIp should handle various IP formats")
+        void extractSourceIpVariousFormats() {
+            // IPv4 with multiple proxies
+            assertEquals("192.168.1.1",
+                    controller.extractSourceIp("192.168.1.1, 10.0.0.1", mockRequest));
+
+            // IPv6
+            assertEquals("::1",
+                    controller.extractSourceIp("::1", mockRequest));
+
+            // Trimmed value
+            assertEquals("192.168.1.1",
+                    controller.extractSourceIp("  192.168.1.1  ", mockRequest));
+        }
+
+        @Test
+        @DisplayName("extractSourceIp should handle empty X-Forwarded-For")
+        void extractSourceIpEmptyXForwardedFor() {
+            assertEquals("127.0.0.1",
+                    controller.extractSourceIp("", mockRequest));
+            assertEquals("127.0.0.1",
+                    controller.extractSourceIp("   ", mockRequest));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add POST `/input` endpoint for analyzers with REST API capabilities
- Auto-detect protocol (ASTM, HL7, CSV) from Content-Type or message content
- Extract source IP from X-Forwarded-For, X-Real-IP, or remote address
- Create MessageEnvelope with Transport.HTTP for M7 normalizer integration

## Test plan
- [x] 30 unit tests covering protocol detection, IP extraction, error handling
- [x] All 101 project tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)