### PR TITLE
chore: refresh repo metadata for analyzer bridge scope

### DIFF
--- a/.cursor/rules/specify-rules.mdc
+++ b/.cursor/rules/specify-rules.mdc
@@ -1,10 +1,15 @@
-# astm-http-bridge Development Guidelines
+# openelis-analyzer-bridge Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2025-12-03
+Auto-generated from all feature plans. Last updated: 2026-02-05
 
 ## Active Technologies
 
-- Java 21 + astm-http-lib, Spring Boot Actuator, Spring Boot Web (001-bi-directional-astm)
+- Java 21 + Spring Boot 3.3.x
+- `astm-http-lib` (ASTM protocol implementation)
+- Spring Boot Actuator + Spring Boot Web
+- HAPI HL7 v2 (dependency present; transport layer in progress via PRs)
+- jSerialComm (dependency present; transport layer in progress via PRs)
+- Apache Commons CSV (dependency present; transport layer in progress via PRs)
 
 ## Project Structure
 
@@ -23,7 +28,8 @@ Java 21: Follow standard conventions
 
 ## Recent Changes
 
-- 001-bi-directional-astm: Added Java 21 + astm-http-lib, Spring Boot Actuator, Spring Boot Web
+- 001-bi-directional-astm: Bi-directional ASTM workflow + `X-Source-Analyzer-IP` header support
+- universal-bridge-foundation: Protocol/transport foundation types (Protocol/Transport/Envelope)
 
 <!-- MANUAL ADDITIONS START -->
 <!-- MANUAL ADDITIONS END -->

--- a/.github/workflows/docker-build-dev.yml
+++ b/.github/workflows/docker-build-dev.yml
@@ -14,6 +14,7 @@ env:
   REGISTRY: docker.io
   IMAGE_NAME: ${{ github.repository }}
   DOCKER_NAME: ${{ vars.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}
+  LEGACY_DOCKER_NAME: ${{ vars.DOCKERHUB_USERNAME }}/astm-http-bridge
 
 jobs:
   test:
@@ -67,7 +68,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.DOCKER_NAME }}
+          images: |
+            ${{ env.DOCKER_NAME }}
+            ${{ env.LEGACY_DOCKER_NAME }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/.github/workflows/docker-build-master.yml
+++ b/.github/workflows/docker-build-master.yml
@@ -16,6 +16,7 @@ env:
   REGISTRY: docker.io
   IMAGE_NAME: ${{ github.repository }}
   DOCKER_NAME: ${{ vars.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}
+  LEGACY_DOCKER_NAME: ${{ vars.DOCKERHUB_USERNAME }}/astm-http-bridge
 
 jobs:
   test:
@@ -69,7 +70,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.DOCKER_NAME }}
+          images: |
+            ${{ env.DOCKER_NAME }}
+            ${{ env.LEGACY_DOCKER_NAME }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
@@ -79,6 +82,7 @@ jobs:
           tags: |
             ${{ steps.meta.outputs.tags }}
             ${{ env.DOCKER_NAME }}:latest
+            ${{ env.LEGACY_DOCKER_NAME }}:latest
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=${{ env.DOCKER_NAME }}:buildcache
           cache-to: type=registry,ref=${{ env.DOCKER_NAME }}:buildcache,mode=max

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -11,53 +11,55 @@ Sync Impact Report (v1.0.0)
 - Follow-up TODOs: None
 -->
 
-# ASTM-HTTP Bridge Constitution
+# OpenELIS Analyzer Bridge Constitution
 
 ## Purpose
 
-The ASTM-HTTP Bridge is a **simple, reliable protocol translator** that enables 
-bi-directional communication between medical laboratory analyzers (ASTM/TCP) and 
-Laboratory Information Systems like OpenELIS (HTTP). The bridge MUST remain focused 
-on protocol translation and MUST NOT implement business logic.
+The OpenELIS Analyzer Bridge is a **simple, reliable protocol/transport bridge** that enables
+bi-directional communication between medical laboratory analyzers and **OpenELIS**.
+
+The bridge MUST remain focused on **transport + protocol mediation** (and minimal metadata
+propagation) and MUST NOT implement OpenELIS business logic (mapping, persistence, workflow).
 
 ## Core Principles
 
 ### I. Single Responsibility
 
-The bridge has ONE job: translate between ASTM TCP protocol and HTTP.
+The bridge has ONE job: translate analyzer protocol/transports to **OpenELIS HTTP** endpoints
+(and support outbound forwarding from OpenELIS to analyzers where required).
 
-- Bridge MUST translate ASTM messages to HTTP POST requests and vice versa
-- Bridge MUST NOT interpret message content beyond protocol requirements
-- Bridge MUST NOT implement analyzer identification logic (OpenELIS responsibility)
-- Bridge MUST NOT implement field mapping or data transformation (OpenELIS responsibility)
-- Bridge MUST NOT persist data (stateless translation only)
+- Bridge MUST translate inbound analyzer messages to HTTP POST requests and vice versa (when applicable)
+- Bridge MUST NOT interpret message content beyond protocol requirements (framing, checksums, acknowledgments)
+- Bridge MUST NOT implement analyzer identification, mapping, or data transformation logic (OpenELIS responsibility)
+- Bridge MUST NOT persist domain data (stateless translation only)
+- Bridge MAY attach **minimal source metadata** derived from the transport (e.g., source IP / port / transport type)
 
 **Rationale**: Keeping the bridge simple ensures reliability, maintainability, and clear 
 separation of concerns. OpenELIS owns all business logic.
 
 ### II. Protocol Compliance
 
-The bridge MUST comply with ASTM/CLSI standards for laboratory communication.
+The bridge MUST comply with the relevant standards for each supported protocol/transport.
 
-- Bridge MUST support CLSI LIS1-A (LIS01-A) protocol
-- Bridge MUST support E1381-95 protocol for legacy analyzers
-- Bridge MUST handle frame numbering, checksums, and ENQ/ACK/NAK handshakes
-- Bridge MUST support line contention handling per CLSI LIS1-A section 8.3.5
-- Bridge SHOULD support non-compliant fallback mode for non-standard analyzers
-- Bridge MUST provide configurable timeouts (establishment: 15s, receive: 30s)
+- **ASTM**:
+  - Bridge MUST support CLSI LIS1-A (LIS01-A)
+  - Bridge MUST support E1381-95 for legacy analyzers
+  - Bridge MUST handle framing, checksums, ENQ/ACK/NAK handshakes, and line contention (CLSI LIS1-A §8.3.5)
+- **HL7 v2.x (MLLP framing)** (when enabled):
+  - Bridge MUST respect MLLP framing delimiters (VT start, FS+CR end)
+  - Bridge MUST generate appropriate ACK/NAK responses where required by the transport/server role
+- Bridge MUST provide configurable timeouts appropriate to the transport (e.g., establishment/receive)
 
 **Rationale**: Standards compliance ensures interoperability with diverse medical analyzers.
 
 ### III. Bi-Directional Communication
 
-The bridge MUST support communication in both directions.
+The bridge MUST support communication in both directions (where the protocol/transport requires it).
 
-- **Analyzer → LIS**: Bridge receives ASTM over TCP, forwards via HTTP POST
-- **LIS → Analyzer**: Bridge receives HTTP POST, forwards via ASTM TCP
-- Bridge MUST include source analyzer IP in HTTP headers (`X-Source-Analyzer-IP`) 
-  when forwarding analyzer messages to LIS
-- Bridge MUST accept target analyzer address (`forwardAddress`, `forwardPort`) via 
-  HTTP request parameters when LIS sends to analyzer
+- **Analyzer → OpenELIS**: Bridge receives messages (e.g., ASTM/TCP) and forwards via HTTP POST
+- **OpenELIS → Analyzer**: Bridge receives HTTP POST and forwards to analyzer (e.g., ASTM/TCP host queries)
+- Bridge MUST include source analyzer identity hints where safely derivable (e.g., `X-Source-Analyzer-IP`)
+- Bridge MUST accept target routing overrides (e.g., `forwardAddress`, `forwardPort`) when OpenELIS sends outbound messages
 - Bridge MUST handle concurrent connections (one thread per connection)
 
 **Rationale**: Bi-directional flow enables both result submission and query operations.
@@ -82,7 +84,8 @@ Runtime behavior MUST be configurable without code changes.
 
 - Connection settings MUST be configurable via `configuration.yml`
 - Forward HTTP server URI MUST be configurable (`org.itech.ahb.forward-http-server.uri`)
-- Listen ports MUST be configurable (LIS1-A: 12001, E1381-95: 12011 by default)
+- Listen ports MUST be configurable (e.g., LIS1-A: 12001, E1381-95: 12011 by default)
+- Optional transports (e.g., MLLP/Serial/File) MUST be enable/disable configurable
 - Timeout values MUST be configurable
 - Authentication credentials MUST be configurable and MUST NOT be hardcoded
 - Sensitive values SHOULD use environment variable substitution (`${VAR_NAME}`)
@@ -97,7 +100,7 @@ The bridge MUST provide visibility into its operation.
 - Bridge MUST log message handling status (success, fail, unhandled)
 - Bridge MUST provide health check endpoint (`/actuator/health`)
 - Log levels MUST be configurable (DEBUG for development, INFO/WARN for production)
-- Bridge SHOULD expose metrics for connection counts and message throughput
+- Bridge SHOULD expose metrics for connection counts and message throughput (by transport/protocol where possible)
 
 **Rationale**: Healthcare systems require auditability and operational visibility.
 
@@ -109,7 +112,7 @@ The bridge MUST handle failures gracefully without losing messages.
 - Bridge MUST handle connection timeouts without crashing
 - Bridge MUST log detailed error context for troubleshooting
 - Bridge MUST close sockets cleanly after errors
-- Bridge SHOULD fall back to non-compliant mode if analyzer doesn't respond with control characters
+- Bridge SHOULD fall back to non-compliant mode if an ASTM analyzer doesn't respond with control characters (where appropriate)
 
 **Rationale**: Laboratory operations depend on reliable message delivery.
 
@@ -178,4 +181,4 @@ astm-http-bridge/
 - [Compatibility Analysis](docs/ASTM_BRIDGE_COMPATIBILITY_ANALYSIS.md) - Protocol coverage
 - [Message Flow](docs/ASTM_MESSAGE_PROCESSING_FLOW.md) - Integration architecture
 
-**Version**: 1.0.0 | **Ratified**: 2025-12-03 | **Last Amended**: 2025-12-03
+**Version**: 1.1.0 | **Ratified**: 2025-12-03 | **Last Amended**: 2026-02-05

--- a/README
+++ b/README
@@ -1,15 +1,6 @@
-To build and deploy this project for development, run the following command in the top-level directory of the project:
+This repository’s primary documentation is in `README.md`.
 
-`sudo docker compose -f docker-compose-dev.yml up -d --build`
+Quick link:
 
-- Note, the project will not commence startup in dev mode until a debugger is attached on port 8000
+- `README.md`: project overview, architecture, quickstart, configuration
 
-To build and deploy this project normally using the latest image on Docker Hub, run the following command in the top-level directory of the project:
-
-`sudo docker compose up -d --build`
-
-to view logging of running container, run:
-
-`sudo docker logs --follow astm-http-bridge`
-
-`configuration.yml` should contain any configuration parameters that a user wants to pass to the application.

--- a/README.md
+++ b/README.md
@@ -1,47 +1,135 @@
-# ASTM-HTTP Bridge
+# OpenELIS Analyzer Bridge
 
-A bi-directional protocol translator for medical laboratory systems, enabling communication between ASTM/TCP analyzers and HTTP-based Laboratory Information Systems (LIS) like OpenELIS.
+Middleware that receives analyzer messages over multiple **protocols/transports** and forwards them to **OpenELIS via HTTP**.
 
-## Architecture Overview
+This repository was previously named **ASTM-HTTP Bridge**. For **backward compatibility**, some technical identifiers (Maven `artifactId`, jar filename, and some Docker/Compose service naming) still use `astm-http-bridge`.
 
-The ASTM-HTTP Bridge provides two-way communication:
+## Scope
+
+### Today (stable on `develop`)
+
+- **ASTM over TCP** (CLSI LIS1-A / ASTM E1381-95 variants) → HTTP forward to OpenELIS
+- **HTTP → ASTM** forwarding (OpenELIS queries / host-driven messaging) with `forwardAddress`/`forwardPort`
+- **Source analyzer IP propagation** via `X-Source-Analyzer-IP`
+
+### Universal Bridge transports (status depends on commit)
+
+Additional transports are being added as part of the “Universal Bridge” scope expansion. Depending on which commit/branch you are running, these may or may not be present. Historical entry points:
+
+- **HL7 v2.x over MLLP** (PR `#7`)
+- **File watcher transport** (CSV/HL7/ASTM routing) (PR `#8`)
+- **Serial/RS232 transport** (ASTM + HL7 framing) (PR `#9`)
+
+## Architecture overview
 
 ```
-┌─────────────────────┐                    ┌─────────────────────┐
-│   Medical Analyzer  │                    │      OpenELIS       │
-│   (ASTM/TCP)        │                    │      (HTTP)         │
-└─────────┬───────────┘                    └──────────┬──────────┘
-          │                                           │
-          │ ASTM Protocol                   HTTP POST │
-          │ (TCP Port 12001)            (Port 8443)   │
-          ▼                                           ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                      ASTM-HTTP Bridge                           │
-│                                                                 │
-│  ┌─────────────────┐              ┌─────────────────┐          │
-│  │ ASTM Listener   │  ───────────►│ HTTP Forwarder  │          │
-│  │ (Analyzer→LIS)  │              │ + X-Source-IP   │          │
-│  └─────────────────┘              └─────────────────┘          │
-│                                                                 │
-│  ┌─────────────────┐              ┌─────────────────┐          │
-│  │ HTTP Listener   │  ◄───────────│ ASTM Forwarder  │          │
-│  │ (LIS→Analyzer)  │              │ + Query Support │          │
-│  └─────────────────┘              └─────────────────┘          │
-└─────────────────────────────────────────────────────────────────┘
+Analyzer(s)                              OpenELIS
+───────────                              ────────
+ASTM/TCP   ─┐
+HL7/MLLP   ─┼─> [OpenELIS Analyzer Bridge] ──HTTP POST──> /api/OpenELIS-Global/analyzer/{astm|hl7|csv}
+RS232/Serial┤
+Files (CSV)─┘
+
+OpenELIS ──HTTP POST──> [Bridge] ──TCP──> Analyzer (ASTM host query / outbound)
 ```
 
-### Communication Flows
+### Protocol vs transport
 
-1. **Analyzer → OpenELIS** (Results submission)
-   - Analyzer sends ASTM message to bridge (TCP port 12001)
-   - Bridge extracts analyzer's IP address from socket
-   - Bridge forwards message to OpenELIS via HTTP POST
-   - HTTP request includes `X-Source-Analyzer-IP` header with analyzer's IP
+- **Protocol**: message format (ASTM, HL7 v2, CSV)
+- **Transport**: how the message arrives (TCP, MLLP, Serial, File, HTTP)
 
-2. **OpenELIS → Analyzer** (Query/Configuration)
-   - OpenELIS sends HTTP POST to bridge with `forwardAddress` and `forwardPort` parameters
-   - Bridge establishes ASTM connection to specified analyzer
-   - Bridge forwards the query and returns analyzer's response
+## Quick start
+
+### Using Docker
+
+```bash
+git clone https://github.com/DIGI-UW/openelis-analyzer-bridge.git
+cd openelis-analyzer-bridge
+
+docker compose up -d --build
+docker logs --follow astm-http-bridge
+```
+
+### Building from source
+
+```bash
+cd astm-http-lib
+mvn clean install
+
+cd ..
+mvn clean package
+
+java -jar target/astm-http-bridge-*.jar --spring.config.location=configuration.yml
+```
+
+## Configuration
+
+Runtime configuration is read from `configuration.yml` in the repo root (mounted into the container at `/app/configuration.yml` in Compose).
+
+```yaml
+org:
+  itech:
+    ahb:
+      # Where to forward inbound analyzer messages (OpenELIS endpoint)
+      forward-http-server:
+        uri: https://openelis.example.org:8443/api/OpenELIS-Global/analyzer/astm
+        # username: admin
+        # password: ${OPENELIS_PASSWORD}
+
+      # ASTM listener ports (analyzers connect here)
+      listen-astm-server:
+        port: 12001
+        establishment-timeout-seconds: 15
+        receive-timeout-seconds: 30
+      listen-astm-e1381-95-server:
+        port: 12011
+
+      # Default outbound target (OpenELIS → analyzer). Can be overridden per-request.
+      forward-astm-server:
+        host-name: analyzer.local
+        port: 5000
+
+server:
+  port: 8443
+```
+
+## HTTP behavior (ASTM stable path)
+
+### Analyzer → OpenELIS (results submission)
+
+- Bridge receives ASTM over TCP.
+- Bridge forwards the raw message to the configured OpenELIS endpoint as `text/plain`.
+- Bridge adds `X-Source-Analyzer-IP` when source IP can be extracted from the TCP socket.
+
+### OpenELIS → Analyzer (query/config)
+
+OpenELIS can send raw ASTM payloads to the bridge HTTP listener and specify the target analyzer:
+
+```bash
+curl -X POST "http://bridge:8443/?forwardAddress=192.168.1.10&forwardPort=5000" \
+  -H "Content-Type: text/plain" \
+  -d "H|\\^&|||"
+```
+
+## Testing
+
+- Unit tests:
+
+```bash
+mvn test
+```
+
+- Docker-based integration tests / mock analyzers: see `docker-compose.test.yml` and `scripts/integration-test.sh`.
+
+## Docs
+
+- `docs/SCOPE_AND_NAMING.md`: canonical naming + compatibility policy
+- `docs/ASTM_MESSAGE_PROCESSING_FLOW.md`: ASTM flow details (OpenELIS-side processing)
+- `specs/001-bi-directional-astm/`: historical spec for the `X-Source-Analyzer-IP` header contract
+
+## License / Contributing
+
+TBD (add project license and contribution guidelines).
 
 ## Quick Start
 

--- a/docker-compose-devhub.yml
+++ b/docker-compose-devhub.yml
@@ -9,7 +9,7 @@ x-logging: &local-logging
 services:
   astm-http-bridge:
     container_name: astm-http-bridge
-    image: itechuw/astm-http-bridge:develop
+    image: itechuw/openelis-analyzer-bridge:develop
     pull_policy: always
     ports:
       - "8442:8443"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ x-logging: &local-logging
 services:
   astm-http-bridge:
     container_name: astm-http-bridge
-    image: itechuw/astm-http-bridge:latest
+    image: itechuw/openelis-analyzer-bridge:latest
     pull_policy: always
     ports:
       - "8442:8443"

--- a/docs/ASTM_BRIDGE_COMPATIBILITY_ANALYSIS.md
+++ b/docs/ASTM_BRIDGE_COMPATIBILITY_ANALYSIS.md
@@ -6,6 +6,8 @@
 - `tools/astm-http-bridge` (v2.3.5) - DIGI-UW/astm-http-bridge submodule
 - `tools/astm-mock-server` - Python mock analyzer server
 
+> **Scope note (2026-02)**: This report covers **ASTM-only** compatibility and bi-directional workflows. The repository has since expanded into the **OpenELIS Analyzer Bridge** to support additional protocols/transports (HL7/MLLP, Serial/RS232, File). Keep this doc as ASTM historical context; for the broadened scope, see the repository `README.md`.
+
 ---
 
 ## Executive Summary

--- a/docs/ASTM_BRIDGE_MULTI_ANALYZER_ANALYSIS.md
+++ b/docs/ASTM_BRIDGE_MULTI_ANALYZER_ANALYSIS.md
@@ -5,6 +5,8 @@
 **Analysis Type**: Architecture Gap Analysis  
 **Scope**: Minimal updates needed to `tools/astm-http-bridge` for multi-analyzer mediation and bi-directional query support
 
+> **Scope note (2026-02)**: This analysis is **ASTM-focused**. It remains relevant for the ASTM transport path, but the repository now targets a broader “Analyzer Bridge” scope (HL7/MLLP, Serial/RS232, File). For the broader context, see the repository `README.md`.
+
 ---
 
 ## Executive Summary

--- a/docs/ASTM_MESSAGE_PROCESSING_FLOW.md
+++ b/docs/ASTM_MESSAGE_PROCESSING_FLOW.md
@@ -4,6 +4,8 @@
 **Feature**: 004-astm-analyzer-mapping  
 **Purpose**: Document how ASTM analyzer messages are received, processed, and stored in OpenELIS
 
+> **Scope note (2026-02)**: This document is **ASTM-specific** (it traces what happens after the bridge forwards an ASTM message into OpenELIS). The repository has expanded into the **OpenELIS Analyzer Bridge** with additional protocols/transports; those follow similar “bridge → HTTP → OpenELIS processing” patterns but use different endpoints/parsers. For high-level context, see the repository `README.md`.
+
 ---
 
 ## Overview

--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,9 @@
 	<groupId>org.itech</groupId>
 	<artifactId>astm-http-bridge</artifactId>
 	<version>2.3.5</version>
-	<name>astm-http-bridge</name>
-	<description>Translates astm to http and vice versa</description>
+	<name>openelis-analyzer-bridge</name>
+	<description>OpenELIS Analyzer Bridge: transports/protocol mediation (ASTM, HL7/MLLP, serial, file) forwarding analyzer messages to OpenELIS via HTTP.</description>
+	<url>https://github.com/DIGI-UW/openelis-analyzer-bridge</url>
 	<properties>
 		<java.version>21</java.version>
 	</properties>


### PR DESCRIPTION
## Summary
- Update README and existing docs to reflect the expanded OpenELIS Analyzer Bridge scope (formerly ASTM-HTTP Bridge).
- Align Docker Compose to the canonical image name (`itechuw/openelis-analyzer-bridge`) and update CI to also publish a legacy alias image (`itechuw/astm-http-bridge`).
- Refresh repo governance metadata and Maven project metadata (keeping Maven `artifactId` stable for compatibility).

## Notes
- Two local, untracked docs were intentionally left uncommitted (per request), so this PR avoids referencing them.

## Test plan
- N/A (docs/metadata + CI config changes only).


Made with [Cursor](https://cursor.com)