### PR TITLE
feat: M7 Message Normalizer — unified routing pipeline

### DIFF
--- a/M7-IMPLEMENTATION-PROMPT.md
+++ b/M7-IMPLEMENTATION-PROMPT.md
@@ -1,0 +1,831 @@
+# M7: Message Normalizer — Implementation Prompt
+
+**Branch**: `feat/universal-bridge-normalizer` (this branch)
+**Repo**: `DIGI-UW/astm-http-bridge`
+**Working directory**: `tools/astm-http-bridge/`
+
+---
+
+## Goal
+
+Unify all 5 transport listeners to route through a single `MessageNormalizer` → `HttpForwardingRouter` pipeline. Currently only MLLP uses the router; Serial, File, ASTM, and HTTP Input each have their own forwarding logic (or none at all).
+
+### Current State (BROKEN — 4 of 5 paths bypass the router)
+
+```
+MLLP:    HapiReceivingApplication → MessageRouter → HttpForwardingRouter  ✅ CORRECT (but skips normalizer)
+Serial:  SerialMessageHandler → own forwardMessage() with HttpClient      ❌ BYPASS
+File:    FileMessageHandler → own forwardToOpenELIS() with RestTemplate   ❌ BYPASS
+ASTM:    ASTMReceiveThread → ASTMHandlerService → legacy handler chain    ❌ LEGACY
+HTTP:    AnalyzerInputController → creates envelope → DOES NOTHING        ❌ BROKEN (TODO)
+```
+
+### Target State (ALL paths through MessageNormalizer)
+
+```
+All listeners → MessageEnvelope → MessageNormalizer → HttpForwardingRouter → OpenELIS
+                                       |
+                                       ├── AnalyzerIdentifier (multi-strategy)
+                                       ├── Retry/backoff (from config)
+                                       └── Audit logging
+```
+
+### Key Design Decision: MessageNormalizer implements MessageRouter
+
+`MessageNormalizer` MUST implement `MessageRouter` and be annotated `@Primary`.
+This way, `HapiReceivingApplication` (which already depends on `MessageRouter`)
+automatically gets the normalizer via Spring injection — **zero changes to MLLP code**.
+
+```
+HapiReceivingApplication → @Autowired MessageRouter → MessageNormalizer (@Primary)
+                                                            ↓
+Serial/File/HTTP/ASTM → normalizer.process(envelope) → same MessageNormalizer
+                                                            ↓
+                                                    HttpForwardingRouter (injected by concrete type)
+```
+
+`MessageNormalizer` injects `HttpForwardingRouter` by **concrete type** (not `MessageRouter` interface) to avoid circular injection ambiguity.
+
+---
+
+## Existing Code You MUST Reuse
+
+These files exist and are correct. Do NOT rewrite them — build on top of them:
+
+### `routing/MessageRouter.java` — Interface (DO NOT MODIFY)
+
+```java
+package org.itech.ahb.routing;
+import org.itech.ahb.normalizer.MessageEnvelope;
+
+public interface MessageRouter {
+    boolean route(MessageEnvelope envelope);
+}
+```
+
+### `routing/HttpForwardingRouter.java` — Routes by protocol to OpenELIS
+
+Already routes `MessageEnvelope` to protocol-specific endpoints:
+- `Protocol.HL7` → `/analyzer/hl7`
+- `Protocol.ASTM` → `/analyzer/astm`
+- `Protocol.CSV` → `/analyzer/csv`
+
+Adds these headers: `X-Analyzer-Id`, `X-Source-Protocol`, `X-Source-Transport`, `X-Source-Id`, `X-Source-Analyzer-IP`
+
+Uses `HTTPForwardServerConfigurationProperties` for URI + credentials.
+Has secure password handling (CharsetEncoder, no String pool exposure).
+**MODIFY THIS FILE** only to add retry/backoff logic (T04).
+
+### `normalizer/MessageEnvelope.java` — Input DTO (DO NOT MODIFY)
+
+```java
+@Getter @Builder @ToString
+public class MessageEnvelope {
+    private final Protocol protocol;
+    private final Transport transport;
+    private final String sourceId;
+    private final String rawMessage;
+    @Builder.Default private final Instant receivedAt = Instant.now();
+    private final String analyzerId;
+}
+```
+
+### `normalizer/NormalizedMessage.java` — Output DTO (exists, may be used for audit)
+
+Has fields: `analyzerId`, `protocol`, `transport`, `message`, `sourceId`, `timestamp`, `messageId`, `error`
+
+### `model/Protocol.java` — Enum: `ASTM, HL7, CSV, UNKNOWN`
+
+### `model/Transport.java` — Enum: `TCP, MLLP, SERIAL, FILE, HTTP`
+
+### `util/ProtocolDetector.java` — Static utility: `Protocol detect(String message)`
+
+### `mllp/HapiReceivingApplication.java` — THE CORRECT PATTERN
+
+This is the **reference implementation** showing how a listener should use the router:
+1. Extract metadata (source IP, analyzer ID from MSH-3/4)
+2. Build `MessageEnvelope`
+3. Call `router.route(envelope)`
+4. Return success/failure
+
+**All other listeners should follow this same pattern** after M7.
+
+---
+
+## Tasks (implement in order)
+
+### T01: Create `MessageNormalizer` service
+
+**File**: `src/main/java/org/itech/ahb/normalizer/MessageNormalizer.java`
+
+Central orchestration service. All listeners delegate to this instead of doing their own forwarding.
+
+```java
+package org.itech.ahb.normalizer;
+
+import org.itech.ahb.routing.HttpForwardingRouter;
+import org.itech.ahb.routing.MessageRouter;
+
+@Component
+@Primary  // CRITICAL: Makes this the default MessageRouter bean.
+          // HapiReceivingApplication depends on MessageRouter — @Primary ensures
+          // it gets MessageNormalizer without any code changes to MLLP.
+@Slf4j
+public class MessageNormalizer implements MessageRouter {
+
+    private final HttpForwardingRouter forwardingRouter;  // Inject by CONCRETE TYPE, not MessageRouter
+    private final AnalyzerIdentifier identifier;
+
+    // Constructor injection: (HttpForwardingRouter forwardingRouter, AnalyzerIdentifier identifier)
+
+    /**
+     * MessageRouter.route() implementation — allows MLLP to use this transparently.
+     * Delegates to process().
+     */
+    @Override
+    public boolean route(MessageEnvelope envelope) {
+        return process(envelope);
+    }
+
+    /**
+     * Process a message envelope: identify analyzer, route to OpenELIS.
+     * Called directly by Serial/File/HTTP/ASTM handlers, or via route() by MLLP.
+     * @return true if routing succeeded
+     */
+    public boolean process(MessageEnvelope envelope) {
+        // 1. If analyzerId not set, try to identify via AnalyzerIdentifier
+        String analyzerId = envelope.getAnalyzerId();
+        if (analyzerId == null || analyzerId.isEmpty()) {
+            analyzerId = identifier.identify(envelope);
+        }
+
+        // 2. Rebuild envelope with analyzerId if we found one
+        MessageEnvelope enriched = (analyzerId != null && !analyzerId.equals(envelope.getAnalyzerId()))
+            ? MessageEnvelope.builder()
+                .protocol(envelope.getProtocol())
+                .transport(envelope.getTransport())
+                .sourceId(envelope.getSourceId())
+                .rawMessage(envelope.getRawMessage())
+                .receivedAt(envelope.getReceivedAt())
+                .analyzerId(analyzerId)
+                .build()
+            : envelope;
+
+        // 3. Audit log
+        log.info("Normalizer processing: protocol={}, transport={}, source={}, analyzer={}",
+            enriched.getProtocol(), enriched.getTransport(),
+            enriched.getSourceId(), enriched.getAnalyzerId());
+
+        // 4. Route via HttpForwardingRouter (NOT via this.route() — that would recurse!)
+        boolean success = forwardingRouter.route(enriched);
+
+        if (!success) {
+            log.error("Failed to route message: protocol={}, source={}",
+                enriched.getProtocol(), enriched.getSourceId());
+        }
+
+        return success;
+    }
+}
+```
+
+### T02: Create `AnalyzerIdentifier`
+
+**File**: `src/main/java/org/itech/ahb/normalizer/AnalyzerIdentifier.java`
+
+Multi-strategy identification. Strategies in priority order:
+1. Envelope already has analyzerId (set by listener) → use it
+2. IP-based lookup from `AnalyzerRegistryConfig`
+3. Serial-port-based lookup from config
+4. File-path-pattern lookup from config
+5. Return null (OpenELIS will identify from message content)
+
+```java
+package org.itech.ahb.normalizer;
+
+@Component
+@Slf4j
+public class AnalyzerIdentifier {
+
+    private final AnalyzerRegistryConfig registry;  // may be null if not configured
+
+    // Constructor: @Autowired(required = false) AnalyzerRegistryConfig
+
+    public String identify(MessageEnvelope envelope) {
+        // Strategy 1: Already identified
+        if (envelope.getAnalyzerId() != null && !envelope.getAnalyzerId().isEmpty()) {
+            return envelope.getAnalyzerId();
+        }
+
+        if (registry == null) {
+            return null;
+        }
+
+        String sourceId = envelope.getSourceId();
+
+        // Strategy 2: IP-based lookup
+        // Strategy 3: Serial port lookup
+        // Strategy 4: File path pattern
+        // Check registry.getAnalyzers() map for sourceId key match
+
+        return registry.findAnalyzerId(sourceId).orElse(null);
+    }
+}
+```
+
+### T03: Create `AnalyzerRegistryConfig`
+
+**File**: `src/main/java/org/itech/ahb/config/AnalyzerRegistryConfig.java`
+
+```java
+package org.itech.ahb.config;
+
+@ConfigurationProperties(prefix = "bridge")
+@Slf4j
+public class AnalyzerRegistryConfig {
+
+    private Map<String, AnalyzerEntry> analyzers = new LinkedHashMap<>();
+
+    // Getters/setters for analyzers map
+
+    public Optional<String> findAnalyzerId(String sourceId) {
+        if (sourceId == null || analyzers.isEmpty()) return Optional.empty();
+
+        // Direct match (IP address, serial port path)
+        AnalyzerEntry entry = analyzers.get(sourceId);
+        if (entry != null) return Optional.of(entry.getId());
+
+        // Pattern match (file paths with wildcards)
+        for (Map.Entry<String, AnalyzerEntry> e : analyzers.entrySet()) {
+            String pattern = e.getKey();
+            if (pattern.contains("*") && matchesGlob(sourceId, pattern)) {
+                return Optional.of(e.getValue().getId());
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    @Data
+    public static class AnalyzerEntry {
+        private String id;
+        private String name;
+        private String expectedProtocol;
+        private String filePattern;
+    }
+}
+```
+
+**IMPORTANT**: This class MUST NOT use `@ConditionalOnProperty`. It should always be loaded (even if the `bridge.analyzers` section is empty/missing in config). Use `@ConfigurationProperties` only.
+
+### T04: Add retry/backoff to `HttpForwardingRouter`
+
+**File**: `src/main/java/org/itech/ahb/routing/HttpForwardingRouter.java` (MODIFY)
+
+Also **File**: `src/main/java/org/itech/ahb/config/OpenELISConfig.java` (MODIFY)
+
+**What to do**:
+1. Remove `@ConditionalOnProperty(prefix = "bridge.file", name = "enabled", havingValue = "true")` from `OpenELISConfig` so retry config is always available (even when file watcher is disabled)
+2. Add `OpenELISConfig` as an **optional** dependency to `HttpForwardingRouter`
+3. Wrap the HTTP send in a retry loop with exponential backoff
+
+**IMPORTANT**: `OpenELISConfig` currently has `@ConditionalOnProperty(prefix = "bridge.file", ...)`.
+After removing that conditional, the class becomes available whenever `bridge.openelis.*` properties exist
+in `configuration.yml` (they already do). Use `@Autowired(required = false)` in `HttpForwardingRouter`
+so the router still works if the config is somehow missing.
+
+The config properties already exist in `configuration.yml`:
+```yaml
+bridge:
+  openelis:
+    retry:
+      maxAttempts: 3
+      backoffMs: 1000
+```
+
+The retry config class already exists in `OpenELISConfig.RetryConfig` (nested static class with
+`maxAttempts` and `backoffMs` fields).
+
+Implementation approach — keep it simple, no Spring Retry dependency needed:
+```java
+// In HttpForwardingRouter, add constructor parameter:
+public HttpForwardingRouter(
+        HTTPForwardServerConfigurationProperties httpConfig,
+        @Autowired(required = false) OpenELISConfig openelisConfig) {
+    this.httpConfig = httpConfig;
+    this.retryConfig = openelisConfig != null ? openelisConfig.getRetry() : null;
+    this.httpClient = HttpClient.newBuilder()
+        .connectTimeout(Duration.ofSeconds(30))
+        .build();
+}
+
+// Modify route() method — wrap the existing try/catch in a retry loop:
+@Override
+public boolean route(MessageEnvelope envelope) {
+    int maxAttempts = retryConfig != null ? retryConfig.getMaxAttempts() : 1;
+    long backoffMs = retryConfig != null ? retryConfig.getBackoffMs() : 1000;
+
+    for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+        try {
+            URI targetUri = buildTargetUri(envelope);
+            HttpRequest request = buildRequest(envelope, targetUri);
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            int statusCode = response.statusCode();
+            if (statusCode >= 200 && statusCode < 300) return true;
+            // Non-retryable HTTP errors (4xx) — fail immediately
+            if (statusCode >= 400 && statusCode < 500) {
+                log.error("Non-retryable HTTP error {}: {}", statusCode, response.body());
+                return false;
+            }
+            // 5xx errors — retry
+            log.warn("Server error {} on attempt {}/{}", statusCode, attempt, maxAttempts);
+        } catch (IOException e) {
+            log.warn("IO error on attempt {}/{}: {}", attempt, maxAttempts, e.getMessage());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        }
+
+        if (attempt < maxAttempts) {
+            try {
+                long waitMs = backoffMs * (1L << (attempt - 1)); // exponential
+                log.info("Retrying in {}ms...", waitMs);
+                Thread.sleep(waitMs);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return false;
+            }
+        }
+    }
+    log.error("All {} attempts failed for {} message", maxAttempts, envelope.getProtocol());
+    return false;
+}
+```
+
+### T05: Refactor `SerialMessageHandler` — delegate to `MessageNormalizer`
+
+**File**: `src/main/java/org/itech/ahb/serial/SerialMessageHandler.java` (MODIFY)
+**Also update**: `src/test/java/org/itech/ahb/serial/SerialMessageHandlerTest.java` (MODIFY)
+
+**What to remove**: The entire `forwardMessage()` method, `determineTargetUri()`, `determineContentType()`, `HttpClient` field, `HTTPForwardServerConfigurationProperties` field, `SOURCE_ID_HEADER`, `TRANSPORT_HEADER`, `ANALYZER_ID_HEADER` constants, and the `HTTP_TIMEOUT` constant.
+
+**What to keep**: `handleMessage()` method signature (`String message, String serialPortPath, String analyzerId`), protocol detection, envelope creation, `HandleResult` record.
+
+**What to change**: Inject `MessageNormalizer` instead. Call `normalizer.process(envelope)`.
+
+```java
+@Service
+@Slf4j
+public class SerialMessageHandler {
+
+    private final MessageNormalizer normalizer;  // NEW (replaces httpConfig + httpClient)
+
+    public SerialMessageHandler(MessageNormalizer normalizer) {
+        this.normalizer = normalizer;
+    }
+
+    public HandleResult handleMessage(String message, String serialPortPath, String analyzerId) {
+        if (message == null || message.isEmpty()) {
+            log.warn("Received empty message from serial port {}", serialPortPath);
+            return new HandleResult(false, "Empty message");
+        }
+
+        Protocol protocol = ProtocolDetector.detect(message);
+        log.info("Received {} message from serial port {} ({} bytes)",
+            protocol, serialPortPath, message.length());
+
+        MessageEnvelope envelope = MessageEnvelope.builder()
+            .protocol(protocol)
+            .transport(Transport.SERIAL)
+            .sourceId(serialPortPath)
+            .rawMessage(message)
+            .analyzerId(analyzerId)
+            .build();
+
+        boolean success = normalizer.process(envelope);  // CHANGED: delegate to normalizer
+        return new HandleResult(success, success ? "Routed via normalizer" : "Routing failed");
+    }
+
+    public record HandleResult(boolean success, String message) {}
+}
+```
+
+**CRITICAL — Update `SerialMessageHandlerTest`**: The existing test creates the handler with
+`new SerialMessageHandler(httpConfig)` and uses an embedded HTTP server. After this refactor,
+the constructor takes `MessageNormalizer`. Rewrite the test:
+- Mock `MessageNormalizer` using Mockito
+- Verify `normalizer.process()` is called with correct `MessageEnvelope` fields
+- Remove all embedded HTTP server setup (`com.sun.net.httpserver.HttpServer`)
+- Keep all protocol detection tests (they still apply)
+- Keep empty/null message tests
+- Remove HTTP error response and connection refused tests (those are now HttpForwardingRouter's concern)
+- Remove authentication tests (those are now HttpForwardingRouter's concern)
+
+### T06: Refactor `FileMessageHandler` — delegate to `MessageNormalizer`
+
+**File**: `src/main/java/org/itech/ahb/file/FileMessageHandler.java` (MODIFY)
+
+**What to remove**: The entire `forwardToOpenELIS()` method and `RestTemplate`/`OpenELISConfig` dependencies.
+
+**What to keep**: `processFile()` method signature, file reading, protocol detection, validation.
+
+**What to change**: Inject `MessageNormalizer`. After creating the envelope, call `normalizer.process(envelope)` instead of `forwardToOpenELIS()`.
+
+```java
+@Component
+@ConditionalOnProperty(prefix = "bridge.file", name = "enabled", havingValue = "true")
+public class FileMessageHandler {
+
+    private final CSVParser csvParser;
+    private final MessageNormalizer normalizer;  // NEW (replaces restTemplate + openelisConfig)
+    private final FileConfig fileConfig;
+
+    public MessageEnvelope processFile(Path filePath, String analyzerId) throws IOException, FileProcessingException {
+        // ... existing file reading, protocol detection, validation ...
+        // ... existing MessageEnvelope creation ...
+
+        // CHANGED: delegate to normalizer instead of forwardToOpenELIS()
+        boolean success = normalizer.process(envelope);
+        if (!success) {
+            throw new FileProcessingException("Failed to route message for file: " + filePath);
+        }
+
+        return envelope;
+    }
+
+    // DELETE: forwardToOpenELIS(), getEndpointForProtocol()
+    // DELETE: RestTemplate field, OpenELISConfig field
+    // KEEP: validateFileContent(), FileProcessingException
+}
+```
+
+**Also**: Remove `@Qualifier("fileWatcherRestTemplate") RestTemplate` parameter from constructor.
+The `fileWatcherRestTemplate` bean is defined in `src/main/java/org/itech/ahb/config/HttpClientConfig.java` (line 31-38).
+After this refactor, that bean has no consumers. **Remove the `fileWatcherRestTemplate` method** from `HttpClientConfig.java`.
+Keep the `bridgeRestTemplate` method (it may be used elsewhere or in the future).
+Also remove the `OpenELISConfig` import from `FileMessageHandler` since it's no longer used there.
+
+### T07: Wire `AnalyzerInputController` — call `MessageNormalizer`
+
+**File**: `src/main/java/org/itech/ahb/controller/AnalyzerInputController.java` (MODIFY)
+**Also update**: `src/test/java/org/itech/ahb/controller/AnalyzerInputControllerTest.java` (MODIFY)
+
+**What to change**:
+1. Add `MessageNormalizer` as a constructor dependency
+2. Replace the TODO comment with actual routing
+
+Add constructor:
+```java
+private final MessageNormalizer normalizer;
+
+public AnalyzerInputController(MessageNormalizer normalizer) {
+    this.normalizer = normalizer;
+}
+```
+
+Find this block (around line 109):
+```java
+// TODO: Forward to MessageNormalizer for routing once M7 integration is available
+// For now, return success with envelope details
+```
+
+Replace with:
+```java
+boolean success = normalizer.process(envelope);
+
+if (!success) {
+    log.error("Failed to route {} message from {}", protocol, sourceIp);
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+        .body(new InputResponse(false, "Message routing failed", sourceIp, protocol.name(), null));
+}
+```
+
+**CRITICAL — Update `AnalyzerInputControllerTest`**: The existing test creates the controller
+with `controller = new AnalyzerInputController()` (no-arg). After adding the `MessageNormalizer`
+dependency, this will fail to compile. Update the test:
+- Add `@Mock private MessageNormalizer mockNormalizer;`
+- Change setUp to: `controller = new AnalyzerInputController(mockNormalizer);`
+- Add `when(mockNormalizer.process(any())).thenReturn(true);` in setUp (default success)
+- Keep ALL existing test cases (protocol detection, source IP extraction, error handling) — they still apply
+- Add new test: verify `normalizer.process()` is called for successful requests
+- Add new test: verify 500 response when `normalizer.process()` returns false
+
+### T08: Create `ASTMBridgeAdapter`
+
+**File**: `src/main/java/org/itech/ahb/normalizer/ASTMBridgeAdapter.java` (NEW)
+
+Implements `ASTMHandler` (the library interface at `org.itech.ahb.lib.astm.handling.ASTMHandler`).
+Replaces `DefaultForwardingASTMToHTTPHandler` in the bean factory.
+
+```java
+package org.itech.ahb.normalizer;
+
+import lombok.extern.slf4j.Slf4j;
+import org.itech.ahb.lib.astm.concept.ASTMMessage;
+import org.itech.ahb.lib.astm.concept.DefaultASTMMessage;
+import org.itech.ahb.lib.astm.handling.ASTMHandler;
+import org.itech.ahb.lib.astm.handling.ASTMHandlerResponse;
+import org.itech.ahb.lib.common.handling.HandleStatus;
+import org.itech.ahb.model.Protocol;
+import org.itech.ahb.model.Transport;
+
+@Slf4j
+public class ASTMBridgeAdapter implements ASTMHandler {
+
+    private final MessageNormalizer normalizer;
+
+    public ASTMBridgeAdapter(MessageNormalizer normalizer) {
+        this.normalizer = normalizer;
+    }
+
+    @Override
+    public String getName() {
+        return "ASTM Bridge Adapter";
+    }
+
+    @Override
+    public ASTMHandlerResponse handle(ASTMMessage message, String sourceIp) {
+        log.debug("ASTMBridgeAdapter handling message from {}", sourceIp);
+
+        MessageEnvelope envelope = MessageEnvelope.builder()
+            .protocol(Protocol.ASTM)
+            .transport(Transport.TCP)
+            .sourceId(sourceIp != null ? sourceIp : "unknown")
+            .rawMessage(message.getMessage())
+            .build();
+
+        boolean success = normalizer.process(envelope);
+
+        return new ASTMHandlerResponse(
+            "",
+            success ? HandleStatus.SUCCESS : HandleStatus.FORWARD_FAIL_ERROR,
+            false,
+            this
+        );
+    }
+
+    @Override
+    public boolean matches(ASTMMessage message) {
+        return message instanceof DefaultASTMMessage;
+    }
+}
+```
+
+**Then modify the bean factory** in `AstmHttpBridgeApplication.java`:
+
+Replace the `astmHandlerService` bean method:
+
+```java
+@Bean
+public ASTMHandlerService astmHandlerService(MessageNormalizer normalizer) {
+    List<ASTMHandler> astmHandlers = Arrays.asList(
+        new ASTMBridgeAdapter(normalizer)
+    );
+    return new ASTMHandlerService(astmHandlers, Mode.FIRST);
+}
+```
+
+**CRITICAL — Also update the servlet beans** that call `astmHandlerService()` directly:
+
+The two ASTM servlet beans (`astmLIS01AServlet` at line 90, `astmE138195Servlet` at line 111)
+currently call `astmHandlerService(httpForwardConfig)` as a Java method call. After changing
+the parameter from `HTTPForwardServerConfigurationProperties` to `MessageNormalizer`, these
+calls will break.
+
+**Best fix**: Change the servlet beans to receive `ASTMHandlerService` as a Spring-injected parameter instead:
+
+```java
+@Bean
+public ASTMServlet astmLIS01AServlet(
+    ASTMLIS1AListenServerConfigurationProperties astmListenConfig,
+    ASTMHandlerService astmHandlerService  // CHANGED: inject bean instead of calling method
+) {
+    log.info("creating astm server bean to handle incoming astm LIS1-A requests on port " + astmListenConfig.getPort());
+    return new ASTMServlet(
+      astmHandlerService,  // CHANGED: use injected bean
+      astmInterpreterFactory(),
+      astmListenConfig.getPort(),
+      ASTMVersion.LIS01_A
+    );
+}
+
+@Bean
+public ASTMServlet astmE138195Servlet(
+    ASTME138195ListenServerConfigurationProperties astmListenConfig,
+    ASTMHandlerService astmHandlerService  // CHANGED: inject bean instead of calling method
+) {
+    log.info("creating astm 1381-95 server bean...");
+    return new ASTMServlet(
+      astmHandlerService,  // CHANGED: use injected bean
+      astmInterpreterFactory(),
+      astmListenConfig.getPort(),
+      ASTMVersion.E1381_95
+    );
+}
+```
+
+**Remove**: The `HTTPForwardServerConfigurationProperties httpForwardConfig` parameter from
+`astmHandlerService()`, `astmLIS01AServlet()`, and `astmE138195Servlet()` methods. Also remove
+the `DefaultForwardingASTMToHTTPHandler` import. Note: `HTTPForwardServerConfigurationProperties`
+is still needed by `HttpForwardingRouter` — just not by any bean factory methods anymore.
+
+**IMPORTANT**: Do NOT modify any files in `astm-http-lib/`. The adapter lives in the main app and implements the library interface.
+
+### T09: Update `configuration.yml`
+
+**File**: `configuration.yml` (MODIFY)
+
+Add the `bridge.analyzers` section with examples:
+
+```yaml
+bridge:
+  # ... existing openelis and file sections ...
+
+  # Analyzer identification registry (M7)
+  # Maps source identifiers to analyzer IDs for the AnalyzerIdentifier.
+  # Keys can be: IP addresses, serial port paths, or glob patterns for file paths.
+  analyzers: {}
+  # Example configuration (uncomment and modify):
+  #   "192.168.1.10":
+  #     id: MINDRAY-BC5380-001
+  #     name: "Mindray BC-5380"
+  #     expectedProtocol: ASTM
+  #   "192.168.1.11":
+  #     id: SYSMEX-XN-001
+  #     name: "Sysmex XN-1000"
+  #     expectedProtocol: HL7
+  #   "/dev/ttyUSB0":
+  #     id: HORIBA-PENTRA60-001
+  #     name: "Horiba Pentra 60"
+  #     expectedProtocol: ASTM
+  #   "quantstudio-*":
+  #     id: QUANTSTUDIO-001
+  #     name: "QuantStudio 7 Flex"
+  #     expectedProtocol: CSV
+  #     filePattern: ".*/quantstudio-.*\\.csv"
+```
+
+Also consolidate the dual OpenELIS URIs. Add a comment noting the legacy `org.itech.ahb.forward-http-server.uri` is used by `HttpForwardingRouter` (via `HTTPForwardServerConfigurationProperties`) while `bridge.openelis.url` was used by the now-removed File direct forwarding.
+
+### T10: Unit Tests
+
+**Files** (NEW):
+- `src/test/java/org/itech/ahb/normalizer/MessageNormalizerTest.java`
+- `src/test/java/org/itech/ahb/normalizer/AnalyzerIdentifierTest.java`
+- `src/test/java/org/itech/ahb/normalizer/ASTMBridgeAdapterTest.java`
+
+Use the existing test patterns: JUnit 5 + Mockito (from `spring-boot-starter-test`).
+Follow the `@Nested` + `@DisplayName` pattern used in `SerialMessageHandlerTest` and
+`AnalyzerInputControllerTest`.
+
+**MessageNormalizerTest**: Mock `HttpForwardingRouter` (concrete type) and `AnalyzerIdentifier`.
+- Test: envelope with analyzerId already set → `forwardingRouter.route()` called with same analyzerId
+- Test: envelope without analyzerId, identifier returns "MINDRAY-001" → `forwardingRouter.route()` called with enriched envelope containing "MINDRAY-001"
+- Test: envelope without analyzerId, identifier returns null → `forwardingRouter.route()` called with original envelope
+- Test: forwardingRouter returns false → normalizer returns false
+- Test: forwardingRouter returns true → normalizer returns true
+- Test: `route(envelope)` delegates to `process(envelope)` (verifies MessageRouter implementation)
+
+**AnalyzerIdentifierTest**: Mock or create test `AnalyzerRegistryConfig`.
+- Test: direct IP match → returns analyzer ID
+- Test: serial port path match → returns analyzer ID
+- Test: glob pattern match for file path → returns analyzer ID
+- Test: no match → returns null
+- Test: null registry → returns null
+
+**ASTMBridgeAdapterTest**: Mock `MessageNormalizer`.
+- Test: handle with sourceIp → creates envelope with Protocol.ASTM, Transport.TCP, correct sourceIp
+- Test: handle with null sourceIp → creates envelope with sourceId "unknown"
+- Test: normalizer returns true → response has `HandleStatus.SUCCESS`
+- Test: normalizer returns false → response has `HandleStatus.FORWARD_FAIL_ERROR`
+- Test: matches `DefaultASTMMessage` → true
+- Test: `getName()` returns "ASTM Bridge Adapter"
+
+**NOTE on HandleStatus**: The enum has 9 values (SUCCESS, GENERIC_FAIL, FORWARD_FAIL_BAD_RESPONSE,
+FORWARD_FAIL_ERROR, FAIL_TOO_MANY_ATTEMPTS, FAIL_LINE_CONTESTED, INTERRUPTED, and 2 deprecated).
+The adapter only uses SUCCESS and FORWARD_FAIL_ERROR because it represents a simple pass/fail
+from the normalizer. The other statuses (retry exhaustion, line contention, etc.) were specific
+to the old `DefaultForwardingASTMToHTTPHandler` which handled its own HTTP forwarding.
+
+### T11: Integration Test — Unified Routing
+
+**File** (NEW): `src/test/java/org/itech/ahb/integration/UnifiedRoutingTest.java`
+
+Verify all 5 listener types route through `MessageNormalizer` to `HttpForwardingRouter`:
+
+Use `com.sun.net.httpserver.HttpServer` (JDK built-in) as the mock HTTP server to capture
+forwarded requests. This is the **existing test pattern** used in `SerialMessageHandlerTest`.
+Do NOT use `MockWebServer` (it's not a project dependency).
+
+Configure `HttpForwardingRouter` to point to this embedded server.
+
+Test scenarios:
+1. MLLP HL7 message → `HapiReceivingApplication.processMessage()` → verify mock receives POST to `/analyzer/hl7` with correct headers (goes through normalizer because `MessageNormalizer` is `@Primary MessageRouter`)
+2. Serial ASTM message → `SerialMessageHandler.handleMessage()` → verify mock receives POST to `/analyzer/astm` (no longer bypasses)
+3. File CSV drop → `FileMessageHandler.processFile()` → verify mock receives POST to `/analyzer/csv` (no longer bypasses)
+4. HTTP `/input` POST → `AnalyzerInputController.receiveAnalyzerMessage()` → verify mock receives POST to correct protocol endpoint (no longer drops)
+5. ASTM TCP message → `ASTMBridgeAdapter.handle()` → verify mock receives POST to `/analyzer/astm` via MessageNormalizer
+
+For each: verify `X-Source-Protocol`, `X-Source-Transport`, `X-Source-Id` headers are correct.
+For MLLP: also verify `X-Analyzer-Id` is set from MSH-3/MSH-4 (via normalizer enrichment).
+
+**Setup approach**: Create a `@SpringBootTest` or manual wiring that:
+1. Starts `com.sun.net.httpserver.HttpServer` on a random port
+2. Creates `HTTPForwardServerConfigurationProperties` pointing to that server
+3. Creates the full chain: `AnalyzerRegistryConfig` → `AnalyzerIdentifier` → `HttpForwardingRouter` → `MessageNormalizer`
+4. Tests each listener's handler method with the normalizer
+5. Captures and asserts on the HTTP requests received by the mock server
+
+---
+
+## Additional Cleanup (R-BRIDGE items folded into this PR)
+
+### RB-05: Document config prefix standardization
+
+Add a note in `README.md` (or a comment in `configuration.yml`) that `org.itech.ahb.*` is legacy and `bridge.*` is the preferred format for new configuration.
+
+### RB-06: Consolidate dual OpenELIS URIs
+
+In `configuration.yml`, add a comment explaining:
+- `org.itech.ahb.forward-http-server.uri` → used by `HttpForwardingRouter` (via `HTTPForwardServerConfigurationProperties`)
+- `bridge.openelis.url` → was used by FileMessageHandler's direct forwarding (now removed by T06)
+- Future: migrate `HttpForwardingRouter` to use `bridge.openelis.url` (deferred)
+
+---
+
+## Build & Verify
+
+```bash
+# Build (skip tests first to check compilation)
+mvn clean compile
+
+# Run all tests
+mvn clean test
+
+# Run specific M7 tests
+mvn test -Dtest="MessageNormalizerTest,AnalyzerIdentifierTest,ASTMBridgeAdapterTest,UnifiedRoutingTest"
+
+# Run full test suite including existing tests (ensure nothing broke)
+mvn clean verify
+```
+
+### What Success Looks Like
+
+1. `mvn clean verify` passes with zero failures (including all existing tests + new M7 tests)
+2. All 5 listener types route through `MessageNormalizer`:
+   - MLLP: via `@Primary MessageRouter` injection (no code change to `HapiReceivingApplication`)
+   - Serial: via `normalizer.process()` (refactored T05)
+   - File: via `normalizer.process()` (refactored T06)
+   - HTTP: via `normalizer.process()` (wired T07)
+   - ASTM: via `ASTMBridgeAdapter` → `normalizer.process()` (new T08)
+3. `SerialMessageHandler` no longer has its own `HttpClient` or `forwardMessage()` method
+4. `FileMessageHandler` no longer has its own `RestTemplate` or `forwardToOpenELIS()` method
+5. `AnalyzerInputController` no longer has a TODO — it actually routes messages
+6. ASTM messages go through `ASTMBridgeAdapter` → `MessageNormalizer` → `HttpForwardingRouter`
+7. Retry/backoff works on `HttpForwardingRouter` (configurable via `bridge.openelis.retry.*`)
+8. No changes to any files in `astm-http-lib/` directory
+9. Existing tests (`SerialMessageHandlerTest`, `AnalyzerInputControllerTest`) updated and passing
+10. `MessageNormalizer` is `@Primary MessageRouter` — zero changes to MLLP path
+
+---
+
+## Files Summary
+
+### Create (NEW)
+| File | Package |
+|------|---------|
+| `normalizer/MessageNormalizer.java` | `org.itech.ahb.normalizer` |
+| `normalizer/AnalyzerIdentifier.java` | `org.itech.ahb.normalizer` |
+| `normalizer/ASTMBridgeAdapter.java` | `org.itech.ahb.normalizer` |
+| `config/AnalyzerRegistryConfig.java` | `org.itech.ahb.config` |
+| `test/normalizer/MessageNormalizerTest.java` | test |
+| `test/normalizer/AnalyzerIdentifierTest.java` | test |
+| `test/normalizer/ASTMBridgeAdapterTest.java` | test |
+| `test/integration/UnifiedRoutingTest.java` | test |
+
+### Modify
+| File | What Changes |
+|------|-------------|
+| `routing/HttpForwardingRouter.java` | Add retry/backoff loop, inject `OpenELISConfig` for retry config |
+| `serial/SerialMessageHandler.java` | Remove direct HTTP; inject + delegate to MessageNormalizer |
+| `file/FileMessageHandler.java` | Remove direct HTTP; inject + delegate to MessageNormalizer |
+| `controller/AnalyzerInputController.java` | Add MessageNormalizer dependency; replace TODO with normalizer.process() call |
+| `AstmHttpBridgeApplication.java` | Swap bean: ASTMBridgeAdapter replaces DefaultForwarding; update servlet beans to inject ASTMHandlerService |
+| `config/OpenELISConfig.java` | Remove @ConditionalOnProperty("bridge.file") |
+| `config/HttpClientConfig.java` | Remove unused `fileWatcherRestTemplate` bean |
+| `configuration.yml` | Add bridge.analyzers section, document URI consolidation |
+| `test/.../serial/SerialMessageHandlerTest.java` | Rewrite to mock MessageNormalizer (remove embedded HTTP server) |
+| `test/.../controller/AnalyzerInputControllerTest.java` | Add mock MessageNormalizer to constructor |
+
+### DO NOT Modify
+| File | Reason |
+|------|--------|
+| `astm-http-lib/**/*` | Library module — adapter pattern avoids changes |
+| `routing/MessageRouter.java` | Interface is correct as-is |
+| `normalizer/MessageEnvelope.java` | DTO is correct as-is |
+| `normalizer/NormalizedMessage.java` | Keep for future use |
+| `mllp/HapiReceivingApplication.java` | Already uses `MessageRouter` — gets `MessageNormalizer` via `@Primary` injection automatically |
+| `model/Protocol.java` | Enum is complete |
+| `model/Transport.java` | Enum is complete |
+| `util/ProtocolDetector.java` | Utility is correct as-is |

--- a/configuration.yml
+++ b/configuration.yml
@@ -22,6 +22,10 @@
 # Bridge Configuration (NEW FORMAT - v2.0+)
 bridge:
   # OpenELIS connection settings
+  # NOTE: This 'url' property was used by FileMessageHandler's direct forwarding (pre-M7).
+  #       After M7 (Message Normalizer), all routing uses HttpForwardingRouter, which reads
+  #       from org.itech.ahb.forward-http-server.uri (legacy format).
+  #       Future: Consolidate to bridge.openelis.url once legacy format is fully migrated.
   openelis:
     url: http://localhost:8443
     connectTimeoutSeconds: 30
@@ -29,6 +33,35 @@ bridge:
     retry:
       maxAttempts: 3
       backoffMs: 1000
+
+  # Analyzer identification registry (M7: Message Normalizer)
+  # Maps source identifiers (IP addresses, serial ports, file paths) to analyzer IDs.
+  # The AnalyzerIdentifier service uses these mappings to identify analyzers before routing.
+  # If no match is found, OpenELIS will identify the analyzer from message content (e.g., MSH-3/MSH-4 for HL7).
+  #
+  # Key types:
+  #   - IP addresses: Exact match (e.g., "192.168.1.10")
+  #   - Serial port paths: Exact match (e.g., "/dev/ttyUSB0")
+  #   - Glob patterns: Wildcard match for file paths (e.g., "quantstudio-*" matches "quantstudio-20260205.csv")
+  analyzers: {}
+  # Example configuration (uncomment and modify as needed):
+  #   "192.168.1.10":
+  #     id: MINDRAY-BC5380-001
+  #     name: "Mindray BC-5380"
+  #     expectedProtocol: ASTM
+  #   "192.168.1.11":
+  #     id: SYSMEX-XN-001
+  #     name: "Sysmex XN-1000"
+  #     expectedProtocol: HL7
+  #   "/dev/ttyUSB0":
+  #     id: HORIBA-PENTRA60-001
+  #     name: "Horiba Pentra 60"
+  #     expectedProtocol: ASTM
+  #   "quantstudio-*":
+  #     id: QUANTSTUDIO-001
+  #     name: "QuantStudio 7 Flex"
+  #     expectedProtocol: CSV
+  #     filePattern: ".*/quantstudio-.*\\.csv"
 
   # File watcher configuration (M4)
   file:
@@ -57,12 +90,18 @@ bridge:
         flags: 5
 
 # Legacy configuration (still supported)
+# NOTE: This org.itech.ahb.* format is from Bridge v1.x. After M7 (Message Normalizer),
+#       HttpForwardingRouter reads from this URI for ALL transport types (ASTM, MLLP, Serial, File, HTTP).
+#       It routes to protocol-specific endpoints automatically (/analyzer/astm, /analyzer/hl7, /analyzer/csv).
+#       Future: Migrate to bridge.openelis.url once legacy format is fully deprecated.
 org:
   itech:
     ahb:
       forward-http-server:
-        # URI of the OpenELIS ASTM endpoint (or http-capture for testing)
-        uri: http://localhost:8080/api/analyzer/astm
+        # URI of the OpenELIS base endpoint (HttpForwardingRouter appends protocol paths)
+        # Base path only - router appends /astm, /hl7, /csv, /raw per message protocol
+        # Example: http://localhost:8080/api/OpenELIS-Global/analyzer → /analyzer/astm, /analyzer/hl7, etc.
+        uri: http://localhost:8080/api/OpenELIS-Global/analyzer
 
       # ASTM LIS1-A Server - Listens for ASTM messages from analyzers
       listen-astm-server:

--- a/src/main/java/org/itech/ahb/AstmHttpBridgeApplication.java
+++ b/src/main/java/org/itech/ahb/AstmHttpBridgeApplication.java
@@ -6,15 +6,15 @@ import lombok.extern.slf4j.Slf4j;
 import org.itech.ahb.config.YamlPropertySourceFactory;
 import org.itech.ahb.config.properties.ASTME138195ListenServerConfigurationProperties;
 import org.itech.ahb.config.properties.ASTMLIS1AListenServerConfigurationProperties;
-import org.itech.ahb.config.properties.HTTPForwardServerConfigurationProperties;
 import org.itech.ahb.lib.astm.handling.ASTMHandler;
 import org.itech.ahb.lib.astm.handling.ASTMHandlerService;
 import org.itech.ahb.lib.astm.handling.ASTMHandlerService.Mode;
-import org.itech.ahb.lib.astm.handling.DefaultForwardingASTMToHTTPHandler;
 import org.itech.ahb.lib.astm.interpretation.ASTMInterpreterFactory;
 import org.itech.ahb.lib.astm.interpretation.DefaultASTMInterpreterFactory;
 import org.itech.ahb.lib.astm.servlet.ASTMServlet;
 import org.itech.ahb.lib.astm.servlet.ASTMServlet.ASTMVersion;
+import org.itech.ahb.normalizer.ASTMBridgeAdapter;
+import org.itech.ahb.normalizer.MessageNormalizer;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
@@ -58,42 +58,43 @@ public class AstmHttpBridgeApplication {
 
   /**
    * Bean for creating an ASTM handler service.
+   * <p>
+   * After M7 (Message Normalizer) refactoring, the handler service uses
+   * {@link ASTMBridgeAdapter} instead of {@code DefaultForwardingASTMToHTTPHandler}.
+   * The adapter delegates to {@link MessageNormalizer} for unified routing,
+   * retry/backoff, and audit logging.
+   * </p>
    *
-   * @param httpForwardConfig the HTTP forward server configuration properties
+   * @param normalizer the message normalizer for routing
    * @return the ASTM handler service
    */
   @Bean
-  public ASTMHandlerService astmHandlerService(HTTPForwardServerConfigurationProperties httpForwardConfig) {
-    List<ASTMHandler> astmHandlers;
-    if (StringUtils.hasText(httpForwardConfig.getUsername())) {
-      astmHandlers = Arrays.asList(
-        new DefaultForwardingASTMToHTTPHandler(
-          httpForwardConfig.getUri(),
-          httpForwardConfig.getUsername(),
-          httpForwardConfig.getPassword()
-        )
-      );
-    } else {
-      astmHandlers = Arrays.asList(new DefaultForwardingASTMToHTTPHandler(httpForwardConfig.getUri()));
-    }
+  public ASTMHandlerService astmHandlerService(MessageNormalizer normalizer) {
+    List<ASTMHandler> astmHandlers = Arrays.asList(
+      new ASTMBridgeAdapter(normalizer)
+    );
     return new ASTMHandlerService(astmHandlers, Mode.FIRST);
   }
 
   /**
    * Bean for creating an ASTM servlet for LIS1-A.
+   * <p>
+   * After M7 refactoring, the servlet receives {@link ASTMHandlerService} via dependency
+   * injection instead of calling the method directly.
+   * </p>
    *
    * @param astmListenConfig the ASTM listen server configuration properties
-   * @param httpForwardConfig the HTTP forward server configuration properties
+   * @param astmHandlerService the ASTM handler service (injected)
    * @return the ASTM servlet
    */
   @Bean
   public ASTMServlet astmLIS01AServlet(
     ASTMLIS1AListenServerConfigurationProperties astmListenConfig,
-    HTTPForwardServerConfigurationProperties httpForwardConfig
+    ASTMHandlerService astmHandlerService
   ) {
     log.info("creating astm server bean to handle incoming astm LIS1-A requests on port " + astmListenConfig.getPort());
     return new ASTMServlet(
-      astmHandlerService(httpForwardConfig),
+      astmHandlerService,
       astmInterpreterFactory(),
       astmListenConfig.getPort(),
       ASTMVersion.LIS01_A
@@ -102,21 +103,25 @@ public class AstmHttpBridgeApplication {
 
   /**
    * Bean for creating an ASTM servlet for E1381-95.
+   * <p>
+   * After M7 refactoring, the servlet receives {@link ASTMHandlerService} via dependency
+   * injection instead of calling the method directly.
+   * </p>
    *
    * @param astmListenConfig the ASTM listen server configuration properties
-   * @param httpForwardConfig the HTTP forward server configuration properties
+   * @param astmHandlerService the ASTM handler service (injected)
    * @return the ASTM servlet
    */
   @Bean
   public ASTMServlet astmE138195Servlet(
     ASTME138195ListenServerConfigurationProperties astmListenConfig,
-    HTTPForwardServerConfigurationProperties httpForwardConfig
+    ASTMHandlerService astmHandlerService
   ) {
     log.info(
       "creating astm 1381-95 server bean to handle incoming astm 1381-95 requests on port " + astmListenConfig.getPort()
     );
     return new ASTMServlet(
-      astmHandlerService(httpForwardConfig),
+      astmHandlerService,
       astmInterpreterFactory(),
       astmListenConfig.getPort(),
       ASTMVersion.E1381_95

--- a/src/main/java/org/itech/ahb/config/AnalyzerRegistryConfig.java
+++ b/src/main/java/org/itech/ahb/config/AnalyzerRegistryConfig.java
@@ -37,7 +37,7 @@ import java.util.regex.PatternSyntaxException;
  *       id: QUANTSTUDIO-001
  *       name: "QuantStudio 7 Flex"
  *       expectedProtocol: CSV
- *       filePattern: ".* /quantstudio-.*\\.csv"
+ *       filePattern: ".*\\/quantstudio-.*\\.csv"
  * </pre>
  * </p>
  * <p>

--- a/src/main/java/org/itech/ahb/config/AnalyzerRegistryConfig.java
+++ b/src/main/java/org/itech/ahb/config/AnalyzerRegistryConfig.java
@@ -1,0 +1,173 @@
+package org.itech.ahb.config;
+
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.PatternSyntaxException;
+
+/**
+ * Configuration properties for analyzer identification registry.
+ * <p>
+ * Maps source identifiers (IP addresses, serial ports, file paths) to analyzer IDs
+ * for the {@link org.itech.ahb.normalizer.AnalyzerIdentifier} service.
+ * </p>
+ * <p>
+ * Configuration format in {@code configuration.yml}:
+ * <pre>
+ * bridge:
+ *   analyzers:
+ *     "192.168.1.10":
+ *       id: MINDRAY-BC5380-001
+ *       name: "Mindray BC-5380"
+ *       expectedProtocol: ASTM
+ *     "/dev/ttyUSB0":
+ *       id: HORIBA-PENTRA60-001
+ *       name: "Horiba Pentra 60"
+ *       expectedProtocol: ASTM
+ *     "quantstudio-*":
+ *       id: QUANTSTUDIO-001
+ *       name: "QuantStudio 7 Flex"
+ *       expectedProtocol: CSV
+ *       filePattern: ".* /quantstudio-.*\\.csv"
+ * </pre>
+ * </p>
+ * <p>
+ * Keys can be:
+ * <ul>
+ *   <li><strong>IP addresses:</strong> Exact match (e.g., "192.168.1.10")</li>
+ *   <li><strong>Serial port paths:</strong> Exact match (e.g., "/dev/ttyUSB0")</li>
+ *   <li><strong>Glob patterns:</strong> Wildcard match for file paths (e.g., "quantstudio-*")</li>
+ * </ul>
+ * </p>
+ *
+ * @see org.itech.ahb.normalizer.AnalyzerIdentifier
+ */
+@Configuration
+@ConfigurationProperties(prefix = "bridge")
+@Data
+@Slf4j
+public class AnalyzerRegistryConfig {
+
+    /**
+     * Map of source identifiers to analyzer entries.
+     * <p>
+     * Keys are source identifiers (IP addresses, serial ports, glob patterns).
+     * Values are {@link AnalyzerEntry} objects with analyzer metadata.
+     * </p>
+     */
+    private Map<String, AnalyzerEntry> analyzers = new LinkedHashMap<>();
+
+    /**
+     * Finds an analyzer ID by source identifier.
+     * <p>
+     * Lookup strategy:
+     * <ol>
+     *   <li><strong>Direct match:</strong> Exact key match (IP address, serial port)</li>
+     *   <li><strong>Pattern match:</strong> Glob pattern match for file paths (keys with "*")</li>
+     * </ol>
+     * </p>
+     *
+     * @param sourceId the source identifier (IP address, serial port, file path)
+     * @return Optional containing the analyzer ID, or empty if no match
+     */
+    public Optional<String> findAnalyzerId(String sourceId) {
+        if (sourceId == null || analyzers.isEmpty()) {
+            return Optional.empty();
+        }
+
+        // Strategy 1: Direct match (IP address, serial port path)
+        AnalyzerEntry entry = analyzers.get(sourceId);
+        if (entry != null) {
+            log.debug("Direct match for source '{}': analyzer '{}'", sourceId, entry.getId());
+            return Optional.of(entry.getId());
+        }
+
+        // Strategy 2: Pattern match (file paths with wildcards)
+        for (Map.Entry<String, AnalyzerEntry> e : analyzers.entrySet()) {
+            String pattern = e.getKey();
+            if (pattern.contains("*") && matchesGlob(sourceId, pattern)) {
+                log.debug("Pattern match for source '{}' using pattern '{}': analyzer '{}'",
+                    sourceId, pattern, e.getValue().getId());
+                return Optional.of(e.getValue().getId());
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Checks if a source ID matches a glob pattern.
+     * <p>
+     * Converts glob pattern to regex:
+     * <ul>
+     *   <li>{@code *} becomes {@code .*} (match any characters)</li>
+     *   <li>{@code ?} becomes {@code .} (match single character)</li>
+     *   <li>Special regex chars are escaped</li>
+     * </ul>
+     * </p>
+     *
+     * @param sourceId the source identifier to test
+     * @param globPattern the glob pattern (may contain * or ?)
+     * @return true if sourceId matches the pattern
+     */
+    private boolean matchesGlob(String sourceId, String globPattern) {
+        try {
+            // Convert glob to regex
+            String regex = globPattern
+                .replace(".", "\\.")  // Escape dots
+                .replace("*", ".*")   // * matches any characters
+                .replace("?", ".");   // ? matches single character
+            if (sourceId.matches(regex)) {
+                return true;
+            }
+
+            // If sourceId looks like a path, also check against the file name
+            Path path = Paths.get(sourceId);
+            Path fileName = path.getFileName();
+            return fileName != null && fileName.toString().matches(regex);
+        } catch (PatternSyntaxException e) {
+            log.warn("Invalid glob pattern '{}': {}", globPattern, e.getMessage());
+            return false;
+        } catch (Exception e) {
+            log.debug("Failed to evaluate glob pattern '{}' against source '{}': {}",
+                globPattern, sourceId, e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Analyzer entry with metadata.
+     * <p>
+     * Contains analyzer identification and configuration information.
+     * </p>
+     */
+    @Data
+    public static class AnalyzerEntry {
+        /**
+         * Unique analyzer identifier (e.g., "MINDRAY-BC5380-001")
+         */
+        private String id;
+
+        /**
+         * Human-readable analyzer name (e.g., "Mindray BC-5380")
+         */
+        private String name;
+
+        /**
+         * Expected protocol (ASTM, HL7, CSV) for validation
+         */
+        private String expectedProtocol;
+
+        /**
+         * Optional file pattern for additional validation (regex)
+         */
+        private String filePattern;
+    }
+}

--- a/src/main/java/org/itech/ahb/config/AnalyzerRegistryConfig.java
+++ b/src/main/java/org/itech/ahb/config/AnalyzerRegistryConfig.java
@@ -5,7 +5,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
+import java.nio.file.FileSystems;
 import java.nio.file.Path;
+import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -119,22 +121,18 @@ public class AnalyzerRegistryConfig {
      */
     private boolean matchesGlob(String sourceId, String globPattern) {
         try {
-            // Convert glob to regex
-            String regex = globPattern
-                .replace(".", "\\.")  // Escape dots
-                .replace("*", ".*")   // * matches any characters
-                .replace("?", ".");   // ? matches single character
-            if (sourceId.matches(regex)) {
+            PathMatcher matcher = FileSystems.getDefault()
+                .getPathMatcher("glob:" + globPattern);
+
+            // Try full path match first
+            if (matcher.matches(Paths.get(sourceId))) {
                 return true;
             }
 
             // If sourceId looks like a path, also check against the file name
             Path path = Paths.get(sourceId);
             Path fileName = path.getFileName();
-            return fileName != null && fileName.toString().matches(regex);
-        } catch (PatternSyntaxException e) {
-            log.warn("Invalid glob pattern '{}': {}", globPattern, e.getMessage());
-            return false;
+            return fileName != null && matcher.matches(fileName);
         } catch (Exception e) {
             log.debug("Failed to evaluate glob pattern '{}' against source '{}': {}",
                 globPattern, sourceId, e.getMessage());

--- a/src/main/java/org/itech/ahb/config/HttpClientConfig.java
+++ b/src/main/java/org/itech/ahb/config/HttpClientConfig.java
@@ -1,6 +1,5 @@
 package org.itech.ahb.config;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,34 +12,20 @@ import java.time.Duration;
  * <p>
  * Configures RestTemplate beans for HTTP communication with OpenELIS and other services.
  * </p>
+ * <p>
+ * NOTE: After M7 (Message Normalizer) refactoring, file watcher no longer uses RestTemplate
+ * (delegates to MessageNormalizer → HttpForwardingRouter which uses java.net.http.HttpClient).
+ * The fileWatcherRestTemplate bean was removed as it has no consumers.
+ * </p>
  */
 @Configuration
 public class HttpClientConfig {
 
     /**
-     * RestTemplate bean for file watcher HTTP forwarding.
-     * <p>
-     * Only created when file watcher is enabled.
-     * Configured with timeouts from OpenELISConfig.
-     * </p>
-     *
-     * @param builder Spring-provided RestTemplate builder
-     * @param openelisConfig OpenELIS configuration with timeout settings
-     * @return configured RestTemplate instance
-     */
-    @Bean
-    @ConditionalOnProperty(prefix = "bridge.file", name = "enabled", havingValue = "true")
-    public RestTemplate fileWatcherRestTemplate(RestTemplateBuilder builder, OpenELISConfig openelisConfig) {
-        return builder
-                .setConnectTimeout(Duration.ofSeconds(openelisConfig.getConnectTimeoutSeconds()))
-                .setReadTimeout(Duration.ofSeconds(openelisConfig.getReadTimeoutSeconds()))
-                .build();
-    }
-
-    /**
      * General-purpose RestTemplate bean for bridge HTTP operations.
      * <p>
      * Used by components that need HTTP client but aren't file-watcher-specific.
+     * May be used in future for non-analyzer HTTP operations.
      * </p>
      *
      * @param builder Spring-provided RestTemplate builder

--- a/src/main/java/org/itech/ahb/config/OpenELISConfig.java
+++ b/src/main/java/org/itech/ahb/config/OpenELISConfig.java
@@ -14,7 +14,6 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration
 @ConfigurationProperties(prefix = "bridge.openelis")
-@ConditionalOnProperty(prefix = "bridge.file", name = "enabled", havingValue = "true")
 @Data
 public class OpenELISConfig {
 

--- a/src/main/java/org/itech/ahb/controller/AnalyzerInputController.java
+++ b/src/main/java/org/itech/ahb/controller/AnalyzerInputController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
  * HTTP input endpoint for analyzers with REST API capabilities.
  * <p>
  * This controller accepts raw analyzer messages (ASTM, HL7, or CSV) over HTTP POST
- * and creates a MessageEnvelope for downstream processing by the message normalizer.
+ * and routes them via {@link org.itech.ahb.normalizer.MessageNormalizer} to OpenELIS.
  * </p>
  * <p>
  * Protocol detection:
@@ -36,6 +36,13 @@ import org.springframework.web.bind.annotation.RestController;
  * infrastructure level (API gateway, firewall). IP headers (X-Forwarded-For, X-Real-IP)
  * are trusted for logging; do not use for security decisions without proxy validation.
  * </p>
+ * <p>
+ * Part of M7: Message Normalizer milestone — all transport handlers delegate to
+ * the normalizer for unified routing logic, retry/backoff, and audit logging.
+ * </p>
+ *
+ * @see org.itech.ahb.normalizer.MessageNormalizer
+ * @see MessageEnvelope
  */
 @RestController
 @RequestMapping("/input")
@@ -47,6 +54,17 @@ public class AnalyzerInputController {
      */
     private static final String CONTENT_TYPE_HL7_V2 = "application/hl7-v2";
     private static final String CONTENT_TYPE_HL7_V2_ALT = "x-application/hl7-v2";
+
+    private final org.itech.ahb.normalizer.MessageNormalizer normalizer;
+
+    /**
+     * Constructs a new AnalyzerInputController.
+     *
+     * @param normalizer the message normalizer for routing
+     */
+    public AnalyzerInputController(org.itech.ahb.normalizer.MessageNormalizer normalizer) {
+        this.normalizer = normalizer;
+    }
 
     /**
      * Receives analyzer messages over HTTP POST.
@@ -88,11 +106,8 @@ public class AnalyzerInputController {
             Protocol protocol = detectProtocol(contentType, requestBody);
             log.debug("Detected protocol: {}", protocol);
 
-            // Reject UNKNOWN protocol
             if (protocol == Protocol.UNKNOWN) {
-                log.warn("Unable to detect protocol for message from {}", sourceIp);
-                return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
-                        .body(new InputResponse(false, "Unable to detect message protocol", sourceIp, null, null));
+                log.warn("Unable to detect protocol for message from {}, routing as raw", sourceIp);
             }
 
             // Create MessageEnvelope
@@ -106,12 +121,18 @@ public class AnalyzerInputController {
             log.info("Created MessageEnvelope: protocol={}, transport={}, sourceId={}",
                     envelope.getProtocol(), envelope.getTransport(), envelope.getSourceId());
 
-            // TODO: Forward to MessageNormalizer for routing once M7 integration is available
-            // For now, return success with envelope details
+            // Route via MessageNormalizer
+            boolean success = normalizer.process(envelope);
+
+            if (!success) {
+                log.error("Failed to route {} message from {}", protocol, sourceIp);
+                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new InputResponse(false, "Message routing failed", sourceIp, protocol.name(), null));
+            }
 
             return ResponseEntity.ok(new InputResponse(
                     true,
-                    "Message received successfully",
+                    "Message routed successfully",
                     sourceIp,
                     protocol.name(),
                     envelope.getReceivedAt().toString()));

--- a/src/main/java/org/itech/ahb/controller/HTTPListenController.java
+++ b/src/main/java/org/itech/ahb/controller/HTTPListenController.java
@@ -78,7 +78,7 @@ public class HTTPListenController {
     HttpServletResponse response
   ) {
     log.debug("received http request to handle");
-    log.trace("requestBody: " + requestBody);
+    log.trace("requestBody length: " + (requestBody != null ? requestBody.length() : 0));
     log.trace("forwardAddress: " + forwardAddress);
     log.trace("forwardPort: " + forwardPort);
     log.trace("forwardAstmVersion: " + forwardAstmVersion);

--- a/src/main/java/org/itech/ahb/file/FileMessageHandler.java
+++ b/src/main/java/org/itech/ahb/file/FileMessageHandler.java
@@ -1,20 +1,13 @@
 package org.itech.ahb.file;
 
 import lombok.extern.slf4j.Slf4j;
-import org.itech.ahb.config.OpenELISConfig;
 import org.itech.ahb.model.Protocol;
 import org.itech.ahb.model.Transport;
 import org.itech.ahb.normalizer.MessageEnvelope;
+import org.itech.ahb.normalizer.MessageNormalizer;
 import org.itech.ahb.util.ProtocolDetector;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
-import org.springframework.web.client.RestTemplate;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -23,14 +16,16 @@ import java.nio.file.Path;
 /**
  * Handles file-based analyzer messages.
  * <p>
- * Reads file content, detects protocol format, and forwards to appropriate
- * OpenELIS endpoint based on protocol type (ASTM, HL7, CSV).
+ * Reads file content, detects protocol format, and delegates to
+ * {@link MessageNormalizer} for routing to OpenELIS.
  * </p>
  * <p>
- * NOTE: This component currently forwards directly to OpenELIS endpoints.
- * When M7 (Message Normalizer) is implemented, refactor to route through
- * the centralized normalizer for consistent audit logging and analyzer identification.
+ * Part of M7: Message Normalizer milestone — all transport handlers delegate to
+ * the normalizer for unified routing logic, retry/backoff, and audit logging.
  * </p>
+ *
+ * @see MessageNormalizer
+ * @see MessageEnvelope
  */
 @Component
 @ConditionalOnProperty(prefix = "bridge.file", name = "enabled", havingValue = "true")
@@ -38,26 +33,34 @@ import java.nio.file.Path;
 public class FileMessageHandler {
 
     private final CSVParser csvParser;
-    private final RestTemplate restTemplate;
+    private final MessageNormalizer normalizer;
     private final FileConfig fileConfig;
-    private final OpenELISConfig openelisConfig;
 
     // Maximum file size to process (10MB default)
     private static final long MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
 
+    /**
+     * Creates a new FileMessageHandler.
+     *
+     * @param csvParser the CSV parser for validation
+     * @param fileConfig the file watcher configuration
+     * @param normalizer the message normalizer for routing
+     */
     public FileMessageHandler(
             CSVParser csvParser,
             FileConfig fileConfig,
-            OpenELISConfig openelisConfig,
-            @Qualifier("fileWatcherRestTemplate") RestTemplate restTemplate) {
+            MessageNormalizer normalizer) {
         this.csvParser = csvParser;
         this.fileConfig = fileConfig;
-        this.openelisConfig = openelisConfig;
-        this.restTemplate = restTemplate;
+        this.normalizer = normalizer;
     }
 
     /**
-     * Process a file and forward to OpenELIS.
+     * Process a file and forward to OpenELIS via MessageNormalizer.
+     * <p>
+     * Reads the file, detects protocol, validates content, creates a MessageEnvelope,
+     * and delegates to the {@link MessageNormalizer} for routing to OpenELIS.
+     * </p>
      *
      * @param filePath   the file path to process
      * @param analyzerId optional analyzer identifier (for CSV mapping lookup)
@@ -89,11 +92,8 @@ public class FileMessageHandler {
         log.debug("Detected protocol: {} for file: {}", protocol, filePath.getFileName());
 
         if (protocol == Protocol.UNKNOWN) {
-            throw new FileProcessingException("Unable to detect protocol for file: " + filePath);
-        }
-
-        // Validate file content for detected protocol
-        if (!validateFileContent(filePath, protocol)) {
+            log.warn("Unable to detect protocol for file {}, routing as raw", filePath.getFileName());
+        } else if (!validateFileContent(filePath, protocol)) {
             throw new FileProcessingException("Invalid " + protocol + " content in file: " + filePath);
         }
 
@@ -106,74 +106,13 @@ public class FileMessageHandler {
                 .analyzerId(analyzerId)
                 .build();
 
-        // Forward to appropriate endpoint
-        forwardToOpenELIS(envelope);
+        // Delegate to normalizer for routing
+        boolean success = normalizer.process(envelope);
+        if (!success) {
+            throw new FileProcessingException("Failed to route message for file: " + filePath);
+        }
 
         return envelope;
-    }
-
-    /**
-     * Forward message envelope to OpenELIS endpoint based on protocol.
-     *
-     * @param envelope the message envelope to forward
-     * @throws FileProcessingException if HTTP forwarding fails
-     */
-    private void forwardToOpenELIS(MessageEnvelope envelope) throws FileProcessingException {
-        String endpoint = getEndpointForProtocol(envelope.getProtocol());
-        String fullUrl = openelisConfig.getUrl() + endpoint;
-
-        log.debug("Forwarding {} message to: {}", envelope.getProtocol(), fullUrl);
-
-        try {
-            // Build headers
-            HttpHeaders headers = new HttpHeaders();
-            headers.set("X-Source-Analyzer-IP", envelope.getSourceId());
-            headers.set("X-Message-Transport", Transport.FILE.name());
-
-            if (envelope.getAnalyzerId() != null) {
-                headers.set("X-Analyzer-ID", envelope.getAnalyzerId());
-            }
-
-            // Set content type based on protocol
-            if (envelope.getProtocol() == Protocol.CSV) {
-                headers.setContentType(MediaType.parseMediaType("text/csv"));
-            } else {
-                headers.setContentType(MediaType.TEXT_PLAIN);
-            }
-
-            // Create request
-            HttpEntity<String> request = new HttpEntity<>(envelope.getRawMessage(), headers);
-
-            // Send POST request
-            ResponseEntity<String> response = restTemplate.postForEntity(fullUrl, request, String.class);
-
-            if (response.getStatusCode() != HttpStatus.OK) {
-                throw new FileProcessingException(
-                        "OpenELIS returned non-OK status: " + response.getStatusCode() +
-                                " for protocol: " + envelope.getProtocol());
-            }
-
-            log.info("Successfully forwarded {} message to OpenELIS", envelope.getProtocol());
-
-        } catch (Exception e) {
-            log.error("Failed to forward message to OpenELIS: {}", e.getMessage(), e);
-            throw new FileProcessingException("Failed to forward to OpenELIS: " + e.getMessage(), e);
-        }
-    }
-
-    /**
-     * Get OpenELIS endpoint path based on protocol.
-     *
-     * @param protocol the message protocol
-     * @return endpoint path (e.g., "/api/analyzer/csv")
-     */
-    private String getEndpointForProtocol(Protocol protocol) {
-        return switch (protocol) {
-            case CSV -> "/api/OpenELIS-Global/analyzer/csv";
-            case HL7 -> "/api/OpenELIS-Global/analyzer/hl7";
-            case ASTM -> "/api/OpenELIS-Global/analyzer/astm";
-            default -> throw new IllegalArgumentException("Unsupported protocol: " + protocol);
-        };
     }
 
     /**

--- a/src/main/java/org/itech/ahb/health/HTTPForwardServerHealthIndicator.java
+++ b/src/main/java/org/itech/ahb/health/HTTPForwardServerHealthIndicator.java
@@ -82,7 +82,7 @@ public class HTTPForwardServerHealthIndicator implements HealthIndicator {
         "using username '" +
         properties.getUsername() +
         "' to test forward http server at " +
-        properties.getUri().toString().toString()
+        properties.getUri().toString()
       );
       addBasicAuth(requestBuilder, properties.getUsername(), properties.getPassword());
     }

--- a/src/main/java/org/itech/ahb/health/HTTPForwardServerHealthIndicator.java
+++ b/src/main/java/org/itech/ahb/health/HTTPForwardServerHealthIndicator.java
@@ -4,13 +4,22 @@ import java.io.IOException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.Builder;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
 import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Arrays;
 import java.util.Base64;
 import lombok.extern.slf4j.Slf4j;
+import org.itech.ahb.config.OpenELISConfig;
 import org.itech.ahb.config.properties.HTTPForwardServerConfigurationProperties;
 import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
@@ -29,14 +38,25 @@ import org.springframework.stereotype.Component;
 public class HTTPForwardServerHealthIndicator implements HealthIndicator {
 
   private final HTTPForwardServerConfigurationProperties properties;
+  private final int connectTimeoutSeconds;
+  private final int readTimeoutSeconds;
 
   /**
    * Constructor for HTTPForwardServerHealthIndicator.
    *
    * @param properties the HTTP forward server configuration properties
    */
-  public HTTPForwardServerHealthIndicator(HTTPForwardServerConfigurationProperties properties) {
+  public HTTPForwardServerHealthIndicator(
+    HTTPForwardServerConfigurationProperties properties,
+    @Autowired(required = false) OpenELISConfig openelisConfig
+  ) {
     this.properties = properties;
+    this.connectTimeoutSeconds = openelisConfig != null
+      ? openelisConfig.getConnectTimeoutSeconds()
+      : 30;
+    this.readTimeoutSeconds = openelisConfig != null
+      ? openelisConfig.getReadTimeoutSeconds()
+      : 30;
   }
 
   /**
@@ -49,11 +69,14 @@ public class HTTPForwardServerHealthIndicator implements HealthIndicator {
     if (properties.getHealthUri() == null) {
       return Health.unknown().build();
     }
-    HttpClient client = HttpClient.newHttpClient();
+    HttpClient client = HttpClient.newBuilder()
+      .connectTimeout(Duration.ofSeconds(connectTimeoutSeconds))
+      .build();
     log.debug("creating request to test forward http server at " + properties.getHealthUri().toString());
     Builder requestBuilder = HttpRequest.newBuilder()
       .method(properties.getHealthMethod().toString(), HttpRequest.BodyPublishers.ofString(properties.getHealthBody()))
-      .uri(properties.getHealthUri());
+      .uri(properties.getHealthUri())
+      .timeout(Duration.ofSeconds(readTimeoutSeconds));
     if (!(properties.getUsername() == null || properties.getUsername().equals(""))) {
       log.debug(
         "using username '" +
@@ -61,12 +84,7 @@ public class HTTPForwardServerHealthIndicator implements HealthIndicator {
         "' to test forward http server at " +
         properties.getUri().toString().toString()
       );
-      requestBuilder.header(
-        "Authorization",
-        "Basic " +
-        Base64.getEncoder()
-          .encodeToString((properties.getUsername() + ":" + new String(properties.getPassword())).getBytes())
-      );
+      addBasicAuth(requestBuilder, properties.getUsername(), properties.getPassword());
     }
     HttpRequest request = requestBuilder.build();
 
@@ -82,5 +100,40 @@ public class HTTPForwardServerHealthIndicator implements HealthIndicator {
     }
     log.debug("testing forward http server at " + properties.getHealthUri().toString() + " failure");
     return Health.down().build();
+  }
+
+  private void addBasicAuth(Builder requestBuilder, String username, char[] password) {
+    if (password == null || password.length == 0) {
+      log.warn("Password is null or empty, skipping Basic auth");
+      return;
+    }
+
+    byte[] usernameBytes = username.getBytes(StandardCharsets.UTF_8);
+    byte[] colonBytes = ":".getBytes(StandardCharsets.UTF_8);
+
+    byte[] passwordBytes;
+    try {
+      CharsetEncoder encoder = StandardCharsets.UTF_8.newEncoder()
+        .onMalformedInput(CodingErrorAction.REPLACE)
+        .onUnmappableCharacter(CodingErrorAction.REPLACE);
+      ByteBuffer byteBuffer = encoder.encode(CharBuffer.wrap(password));
+      passwordBytes = new byte[byteBuffer.remaining()];
+      byteBuffer.get(passwordBytes);
+    } catch (Exception e) {
+      log.error("Failed to encode password bytes", e);
+      return;
+    }
+
+    byte[] authBytes = new byte[usernameBytes.length + colonBytes.length + passwordBytes.length];
+    System.arraycopy(usernameBytes, 0, authBytes, 0, usernameBytes.length);
+    System.arraycopy(colonBytes, 0, authBytes, usernameBytes.length, colonBytes.length);
+    System.arraycopy(passwordBytes, 0, authBytes, usernameBytes.length + colonBytes.length,
+      passwordBytes.length);
+
+    String encodedAuth = Base64.getEncoder().encodeToString(authBytes);
+    requestBuilder.header("Authorization", "Basic " + encodedAuth);
+
+    Arrays.fill(passwordBytes, (byte) 0);
+    Arrays.fill(authBytes, (byte) 0);
   }
 }

--- a/src/main/java/org/itech/ahb/mllp/HapiReceivingApplication.java
+++ b/src/main/java/org/itech/ahb/mllp/HapiReceivingApplication.java
@@ -84,7 +84,7 @@ public class HapiReceivingApplication implements ReceivingApplication<Message> {
             String analyzerId = extractAnalyzerId(message, sourceIp);
 
             log.debug("Processing HL7 message from {} (analyzer: {}), {} bytes",
-                sourceIp, analyzerId, rawMessage.length());
+                sourceIp, analyzerId, rawMessage != null ? rawMessage.length() : 0);
             log.trace("HL7 message received ({} bytes)", rawMessage != null ? rawMessage.length() : 0);
 
             // Create MessageEnvelope for routing

--- a/src/main/java/org/itech/ahb/mllp/HapiReceivingApplication.java
+++ b/src/main/java/org/itech/ahb/mllp/HapiReceivingApplication.java
@@ -85,7 +85,7 @@ public class HapiReceivingApplication implements ReceivingApplication<Message> {
 
             log.debug("Processing HL7 message from {} (analyzer: {}), {} bytes",
                 sourceIp, analyzerId, rawMessage.length());
-            log.trace("HL7 message content: {}", rawMessage);
+            log.trace("HL7 message received ({} bytes)", rawMessage != null ? rawMessage.length() : 0);
 
             // Create MessageEnvelope for routing
             MessageEnvelope envelope = MessageEnvelope.builder()

--- a/src/main/java/org/itech/ahb/normalizer/ASTMBridgeAdapter.java
+++ b/src/main/java/org/itech/ahb/normalizer/ASTMBridgeAdapter.java
@@ -1,0 +1,118 @@
+package org.itech.ahb.normalizer;
+
+import lombok.extern.slf4j.Slf4j;
+import org.itech.ahb.lib.astm.concept.ASTMMessage;
+import org.itech.ahb.lib.astm.concept.DefaultASTMMessage;
+import org.itech.ahb.lib.astm.handling.ASTMHandler;
+import org.itech.ahb.lib.astm.handling.ASTMHandlerResponse;
+import org.itech.ahb.lib.common.handling.HandleStatus;
+import org.itech.ahb.model.Protocol;
+import org.itech.ahb.model.Transport;
+
+/**
+ * ASTM bridge adapter that implements the ASTM library's {@link ASTMHandler} interface
+ * and delegates to {@link MessageNormalizer} for routing to OpenELIS.
+ * <p>
+ * This adapter replaces {@code DefaultForwardingASTMToHTTPHandler} in the M7 milestone,
+ * ensuring all transport listeners (including ASTM TCP) route through the unified normalizer
+ * for consistent retry/backoff, audit logging, and analyzer identification.
+ * </p>
+ * <p>
+ * The adapter:
+ * <ol>
+ *   <li>Receives ASTM messages from the ASTM servlet (TCP listener)</li>
+ *   <li>Creates a {@link MessageEnvelope} with Protocol.ASTM and Transport.TCP</li>
+ *   <li>Delegates to {@link MessageNormalizer} for routing to OpenELIS</li>
+ *   <li>Returns {@link ASTMHandlerResponse} with appropriate {@link HandleStatus}</li>
+ * </ol>
+ * </p>
+ * <p>
+ * NOTE: This class lives in the main application (not astm-http-lib) and uses the adapter
+ * pattern to avoid modifying the library code.
+ * </p>
+ *
+ * @see MessageNormalizer
+ * @see MessageEnvelope
+ * @see ASTMHandler
+ */
+@Slf4j
+public class ASTMBridgeAdapter implements ASTMHandler {
+
+    private final MessageNormalizer normalizer;
+
+    /**
+     * Constructs a new ASTMBridgeAdapter.
+     *
+     * @param normalizer the message normalizer for routing
+     */
+    public ASTMBridgeAdapter(MessageNormalizer normalizer) {
+        this.normalizer = normalizer;
+    }
+
+    /**
+     * Returns the name of this handler for logging purposes.
+     *
+     * @return "ASTM Bridge Adapter"
+     */
+    @Override
+    public String getName() {
+        return "ASTM Bridge Adapter";
+    }
+
+    /**
+     * Handles an ASTM message by creating a MessageEnvelope and routing via the normalizer.
+     * <p>
+     * The adapter:
+     * <ul>
+     *   <li>Extracts the raw message string from {@link ASTMMessage}</li>
+     *   <li>Uses the provided sourceIp (or "unknown" if null)</li>
+     *   <li>Creates a MessageEnvelope with Protocol.ASTM and Transport.TCP</li>
+     *   <li>Delegates to {@link MessageNormalizer#process(MessageEnvelope)}</li>
+     *   <li>Returns SUCCESS or FORWARD_FAIL_ERROR status</li>
+     * </ul>
+     * </p>
+     *
+     * @param message the ASTM message from the TCP listener
+     * @param sourceIp the IP address of the analyzer (may be null)
+     * @return ASTMHandlerResponse with appropriate status
+     */
+    @Override
+    public ASTMHandlerResponse handle(ASTMMessage message, String sourceIp) {
+        log.debug("ASTMBridgeAdapter handling message from {}", sourceIp);
+
+        // Create MessageEnvelope
+        MessageEnvelope envelope = MessageEnvelope.builder()
+            .protocol(Protocol.ASTM)
+            .transport(Transport.TCP)
+            .sourceId(sourceIp != null ? sourceIp : "unknown")
+            .rawMessage(message.getMessage())
+            .build();
+
+        // Route via normalizer
+        boolean success = normalizer.process(envelope);
+
+        // Return appropriate response
+        HandleStatus status = success ? HandleStatus.SUCCESS : HandleStatus.FORWARD_FAIL_ERROR;
+
+        return new ASTMHandlerResponse(
+            "",  // Empty response string (not used by ASTM protocol ACK)
+            status,
+            false,  // Don't communicate response back to analyzer
+            this
+        );
+    }
+
+    /**
+     * Checks if this handler matches the given ASTM message.
+     * <p>
+     * This adapter matches all {@link DefaultASTMMessage} instances (the standard ASTM message type).
+     * </p>
+     *
+     * @param message the ASTM message to check
+     * @return true if message is a DefaultASTMMessage, false otherwise
+     */
+    @Override
+    public boolean matches(ASTMMessage message) {
+        return message instanceof DefaultASTMMessage;
+    }
+}

--- a/src/main/java/org/itech/ahb/normalizer/AnalyzerIdentifier.java
+++ b/src/main/java/org/itech/ahb/normalizer/AnalyzerIdentifier.java
@@ -1,0 +1,99 @@
+package org.itech.ahb.normalizer;
+
+import lombok.extern.slf4j.Slf4j;
+import org.itech.ahb.config.AnalyzerRegistryConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Multi-strategy analyzer identification service.
+ * <p>
+ * Identifies analyzers using a priority-ordered strategy chain:
+ * <ol>
+ *   <li><strong>Pre-identified:</strong> Envelope already has analyzerId (set by listener)</li>
+ *   <li><strong>IP-based lookup:</strong> Match source IP address in registry</li>
+ *   <li><strong>Serial port lookup:</strong> Match serial port path in registry</li>
+ *   <li><strong>File path pattern:</strong> Match file path using glob patterns</li>
+ *   <li><strong>Fallback to OpenELIS:</strong> Return null, let OpenELIS identify from message content</li>
+ * </ol>
+ * </p>
+ * <p>
+ * The analyzer registry is optional — if not configured, the service simply returns null
+ * and OpenELIS will attempt to identify the analyzer from the message content (e.g., MSH-3/MSH-4
+ * for HL7, ASTM record fields, CSV headers).
+ * </p>
+ *
+ * @see AnalyzerRegistryConfig
+ * @see MessageEnvelope
+ */
+@Component
+@Slf4j
+public class AnalyzerIdentifier {
+
+    private final AnalyzerRegistryConfig registry;  // may be null if not configured
+
+    /**
+     * Constructs a new AnalyzerIdentifier.
+     * <p>
+     * The registry is optional (required = false) — if not configured, all identification
+     * attempts will return null and OpenELIS will identify from message content.
+     * </p>
+     *
+     * @param registry the analyzer registry configuration (may be null)
+     */
+    public AnalyzerIdentifier(@Autowired(required = false) AnalyzerRegistryConfig registry) {
+        this.registry = registry;
+        if (registry == null) {
+            log.info("AnalyzerIdentifier created without registry — will delegate identification to OpenELIS");
+        } else {
+            int analyzerCount = registry.getAnalyzers() != null ? registry.getAnalyzers().size() : 0;
+            log.info("AnalyzerIdentifier created with {} registered analyzers", analyzerCount);
+        }
+    }
+
+    /**
+     * Identifies the analyzer for a message envelope using multi-strategy lookup.
+     * <p>
+     * Strategy priority:
+     * <ol>
+     *   <li>If envelope already has analyzerId → use it</li>
+     *   <li>If registry is configured → lookup by sourceId (IP, serial port, file pattern)</li>
+     *   <li>Otherwise → return null (OpenELIS will identify from message content)</li>
+     * </ol>
+     * </p>
+     *
+     * @param envelope the message envelope with source metadata
+     * @return the identified analyzer ID, or null if identification failed/not configured
+     */
+    public String identify(MessageEnvelope envelope) {
+        // Strategy 1: Already identified
+        if (envelope.getAnalyzerId() != null && !envelope.getAnalyzerId().isEmpty()) {
+            log.debug("Analyzer already identified: {}", envelope.getAnalyzerId());
+            return envelope.getAnalyzerId();
+        }
+
+        // Strategy 2-4: Registry-based lookup
+        if (registry == null) {
+            log.debug("No analyzer registry configured, returning null");
+            return null;
+        }
+
+        String sourceId = envelope.getSourceId();
+        if (sourceId == null || sourceId.isEmpty()) {
+            log.debug("Envelope has no sourceId, cannot identify");
+            return null;
+        }
+
+        // Lookup by sourceId (IP address, serial port path, or file path pattern)
+        String analyzerId = registry.findAnalyzerId(sourceId).orElse(null);
+
+        if (analyzerId != null) {
+            log.info("Identified analyzer '{}' from source '{}' ({} transport)",
+                analyzerId, sourceId, envelope.getTransport());
+        } else {
+            log.debug("No analyzer match for source '{}', will delegate to OpenELIS", sourceId);
+        }
+
+        return analyzerId;
+    }
+}

--- a/src/main/java/org/itech/ahb/normalizer/MessageNormalizer.java
+++ b/src/main/java/org/itech/ahb/normalizer/MessageNormalizer.java
@@ -98,7 +98,9 @@ public class MessageNormalizer implements MessageRouter {
             return false;
         }
         if (envelope.getProtocol() == null || envelope.getTransport() == null) {
-            log.error("MessageEnvelope missing protocol or transport: {}", envelope);
+            log.error("MessageEnvelope missing protocol or transport: protocol={}, transport={}, sourceId={}, analyzerId={}",
+                envelope.getProtocol(), envelope.getTransport(),
+                envelope.getSourceId(), envelope.getAnalyzerId());
             return false;
         }
         if (envelope.getSourceId() == null || envelope.getSourceId().trim().isEmpty()) {

--- a/src/main/java/org/itech/ahb/normalizer/MessageNormalizer.java
+++ b/src/main/java/org/itech/ahb/normalizer/MessageNormalizer.java
@@ -1,0 +1,146 @@
+package org.itech.ahb.normalizer;
+
+import lombok.extern.slf4j.Slf4j;
+import org.itech.ahb.routing.HttpForwardingRouter;
+import org.itech.ahb.routing.MessageRouter;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+/**
+ * Central message orchestration service for the Universal Analyzer Bridge.
+ * <p>
+ * MessageNormalizer implements the {@link MessageRouter} interface and serves as
+ * the @Primary bean, ensuring that all message routing in the application flows
+ * through this component. This design allows existing MLLP code (which depends on
+ * MessageRouter) to automatically use the normalizer without any code changes.
+ * </p>
+ * <p>
+ * The normalizer orchestrates:
+ * <ul>
+ *   <li>Analyzer identification via {@link AnalyzerIdentifier} (multi-strategy)</li>
+ *   <li>Message enrichment (adding analyzer ID if identified)</li>
+ *   <li>Routing to OpenELIS via {@link HttpForwardingRouter}</li>
+ *   <li>Audit logging of all message flows</li>
+ * </ul>
+ * </p>
+ * <p>
+ * All transport listeners (MLLP, Serial, File, HTTP Input, ASTM TCP) delegate to
+ * this service after creating a {@link MessageEnvelope} with transport metadata.
+ * </p>
+ *
+ * @see MessageRouter
+ * @see HttpForwardingRouter
+ * @see AnalyzerIdentifier
+ * @see MessageEnvelope
+ */
+@Component
+@Primary  // CRITICAL: Makes this the default MessageRouter bean
+@Slf4j
+public class MessageNormalizer implements MessageRouter {
+
+    private final HttpForwardingRouter forwardingRouter;  // Inject by CONCRETE TYPE
+    private final AnalyzerIdentifier identifier;
+
+    /**
+     * Constructs a new MessageNormalizer.
+     * <p>
+     * Injects {@link HttpForwardingRouter} by concrete type (not MessageRouter interface)
+     * to avoid circular injection ambiguity, since this class also implements MessageRouter.
+     * </p>
+     *
+     * @param forwardingRouter the HTTP forwarding router for sending to OpenELIS
+     * @param identifier the analyzer identification service
+     */
+    public MessageNormalizer(
+            HttpForwardingRouter forwardingRouter,
+            AnalyzerIdentifier identifier) {
+        this.forwardingRouter = forwardingRouter;
+        this.identifier = identifier;
+    }
+
+    /**
+     * MessageRouter.route() implementation — allows MLLP to use this transparently.
+     * <p>
+     * This method enables existing code that depends on {@link MessageRouter} to
+     * automatically use the normalizer via Spring's @Primary bean selection.
+     * </p>
+     * <p>
+     * Delegates to {@link #process(MessageEnvelope)} for the actual implementation.
+     * </p>
+     *
+     * @param envelope the message with transport metadata
+     * @return true if routing succeeded, false otherwise
+     */
+    @Override
+    public boolean route(MessageEnvelope envelope) {
+        return process(envelope);
+    }
+
+    /**
+     * Process a message envelope: identify analyzer, enrich envelope, route to OpenELIS.
+     * <p>
+     * Called directly by Serial/File/HTTP/ASTM handlers, or via {@link #route(MessageEnvelope)}
+     * by MLLP. This method:
+     * <ol>
+     *   <li>Attempts to identify the analyzer if not already set in envelope</li>
+     *   <li>Enriches the envelope with the identified analyzer ID</li>
+     *   <li>Logs the routing operation for audit purposes</li>
+     *   <li>Routes to OpenELIS via {@link HttpForwardingRouter}</li>
+     * </ol>
+     * </p>
+     *
+     * @param envelope the message with transport metadata
+     * @return true if routing succeeded, false otherwise
+     */
+    public boolean process(MessageEnvelope envelope) {
+        if (envelope == null) {
+            log.error("Cannot process null MessageEnvelope");
+            return false;
+        }
+        if (envelope.getProtocol() == null || envelope.getTransport() == null) {
+            log.error("MessageEnvelope missing protocol or transport: {}", envelope);
+            return false;
+        }
+        if (envelope.getSourceId() == null || envelope.getSourceId().trim().isEmpty()) {
+            log.error("MessageEnvelope missing sourceId for {}", envelope.getProtocol());
+            return false;
+        }
+        if (envelope.getRawMessage() == null || envelope.getRawMessage().trim().isEmpty()) {
+            log.error("MessageEnvelope missing rawMessage for {}", envelope.getProtocol());
+            return false;
+        }
+
+        // 1. If analyzerId not set, try to identify via AnalyzerIdentifier
+        String analyzerId = envelope.getAnalyzerId();
+        if (analyzerId == null || analyzerId.isEmpty()) {
+            analyzerId = identifier.identify(envelope);
+        }
+
+        // 2. Rebuild envelope with analyzerId if we found one
+        MessageEnvelope enriched = (analyzerId != null && !analyzerId.equals(envelope.getAnalyzerId()))
+            ? MessageEnvelope.builder()
+                .protocol(envelope.getProtocol())
+                .transport(envelope.getTransport())
+                .sourceId(envelope.getSourceId())
+                .rawMessage(envelope.getRawMessage())
+                .receivedAt(envelope.getReceivedAt())
+                .analyzerId(analyzerId)
+                .build()
+            : envelope;
+
+        // 3. Audit log
+        log.info("Normalizer processing: protocol={}, transport={}, source={}, analyzer={}",
+            enriched.getProtocol(), enriched.getTransport(),
+            enriched.getSourceId(), enriched.getAnalyzerId());
+
+        // 4. Route via HttpForwardingRouter (NOT via this.route() — that would recurse!)
+        boolean success = forwardingRouter.route(enriched);
+
+        if (!success) {
+            log.error("Failed to route message: protocol={}, source={}",
+                enriched.getProtocol(), enriched.getSourceId());
+        }
+
+        return success;
+    }
+}

--- a/src/main/java/org/itech/ahb/routing/HttpForwardingRouter.java
+++ b/src/main/java/org/itech/ahb/routing/HttpForwardingRouter.java
@@ -70,9 +70,12 @@ public class HttpForwardingRouter implements MessageRouter {
     public static final String HEADER_SOURCE_ANALYZER_IP = "X-Source-Analyzer-IP";
 
     private static final Pattern IPV4_PATTERN =
-        Pattern.compile("^((25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)(\\.|$)){4}$");
+        Pattern.compile("^(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)){3}$");
     private static final Pattern IPV6_PATTERN =
         Pattern.compile("^[0-9a-fA-F:]+$");
+
+    /** Maximum backoff wait time in milliseconds (1 minute cap to prevent overflow) */
+    private static final long MAX_BACKOFF_MS = 60_000;
 
     private final HTTPForwardServerConfigurationProperties httpConfig;
     private final OpenELISConfig.RetryConfig retryConfig;
@@ -206,7 +209,8 @@ public class HttpForwardingRouter implements MessageRouter {
 
             // Retry with exponential backoff if attempts remaining
             if (attempt < maxAttempts) {
-                long waitMs = backoffMs * (1L << (attempt - 1)); // exponential: backoff * 2^(attempt-1)
+                long uncappedWaitMs = backoffMs * (1L << (attempt - 1)); // exponential: backoff * 2^(attempt-1)
+                long waitMs = Math.min(uncappedWaitMs, MAX_BACKOFF_MS); // Cap to prevent overflow
                 log.info("Retrying in {}ms (attempt {}/{})", waitMs, attempt + 1, maxAttempts);
                 try {
                     Thread.sleep(waitMs);

--- a/src/main/java/org/itech/ahb/routing/HttpForwardingRouter.java
+++ b/src/main/java/org/itech/ahb/routing/HttpForwardingRouter.java
@@ -14,9 +14,12 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
+import org.itech.ahb.config.OpenELISConfig;
 import org.itech.ahb.config.properties.HTTPForwardServerConfigurationProperties;
 import org.itech.ahb.normalizer.MessageEnvelope;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
@@ -66,62 +69,158 @@ public class HttpForwardingRouter implements MessageRouter {
     /** HTTP header for source analyzer IP (for backward compatibility with ASTM) */
     public static final String HEADER_SOURCE_ANALYZER_IP = "X-Source-Analyzer-IP";
 
+    private static final Pattern IPV4_PATTERN =
+        Pattern.compile("^((25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)(\\.|$)){4}$");
+    private static final Pattern IPV6_PATTERN =
+        Pattern.compile("^[0-9a-fA-F:]+$");
+
     private final HTTPForwardServerConfigurationProperties httpConfig;
+    private final OpenELISConfig.RetryConfig retryConfig;
+    private final int connectTimeoutSeconds;
+    private final int readTimeoutSeconds;
     private final HttpClient httpClient;
 
     /**
      * Constructs a new HttpForwardingRouter with the specified configuration.
      *
      * @param httpConfig the HTTP forwarding server configuration
+     * @param openelisConfig the OpenELIS configuration (optional, for retry settings)
      */
-    public HttpForwardingRouter(HTTPForwardServerConfigurationProperties httpConfig) {
+    public HttpForwardingRouter(
+            HTTPForwardServerConfigurationProperties httpConfig,
+            @Autowired(required = false) OpenELISConfig openelisConfig) {
         this.httpConfig = httpConfig;
+        this.retryConfig = openelisConfig != null ? openelisConfig.getRetry() : null;
+        this.connectTimeoutSeconds = openelisConfig != null
+            ? openelisConfig.getConnectTimeoutSeconds()
+            : 30;
+        this.readTimeoutSeconds = openelisConfig != null
+            ? openelisConfig.getReadTimeoutSeconds()
+            : 30;
         this.httpClient = HttpClient.newBuilder()
-            .connectTimeout(Duration.ofSeconds(30))
+            .connectTimeout(Duration.ofSeconds(connectTimeoutSeconds))
             .build();
+
+        if (retryConfig != null) {
+            log.info("HttpForwardingRouter configured with retry: maxAttempts={}, backoffMs={}",
+                retryConfig.getMaxAttempts(), retryConfig.getBackoffMs());
+        } else {
+            log.info("HttpForwardingRouter configured without retry (single attempt)");
+        }
+        log.info("HttpForwardingRouter timeouts: connect={}s read={}s",
+            connectTimeoutSeconds, readTimeoutSeconds);
     }
 
     /**
      * Routes a message envelope to the appropriate HTTP endpoint.
+     * <p>
+     * Implements retry with exponential backoff if configured via {@link OpenELISConfig.RetryConfig}.
+     * Retries are attempted for:
+     * <ul>
+     *   <li>5xx server errors (may be transient)</li>
+     *   <li>Network/IO errors (connection failures, timeouts)</li>
+     * </ul>
+     * </p>
+     * <p>
+     * Non-retryable failures:
+     * <ul>
+     *   <li>4xx client errors (bad request, authentication failure, etc.)</li>
+     *   <li>Thread interruption</li>
+     * </ul>
+     * </p>
      *
      * @param envelope the message with transport metadata
      * @return true if routing succeeded (HTTP 2xx response), false otherwise
      */
     @Override
     public boolean route(MessageEnvelope envelope) {
+        if (envelope == null) {
+            log.error("Cannot route null MessageEnvelope");
+            return false;
+        }
+        if (envelope.getProtocol() == null || envelope.getTransport() == null) {
+            log.error("MessageEnvelope missing protocol or transport");
+            return false;
+        }
+        if (envelope.getSourceId() == null || envelope.getSourceId().trim().isEmpty()) {
+            log.error("MessageEnvelope missing sourceId");
+            return false;
+        }
+        if (envelope.getRawMessage() == null || envelope.getRawMessage().trim().isEmpty()) {
+            log.error("MessageEnvelope missing rawMessage");
+            return false;
+        }
+
         log.debug("Routing {} message from {} via {}",
             envelope.getProtocol(), envelope.getSourceId(), envelope.getTransport());
 
-        try {
-            // Determine endpoint based on protocol
-            URI targetUri = buildTargetUri(envelope);
+        int maxAttempts = retryConfig != null ? retryConfig.getMaxAttempts() : 1;
+        long backoffMs = retryConfig != null ? retryConfig.getBackoffMs() : 1000;
 
-            // Build HTTP request with envelope metadata as headers
-            HttpRequest request = buildRequest(envelope, targetUri);
+        // Determine endpoint based on protocol
+        URI targetUri = buildTargetUri(envelope);
 
-            // Forward to HTTP endpoint
-            HttpResponse<String> response = httpClient.send(
-                request, HttpResponse.BodyHandlers.ofString());
+        // Retry loop with exponential backoff
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            try {
+                // Build HTTP request with envelope metadata as headers
+                HttpRequest request = buildRequest(envelope, targetUri);
 
-            int statusCode = response.statusCode();
-            log.debug("HTTP forward response: {} {}", statusCode, response.body());
+                // Forward to HTTP endpoint
+                HttpResponse<String> response = httpClient.send(
+                    request, HttpResponse.BodyHandlers.ofString());
 
-            if (statusCode >= 200 && statusCode < 300) {
-                log.info("Successfully routed {} message from {} to {}",
-                    envelope.getProtocol(), envelope.getSourceId(), targetUri);
-                return true;
-            } else {
-                log.error("HTTP forward failed with status {}: {}", statusCode, response.body());
+                int statusCode = response.statusCode();
+                log.debug("HTTP forward response (attempt {}/{}): {}",
+                    attempt, maxAttempts, statusCode);
+
+                // Success (2xx)
+                if (statusCode >= 200 && statusCode < 300) {
+                    if (attempt > 1) {
+                        log.info("Successfully routed {} message from {} to {} after {} attempts",
+                            envelope.getProtocol(), envelope.getSourceId(), targetUri, attempt);
+                    } else {
+                        log.info("Successfully routed {} message from {} to {}",
+                            envelope.getProtocol(), envelope.getSourceId(), targetUri);
+                    }
+                    return true;
+                }
+
+                // Non-retryable client errors (4xx) — fail immediately
+                if (statusCode >= 400 && statusCode < 500) {
+                    log.error("Non-retryable HTTP error {}", statusCode);
+                    return false;
+                }
+
+                // Server errors (5xx) — retry if attempts remaining
+                log.warn("Server error {} on attempt {}/{}",
+                    statusCode, attempt, maxAttempts);
+
+            } catch (IOException e) {
+                log.warn("IO error on attempt {}/{}: {}", attempt, maxAttempts, e.getMessage());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.error("Interrupted while routing message");
                 return false;
             }
 
-        } catch (IOException | InterruptedException e) {
-            log.error("Error routing {} message to HTTP endpoint", envelope.getProtocol(), e);
-            if (e instanceof InterruptedException) {
-                Thread.currentThread().interrupt();
+            // Retry with exponential backoff if attempts remaining
+            if (attempt < maxAttempts) {
+                long waitMs = backoffMs * (1L << (attempt - 1)); // exponential: backoff * 2^(attempt-1)
+                log.info("Retrying in {}ms (attempt {}/{})", waitMs, attempt + 1, maxAttempts);
+                try {
+                    Thread.sleep(waitMs);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    log.error("Interrupted during backoff");
+                    return false;
+                }
             }
-            return false;
         }
+
+        log.error("All {} attempts failed for {} message from {}",
+            maxAttempts, envelope.getProtocol(), envelope.getSourceId());
+        return false;
     }
 
     /**
@@ -154,9 +253,10 @@ public class HttpForwardingRouter implements MessageRouter {
             case HL7 -> "/hl7";
             case ASTM -> "/astm";
             case CSV -> "/csv";
+            case UNKNOWN -> "/raw";
             default -> {
-                log.warn("Unknown protocol {}, using base path", envelope.getProtocol());
-                yield "";
+                log.warn("Unknown protocol {}, using raw endpoint", envelope.getProtocol());
+                yield "/raw";
             }
         };
 
@@ -190,12 +290,17 @@ public class HttpForwardingRouter implements MessageRouter {
             .header(HEADER_SOURCE_PROTOCOL, envelope.getProtocol().name())
             .header(HEADER_SOURCE_TRANSPORT, envelope.getTransport().name())
             .header(HEADER_SOURCE_ID, envelope.getSourceId())
-            .header(HEADER_SOURCE_ANALYZER_IP, envelope.getSourceId())  // Backward compat
+            .timeout(Duration.ofSeconds(readTimeoutSeconds))
             .POST(HttpRequest.BodyPublishers.ofString(envelope.getRawMessage()));
 
         // Add analyzer ID header if available
         if (envelope.getAnalyzerId() != null && !envelope.getAnalyzerId().isEmpty()) {
             builder.header(HEADER_ANALYZER_ID, envelope.getAnalyzerId());
+        }
+
+        // Backward compatibility: only set when sourceId looks like an IP address
+        if (isIpAddress(envelope.getSourceId())) {
+            builder.header(HEADER_SOURCE_ANALYZER_IP, envelope.getSourceId());
         }
 
         // Add Basic authentication if configured
@@ -204,6 +309,17 @@ public class HttpForwardingRouter implements MessageRouter {
         }
 
         return builder.build();
+    }
+
+    private boolean isIpAddress(String value) {
+        if (value == null || value.trim().isEmpty()) {
+            return false;
+        }
+        String trimmed = value.trim();
+        if (IPV4_PATTERN.matcher(trimmed).matches()) {
+            return true;
+        }
+        return trimmed.contains(":") && IPV6_PATTERN.matcher(trimmed).matches();
     }
 
     /**

--- a/src/main/java/org/itech/ahb/serial/SerialMessageHandler.java
+++ b/src/main/java/org/itech/ahb/serial/SerialMessageHandler.java
@@ -1,17 +1,10 @@
 package org.itech.ahb.serial;
 
-import java.io.IOException;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.time.Duration;
-import java.util.Base64;
 import lombok.extern.slf4j.Slf4j;
-import org.itech.ahb.config.properties.HTTPForwardServerConfigurationProperties;
 import org.itech.ahb.model.Protocol;
 import org.itech.ahb.model.Transport;
 import org.itech.ahb.normalizer.MessageEnvelope;
+import org.itech.ahb.normalizer.MessageNormalizer;
 import org.itech.ahb.util.ProtocolDetector;
 import org.springframework.stereotype.Service;
 
@@ -22,42 +15,38 @@ import org.springframework.stereotype.Service;
  * <ul>
  *   <li>Detects the message protocol (ASTM, HL7, CSV)</li>
  *   <li>Creates a MessageEnvelope with serial transport metadata</li>
- *   <li>Forwards the message to the appropriate OpenELIS endpoint</li>
+ *   <li>Delegates to {@link MessageNormalizer} for routing to OpenELIS</li>
  * </ul>
  * </p>
+ * <p>
+ * Part of M7: Message Normalizer milestone — all transport handlers delegate to
+ * the normalizer for unified routing logic, retry/backoff, and audit logging.
+ * </p>
+ *
+ * @see MessageNormalizer
+ * @see MessageEnvelope
  */
 @Slf4j
 @Service
 public class SerialMessageHandler {
 
-    /** HTTP header for source analyzer identification */
-    public static final String SOURCE_ID_HEADER = "X-Source-Analyzer-IP";
-
-    /** HTTP header for transport type */
-    public static final String TRANSPORT_HEADER = "X-Message-Transport";
-
-    /** HTTP header for analyzer ID (optional) */
-    public static final String ANALYZER_ID_HEADER = "X-Analyzer-ID";
-
-    private static final Duration HTTP_TIMEOUT = Duration.ofSeconds(30);
-
-    private final HTTPForwardServerConfigurationProperties httpConfig;
-    private final HttpClient httpClient;
+    private final MessageNormalizer normalizer;
 
     /**
      * Creates a new SerialMessageHandler.
      *
-     * @param httpConfig configuration for the HTTP forward server
+     * @param normalizer the message normalizer for routing
      */
-    public SerialMessageHandler(HTTPForwardServerConfigurationProperties httpConfig) {
-        this.httpConfig = httpConfig;
-        this.httpClient = HttpClient.newBuilder()
-            .connectTimeout(HTTP_TIMEOUT)
-            .build();
+    public SerialMessageHandler(MessageNormalizer normalizer) {
+        this.normalizer = normalizer;
     }
 
     /**
      * Handles a complete message received from a serial port.
+     * <p>
+     * Detects the protocol, creates a MessageEnvelope, and delegates to the
+     * {@link MessageNormalizer} for routing to OpenELIS.
+     * </p>
      *
      * @param message the complete message content
      * @param serialPortPath the serial port path (e.g., /dev/ttyUSB0)
@@ -84,112 +73,9 @@ public class SerialMessageHandler {
             .analyzerId(analyzerId)
             .build();
 
-        // Route to appropriate endpoint
-        return forwardMessage(envelope);
-    }
-
-    /**
-     * Forwards a message envelope to the appropriate OpenELIS endpoint.
-     *
-     * @param envelope the message envelope
-     * @return the result of forwarding
-     */
-    private HandleResult forwardMessage(MessageEnvelope envelope) {
-        URI targetUri = determineTargetUri(envelope.getProtocol());
-        String contentType = determineContentType(envelope.getProtocol());
-
-        log.debug("Forwarding {} message to {}", envelope.getProtocol(), targetUri);
-
-        HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
-            .uri(targetUri)
-            .timeout(HTTP_TIMEOUT)
-            .header("Content-Type", contentType)
-            .header(SOURCE_ID_HEADER, envelope.getSourceId())
-            .header(TRANSPORT_HEADER, Transport.SERIAL.name())
-            .POST(HttpRequest.BodyPublishers.ofString(envelope.getRawMessage()));
-
-        // Add analyzer ID header if available
-        if (envelope.getAnalyzerId() != null && !envelope.getAnalyzerId().isEmpty()) {
-            requestBuilder.header(ANALYZER_ID_HEADER, envelope.getAnalyzerId());
-        }
-
-        // Add authentication if configured
-        if (httpConfig.getUsername() != null && !httpConfig.getUsername().isEmpty()) {
-            // Use byte array to avoid keeping password in String memory longer than necessary
-            byte[] credentials = (httpConfig.getUsername() + ":" +
-                new String(httpConfig.getPassword())).getBytes();
-            try {
-                String encodedAuth = Base64.getEncoder().encodeToString(credentials);
-                requestBuilder.header("Authorization", "Basic " + encodedAuth);
-            } finally {
-                // Zero out credentials array to minimize memory exposure
-                java.util.Arrays.fill(credentials, (byte) 0);
-            }
-        }
-
-        try {
-            HttpResponse<String> response = httpClient.send(
-                requestBuilder.build(),
-                HttpResponse.BodyHandlers.ofString()
-            );
-
-            if (response.statusCode() >= 200 && response.statusCode() < 300) {
-                log.info("Successfully forwarded {} message to OpenELIS (status {})",
-                    envelope.getProtocol(), response.statusCode());
-                return new HandleResult(true, response.body());
-            } else {
-                log.warn("Failed to forward message: HTTP {} - {}",
-                    response.statusCode(), response.body());
-                return new HandleResult(false,
-                    "HTTP " + response.statusCode() + ": " + response.body());
-            }
-        } catch (IOException e) {
-            log.error("IO error forwarding message to {}: {}", targetUri, e.getMessage());
-            return new HandleResult(false, "IO Error: " + e.getMessage());
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            log.error("Interrupted while forwarding message to {}", targetUri);
-            return new HandleResult(false, "Interrupted");
-        }
-    }
-
-    /**
-     * Determines the target URI based on the protocol.
-     */
-    private URI determineTargetUri(Protocol protocol) {
-        String basePath = httpConfig.getUri().toString();
-        // Remove trailing slash if present
-        if (basePath.endsWith("/")) {
-            basePath = basePath.substring(0, basePath.length() - 1);
-        }
-
-        // Route to protocol-specific endpoint
-        String endpoint = switch (protocol) {
-            case ASTM -> "/api/OpenELIS-Global/analyzer/astm";
-            case HL7 -> "/api/OpenELIS-Global/analyzer/hl7";
-            case CSV -> "/api/OpenELIS-Global/analyzer/csv";
-            case UNKNOWN -> "/api/OpenELIS-Global/analyzer/raw";
-        };
-
-        // Handle base URI that might already include a path
-        URI baseUri = httpConfig.getUri();
-        String scheme = baseUri.getScheme();
-        String host = baseUri.getHost();
-        int port = baseUri.getPort();
-
-        String portPart = port > 0 ? ":" + port : "";
-        return URI.create(scheme + "://" + host + portPart + endpoint);
-    }
-
-    /**
-     * Determines the Content-Type header based on the protocol.
-     */
-    private String determineContentType(Protocol protocol) {
-        return switch (protocol) {
-            case CSV -> "text/csv";
-            case HL7 -> "application/hl7-v2";
-            default -> "text/plain";
-        };
+        // Delegate to normalizer for routing
+        boolean success = normalizer.process(envelope);
+        return new HandleResult(success, success ? "Routed via normalizer" : "Routing failed");
     }
 
     /**

--- a/src/test/java/org/itech/ahb/config/AnalyzerRegistryConfigTest.java
+++ b/src/test/java/org/itech/ahb/config/AnalyzerRegistryConfigTest.java
@@ -1,0 +1,65 @@
+package org.itech.ahb.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Analyzer Registry Config Tests")
+class AnalyzerRegistryConfigTest {
+
+    @Test
+    @DisplayName("Glob pattern should match against file name")
+    void globMatchesFileName() {
+        AnalyzerRegistryConfig config = new AnalyzerRegistryConfig();
+        Map<String, AnalyzerRegistryConfig.AnalyzerEntry> analyzers = new LinkedHashMap<>();
+        analyzers.put("quantstudio-*", entry("QUANTSTUDIO-001"));
+        config.setAnalyzers(analyzers);
+
+        Optional<String> result = config.findAnalyzerId(
+            "/mnt/analyzer-import/quantstudio/quantstudio-20260205.csv");
+
+        assertTrue(result.isPresent());
+        assertEquals("QUANTSTUDIO-001", result.get());
+    }
+
+    @Test
+    @DisplayName("Glob pattern should match against full path")
+    void globMatchesFullPath() {
+        AnalyzerRegistryConfig config = new AnalyzerRegistryConfig();
+        Map<String, AnalyzerRegistryConfig.AnalyzerEntry> analyzers = new LinkedHashMap<>();
+        analyzers.put("/mnt/analyzer-import/quantstudio/*.csv", entry("QUANTSTUDIO-002"));
+        config.setAnalyzers(analyzers);
+
+        Optional<String> result = config.findAnalyzerId(
+            "/mnt/analyzer-import/quantstudio/quantstudio-20260205.csv");
+
+        assertTrue(result.isPresent());
+        assertEquals("QUANTSTUDIO-002", result.get());
+    }
+
+    @Test
+    @DisplayName("Direct match should take precedence over glob")
+    void directMatchPreferredOverGlob() {
+        AnalyzerRegistryConfig config = new AnalyzerRegistryConfig();
+        Map<String, AnalyzerRegistryConfig.AnalyzerEntry> analyzers = new LinkedHashMap<>();
+        analyzers.put("192.168.1.10", entry("MINDRAY-001"));
+        analyzers.put("192.168.*", entry("GENERIC-001"));
+        config.setAnalyzers(analyzers);
+
+        Optional<String> result = config.findAnalyzerId("192.168.1.10");
+
+        assertTrue(result.isPresent());
+        assertEquals("MINDRAY-001", result.get());
+    }
+
+    private AnalyzerRegistryConfig.AnalyzerEntry entry(String id) {
+        AnalyzerRegistryConfig.AnalyzerEntry entry = new AnalyzerRegistryConfig.AnalyzerEntry();
+        entry.setId(id);
+        return entry;
+    }
+}

--- a/src/test/java/org/itech/ahb/controller/AnalyzerInputControllerTest.java
+++ b/src/test/java/org/itech/ahb/controller/AnalyzerInputControllerTest.java
@@ -2,6 +2,8 @@ package org.itech.ahb.controller;
 
 import jakarta.servlet.http.HttpServletRequest;
 import org.itech.ahb.model.Protocol;
+import org.itech.ahb.normalizer.MessageEnvelope;
+import org.itech.ahb.normalizer.MessageNormalizer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -15,11 +17,15 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 /**
  * Unit tests for AnalyzerInputController.
+ * <p>
  * Tests HTTP input endpoint for ASTM, HL7, and CSV messages.
+ * After M7 refactoring, this controller delegates to MessageNormalizer for routing.
+ * </p>
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -29,6 +35,9 @@ class AnalyzerInputControllerTest {
 
     @Mock
     private HttpServletRequest mockRequest;
+
+    @Mock
+    private MessageNormalizer mockNormalizer;
 
     // Sample messages
     private static final String SAMPLE_ASTM_MESSAGE = "H|\\^&|||HOST^NAME|||||||LIS2-A2|20260205120000\r" +
@@ -49,8 +58,10 @@ class AnalyzerInputControllerTest {
 
     @BeforeEach
     void setUp() {
-        controller = new AnalyzerInputController();
+        controller = new AnalyzerInputController(mockNormalizer);
         lenient().when(mockRequest.getRemoteAddr()).thenReturn("127.0.0.1");
+        // Default: normalizer returns success
+        lenient().when(mockNormalizer.process(any(MessageEnvelope.class))).thenReturn(true);
     }
 
     @Nested
@@ -306,16 +317,16 @@ class AnalyzerInputControllerTest {
         }
 
         @Test
-        @DisplayName("Should return 422 for unrecognized protocol")
-        void shouldRejectUnknownProtocol() {
+        @DisplayName("Should route unknown protocol as raw")
+        void shouldRouteUnknownProtocol() {
             String unknownMessage = "This is not a valid ASTM, HL7, or CSV message";
             ResponseEntity<AnalyzerInputController.InputResponse> response =
                     controller.receiveAnalyzerMessage(unknownMessage, "text/plain", null, mockRequest);
 
-            assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, response.getStatusCode());
+            assertEquals(HttpStatus.OK, response.getStatusCode());
             assertNotNull(response.getBody());
-            assertFalse(response.getBody().success());
-            assertEquals("Unable to detect message protocol", response.getBody().message());
+            assertTrue(response.getBody().success());
+            assertEquals("UNKNOWN", response.getBody().protocol());
         }
     }
 
@@ -345,7 +356,7 @@ class AnalyzerInputControllerTest {
             assertEquals(HttpStatus.OK, response.getStatusCode());
             assertNotNull(response.getBody());
             assertTrue(response.getBody().success());
-            assertEquals("Message received successfully", response.getBody().message());
+            assertEquals("Message routed successfully", response.getBody().message());
             assertEquals("192.168.1.50", response.getBody().sourceIp());
             assertEquals("HL7", response.getBody().protocol());
             assertNotNull(response.getBody().receivedAt());
@@ -416,6 +427,91 @@ class AnalyzerInputControllerTest {
                     controller.extractSourceIp("", mockRequest));
             assertEquals("127.0.0.1",
                     controller.extractSourceIp("   ", mockRequest));
+        }
+    }
+
+    @Nested
+    @DisplayName("Message Normalizer Integration Tests (M7)")
+    class NormalizerIntegrationTests {
+
+        @Test
+        @DisplayName("Should call normalizer.process() for valid ASTM message")
+        void shouldCallNormalizerForValidASTM() {
+            ResponseEntity<AnalyzerInputController.InputResponse> response =
+                    controller.receiveAnalyzerMessage(SAMPLE_ASTM_MESSAGE, null, null, mockRequest);
+
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            verify(mockNormalizer).process(any(MessageEnvelope.class));
+        }
+
+        @Test
+        @DisplayName("Should call normalizer.process() for valid HL7 message")
+        void shouldCallNormalizerForValidHL7() {
+            ResponseEntity<AnalyzerInputController.InputResponse> response =
+                    controller.receiveAnalyzerMessage(SAMPLE_HL7_MESSAGE, "application/hl7-v2", null, mockRequest);
+
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            verify(mockNormalizer).process(any(MessageEnvelope.class));
+        }
+
+        @Test
+        @DisplayName("Should call normalizer.process() for valid CSV message")
+        void shouldCallNormalizerForValidCSV() {
+            ResponseEntity<AnalyzerInputController.InputResponse> response =
+                    controller.receiveAnalyzerMessage(SAMPLE_CSV_MESSAGE, "text/csv", null, mockRequest);
+
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            verify(mockNormalizer).process(any(MessageEnvelope.class));
+        }
+
+        @Test
+        @DisplayName("Should return 500 when normalizer returns false")
+        void shouldReturn500WhenNormalizerFails() {
+            when(mockNormalizer.process(any(MessageEnvelope.class))).thenReturn(false);
+
+            ResponseEntity<AnalyzerInputController.InputResponse> response =
+                    controller.receiveAnalyzerMessage(SAMPLE_ASTM_MESSAGE, null, null, mockRequest);
+
+            assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertFalse(response.getBody().success());
+            assertEquals("Message routing failed", response.getBody().message());
+        }
+
+        @Test
+        @DisplayName("Should return success message when normalizer returns true")
+        void shouldReturnSuccessWhenNormalizerSucceeds() {
+            when(mockNormalizer.process(any(MessageEnvelope.class))).thenReturn(true);
+
+            ResponseEntity<AnalyzerInputController.InputResponse> response =
+                    controller.receiveAnalyzerMessage(SAMPLE_ASTM_MESSAGE, null, null, mockRequest);
+
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertTrue(response.getBody().success());
+            assertEquals("Message routed successfully", response.getBody().message());
+        }
+
+        @Test
+        @DisplayName("Should not call normalizer for empty message")
+        void shouldNotCallNormalizerForEmptyMessage() {
+            ResponseEntity<AnalyzerInputController.InputResponse> response =
+                    controller.receiveAnalyzerMessage("", null, null, mockRequest);
+
+            assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+            verify(mockNormalizer, never()).process(any());
+        }
+
+        @Test
+        @DisplayName("Should call normalizer for unknown protocol")
+        void shouldCallNormalizerForUnknownProtocol() {
+            String unknownMessage = "This is some random text that doesnt match any protocol";
+
+            ResponseEntity<AnalyzerInputController.InputResponse> response =
+                    controller.receiveAnalyzerMessage(unknownMessage, null, null, mockRequest);
+
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            verify(mockNormalizer, times(1)).process(any());
         }
     }
 }

--- a/src/test/java/org/itech/ahb/integration/UnifiedRoutingTest.java
+++ b/src/test/java/org/itech/ahb/integration/UnifiedRoutingTest.java
@@ -1,0 +1,359 @@
+package org.itech.ahb.integration;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.sun.net.httpserver.HttpServer;
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.itech.ahb.config.properties.HTTPForwardServerConfigurationProperties;
+import org.itech.ahb.controller.AnalyzerInputController;
+import org.itech.ahb.file.CSVParser;
+import org.itech.ahb.file.FileConfig;
+import org.itech.ahb.file.FileMessageHandler;
+import org.itech.ahb.lib.astm.concept.DefaultASTMMessage;
+import org.itech.ahb.normalizer.ASTMBridgeAdapter;
+import org.itech.ahb.normalizer.AnalyzerIdentifier;
+import org.itech.ahb.normalizer.MessageNormalizer;
+import org.itech.ahb.routing.HttpForwardingRouter;
+import org.itech.ahb.serial.SerialMessageHandler;
+import org.itech.ahb.mllp.HapiReceivingApplication;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.Mockito.*;
+
+import ca.uhn.hl7v2.model.Message;
+import ca.uhn.hl7v2.parser.PipeParser;
+
+/**
+ * Integration tests verifying all 5 transport listeners route through MessageNormalizer
+ * to HttpForwardingRouter (M7: Message Normalizer milestone).
+ * <p>
+ * Uses com.sun.net.httpserver.HttpServer to capture forwarded HTTP requests and verify
+ * correct path and headers for each listener type.
+ * </p>
+ */
+@DisplayName("Unified Routing Integration Tests (M7)")
+class UnifiedRoutingTest {
+
+    private HttpServer httpServer;
+    private int serverPort;
+    private MessageNormalizer normalizer;
+    private SerialMessageHandler serialHandler;
+    private FileMessageHandler fileHandler;
+    private AnalyzerInputController httpController;
+    private ASTMBridgeAdapter astmAdapter;
+    private HapiReceivingApplication mllpApplication;
+
+    private AtomicReference<CapturedRequest> lastRequest;
+    private CountDownLatch requestLatch;
+
+    @Mock
+    private HttpServletRequest mockHttpRequest;
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        MockitoAnnotations.openMocks(this);
+        lastRequest = new AtomicReference<>();
+        requestLatch = new CountDownLatch(1);
+
+        // Start embedded HTTP server
+        httpServer = HttpServer.create(new InetSocketAddress(0), 0);
+        serverPort = httpServer.getAddress().getPort();
+
+        httpServer.createContext("/api/OpenELIS-Global/analyzer/", exchange -> {
+            String path = exchange.getRequestURI().getPath();
+            String sourceProtocol = exchange.getRequestHeaders().getFirst(HttpForwardingRouter.HEADER_SOURCE_PROTOCOL);
+            String sourceTransport = exchange.getRequestHeaders().getFirst(HttpForwardingRouter.HEADER_SOURCE_TRANSPORT);
+            String sourceId = exchange.getRequestHeaders().getFirst(HttpForwardingRouter.HEADER_SOURCE_ID);
+            String analyzerId = exchange.getRequestHeaders().getFirst(HttpForwardingRouter.HEADER_ANALYZER_ID);
+            String sourceAnalyzerIp = exchange.getRequestHeaders().getFirst(
+                HttpForwardingRouter.HEADER_SOURCE_ANALYZER_IP);
+
+            String body;
+            try (InputStream is = exchange.getRequestBody()) {
+                body = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+            }
+
+            lastRequest.set(new CapturedRequest(
+                path, body, sourceProtocol, sourceTransport, sourceId, analyzerId, sourceAnalyzerIp));
+            requestLatch.countDown();
+
+            exchange.sendResponseHeaders(200, 2);
+            exchange.getResponseBody().write("OK".getBytes());
+        });
+        httpServer.start();
+
+        // Wire full M7 pipeline
+        HTTPForwardServerConfigurationProperties httpConfig = new HTTPForwardServerConfigurationProperties();
+        httpConfig.setUri(java.net.URI.create("http://localhost:" + serverPort + "/api/OpenELIS-Global/analyzer"));
+
+        HttpForwardingRouter forwardingRouter = new HttpForwardingRouter(httpConfig, null);
+        AnalyzerIdentifier identifier = new AnalyzerIdentifier(null);
+        normalizer = new MessageNormalizer(forwardingRouter, identifier);
+
+        serialHandler = new SerialMessageHandler(normalizer);
+
+        FileConfig fileConfig = new FileConfig();
+        fileConfig.setEnabled(true);
+        CSVParser csvParser = new CSVParser(fileConfig);
+        fileHandler = new FileMessageHandler(csvParser, fileConfig, normalizer);
+
+        httpController = new AnalyzerInputController(normalizer);
+
+        astmAdapter = new ASTMBridgeAdapter(normalizer);
+
+        mllpApplication = new HapiReceivingApplication(normalizer);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (httpServer != null) {
+            httpServer.stop(0);
+        }
+    }
+
+    private void resetLatch() {
+        requestLatch = new CountDownLatch(1);
+    }
+
+    private CapturedRequest awaitRequest() throws InterruptedException {
+        assertTrue(requestLatch.await(5, TimeUnit.SECONDS), "Expected HTTP request within 5 seconds");
+        return lastRequest.get();
+    }
+
+    @Nested
+    @DisplayName("Serial Handler Routing")
+    class SerialHandlerTests {
+
+        @Test
+        @DisplayName("Serial ASTM message routes to /analyzer/astm with correct headers")
+        void serialAstmRoutesCorrectly() throws Exception {
+            resetLatch();
+            String astmMessage = "H|\\^&|||TEST|||||||P|1|20260205120000\rP|1||12345\rL|1|N";
+
+            serialHandler.handleMessage(astmMessage, "/dev/ttyUSB0", "SERIAL-001");
+
+            CapturedRequest req = awaitRequest();
+            assertTrue(req.path().endsWith("/astm"), "Path should end with /astm, got: " + req.path());
+            assertEquals("ASTM", req.sourceProtocol());
+            assertEquals("SERIAL", req.sourceTransport());
+            assertEquals("/dev/ttyUSB0", req.sourceId());
+            assertEquals("SERIAL-001", req.analyzerId());
+            assertNull(req.sourceAnalyzerIp());
+            assertTrue(req.body().contains("H|\\^&"));
+        }
+
+        @Test
+        @DisplayName("Serial HL7 message routes to /analyzer/hl7")
+        void serialHl7RoutesCorrectly() throws Exception {
+            resetLatch();
+            String hl7Message = "MSH|^~\\&|TEST|LAB|OPENELIS|LAB|20260205120000||ORU^R01|MSG001|P|2.5.1\r" +
+                    "PID|1||12345\rOBX|1|NM|WBC||7.5|10^3/uL";
+
+            serialHandler.handleMessage(hl7Message, "/dev/ttyUSB1", null);
+
+            CapturedRequest req = awaitRequest();
+            assertTrue(req.path().endsWith("/hl7"), "Path should end with /hl7, got: " + req.path());
+            assertEquals("HL7", req.sourceProtocol());
+            assertEquals("SERIAL", req.sourceTransport());
+        }
+
+        @Test
+        @DisplayName("Serial CSV message routes to /analyzer/csv")
+        void serialCsvRoutesCorrectly() throws Exception {
+            resetLatch();
+            // ProtocolDetector requires >= 4 columns for CSV detection
+            String csvMessage = "SampleID,TestCode,Result,Units\n12345,WBC,7.5,10^3/uL\n12346,RBC,4.8,10^6/uL";
+
+            serialHandler.handleMessage(csvMessage, "/dev/ttyUSB2", null);
+
+            CapturedRequest req = awaitRequest();
+            assertTrue(req.path().endsWith("/csv"), "Path should end with /csv, got: " + req.path());
+            assertEquals("CSV", req.sourceProtocol());
+            assertEquals("SERIAL", req.sourceTransport());
+        }
+    }
+
+    @Nested
+    @DisplayName("File Handler Routing")
+    class FileHandlerTests {
+
+        @Test
+        @DisplayName("File CSV drop routes to /analyzer/csv with correct headers")
+        void fileCsvRoutesCorrectly() throws Exception {
+            resetLatch();
+            Path csvFile = tempDir.resolve("results.csv");
+            String csvContent = "SampleID,TestCode,Result,Units\n12345,WBC,7.5,10^3/uL\n12346,RBC,4.8,10^6/uL";
+            Files.writeString(csvFile, csvContent);
+
+            fileHandler.processFile(csvFile, "QUANTSTUDIO-001");
+
+            CapturedRequest req = awaitRequest();
+            assertTrue(req.path().endsWith("/csv"), "Path should end with /csv, got: " + req.path());
+            assertEquals("CSV", req.sourceProtocol());
+            assertEquals("FILE", req.sourceTransport());
+            assertTrue(req.sourceId().contains("results.csv"));
+            assertEquals("QUANTSTUDIO-001", req.analyzerId());
+        }
+    }
+
+    @Nested
+    @DisplayName("HTTP Input Controller Routing")
+    class HttpInputControllerTests {
+
+        @Test
+        @DisplayName("HTTP POST ASTM routes to /analyzer/astm")
+        void httpAstmRoutesCorrectly() throws Exception {
+            resetLatch();
+            when(mockHttpRequest.getRemoteAddr()).thenReturn("192.168.1.10");
+            when(mockHttpRequest.getHeader("X-Forwarded-For")).thenReturn(null);
+            when(mockHttpRequest.getHeader("X-Real-IP")).thenReturn(null);
+
+            String astmMessage = "H|\\^&|||TEST|||||||P|1|20260205120000\rP|1||12345\rL|1|N";
+
+            var response = httpController.receiveAnalyzerMessage(astmMessage, null, null, mockHttpRequest);
+
+            assertEquals(200, response.getStatusCode().value());
+            CapturedRequest req = awaitRequest();
+            assertTrue(req.path().endsWith("/astm"), "Path should end with /astm, got: " + req.path());
+            assertEquals("ASTM", req.sourceProtocol());
+            assertEquals("HTTP", req.sourceTransport());
+            assertEquals("192.168.1.10", req.sourceId());
+            assertEquals("192.168.1.10", req.sourceAnalyzerIp());
+        }
+
+        @Test
+        @DisplayName("HTTP POST HL7 routes to /analyzer/hl7")
+        void httpHl7RoutesCorrectly() throws Exception {
+            resetLatch();
+            when(mockHttpRequest.getRemoteAddr()).thenReturn("192.168.1.20");
+            when(mockHttpRequest.getHeader(anyString())).thenReturn(null);
+
+            String hl7Message = "MSH|^~\\&|TEST|LAB|OPENELIS|LAB|20260205120000||ORU^R01|MSG001|P|2.5.1\r" +
+                    "PID|1||12345\rOBX|1|NM|WBC||7.5";
+
+            var response = httpController.receiveAnalyzerMessage(hl7Message, "application/hl7-v2", null, mockHttpRequest);
+
+            assertEquals(200, response.getStatusCode().value());
+            CapturedRequest req = awaitRequest();
+            assertTrue(req.path().endsWith("/hl7"), "Path should end with /hl7, got: " + req.path());
+            assertEquals("HL7", req.sourceProtocol());
+            assertEquals("HTTP", req.sourceTransport());
+        }
+
+        @Test
+        @DisplayName("HTTP POST CSV routes to /analyzer/csv")
+        void httpCsvRoutesCorrectly() throws Exception {
+            resetLatch();
+            when(mockHttpRequest.getRemoteAddr()).thenReturn("192.168.1.30");
+            when(mockHttpRequest.getHeader(anyString())).thenReturn(null);
+
+            String csvMessage = "SampleID,TestCode,Result\n12345,WBC,7.5\n12346,RBC,4.8";
+
+            var response = httpController.receiveAnalyzerMessage(csvMessage, "text/csv", null, mockHttpRequest);
+
+            assertEquals(200, response.getStatusCode().value());
+            CapturedRequest req = awaitRequest();
+            assertTrue(req.path().endsWith("/csv"), "Path should end with /csv, got: " + req.path());
+            assertEquals("CSV", req.sourceProtocol());
+            assertEquals("HTTP", req.sourceTransport());
+        }
+    }
+
+    @Nested
+    @DisplayName("ASTM TCP Adapter Routing")
+    class ASTMAdapterTests {
+
+        @Test
+        @DisplayName("ASTM TCP message routes to /analyzer/astm via MessageNormalizer")
+        void astmTcpRoutesCorrectly() throws Exception {
+            resetLatch();
+            String astmMessage = "H|\\^&|||MINDRAY^BC-5380|||||||P|1|20260205120000\r" +
+                    "P|1||PAT001||DOE^JOHN\r" +
+                    "O|1|SAM001||^^^CBC\r" +
+                    "R|1|^^^WBC|7.5|10^3/uL||N||F\r" +
+                    "L|1|N";
+
+            DefaultASTMMessage message = new DefaultASTMMessage(astmMessage);
+            astmAdapter.handle(message, "192.168.1.40");
+
+            CapturedRequest req = awaitRequest();
+            assertTrue(req.path().endsWith("/astm"), "Path should end with /astm, got: " + req.path());
+            assertEquals("ASTM", req.sourceProtocol());
+            assertEquals("TCP", req.sourceTransport());
+            assertEquals("192.168.1.40", req.sourceId());
+            assertTrue(req.body().contains("H|\\^&"));
+        }
+
+        @Test
+        @DisplayName("ASTM with null sourceIp uses unknown")
+        void astmNullSourceIpUsesUnknown() throws Exception {
+            resetLatch();
+            DefaultASTMMessage message = new DefaultASTMMessage("H|\\^&|||TEST\rL|1|N");
+
+            astmAdapter.handle(message, null);
+
+            CapturedRequest req = awaitRequest();
+            assertEquals("unknown", req.sourceId());
+        }
+    }
+
+    @Nested
+    @DisplayName("MLLP Handler Routing")
+    class MLLPHandlerTests {
+
+        @Test
+        @DisplayName("MLLP HL7 message routes to /analyzer/hl7 with X-Analyzer-Id from MSH")
+        void mllpHl7RoutesCorrectly() throws Exception {
+            resetLatch();
+            String hl7Message = "MSH|^~\\&|ANALYZER-APP|LAB-FAC|OPENELIS|LAB|20260205120000||ORU^R01|MSG001|P|2.5.1\r" +
+                    "PID|1||12345||Doe^John\r" +
+                    "OBR|1||ORD001|CBC\r" +
+                    "OBX|1|NM|WBC||7.5|10^3/uL||||F";
+
+            Message message = new PipeParser().parse(hl7Message);
+            java.util.Map<String, Object> metadata = new java.util.HashMap<>();
+            metadata.put("SENDING_IP", "192.168.1.50");
+            metadata.put("raw-message", hl7Message);
+
+            mllpApplication.processMessage(message, metadata);
+
+            CapturedRequest req = awaitRequest();
+            assertTrue(req.path().endsWith("/hl7"), "Path should end with /hl7, got: " + req.path());
+            assertEquals("HL7", req.sourceProtocol());
+            assertEquals("MLLP", req.sourceTransport());
+            assertEquals("192.168.1.50", req.sourceId());
+            // Analyzer ID from MSH-3/MSH-4: ANALYZER-APP-LAB-FAC
+            assertNotNull(req.analyzerId());
+            assertTrue(req.analyzerId().contains("ANALYZER-APP"), "X-Analyzer-Id should come from MSH-3");
+        }
+    }
+
+    private record CapturedRequest(
+            String path,
+            String body,
+            String sourceProtocol,
+            String sourceTransport,
+            String sourceId,
+            String analyzerId,
+            String sourceAnalyzerIp
+    ) {}
+}

--- a/src/test/java/org/itech/ahb/integration/UnifiedRoutingTest.java
+++ b/src/test/java/org/itech/ahb/integration/UnifiedRoutingTest.java
@@ -30,9 +30,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.Mockito.*;
 
@@ -47,6 +48,7 @@ import ca.uhn.hl7v2.parser.PipeParser;
  * correct path and headers for each listener type.
  * </p>
  */
+@ExtendWith(MockitoExtension.class)
 @DisplayName("Unified Routing Integration Tests (M7)")
 class UnifiedRoutingTest {
 
@@ -70,7 +72,6 @@ class UnifiedRoutingTest {
 
     @BeforeEach
     void setUp() throws IOException {
-        MockitoAnnotations.openMocks(this);
         lastRequest = new AtomicReference<>();
         requestLatch = new CountDownLatch(1);
 
@@ -96,8 +97,12 @@ class UnifiedRoutingTest {
                 path, body, sourceProtocol, sourceTransport, sourceId, analyzerId, sourceAnalyzerIp));
             requestLatch.countDown();
 
-            exchange.sendResponseHeaders(200, 2);
-            exchange.getResponseBody().write("OK".getBytes());
+            try {
+                exchange.sendResponseHeaders(200, 2);
+                exchange.getResponseBody().write("OK".getBytes());
+            } finally {
+                exchange.close();
+            }
         });
         httpServer.start();
 
@@ -224,7 +229,6 @@ class UnifiedRoutingTest {
         void httpAstmRoutesCorrectly() throws Exception {
             resetLatch();
             when(mockHttpRequest.getRemoteAddr()).thenReturn("192.168.1.10");
-            when(mockHttpRequest.getHeader("X-Forwarded-For")).thenReturn(null);
             when(mockHttpRequest.getHeader("X-Real-IP")).thenReturn(null);
 
             String astmMessage = "H|\\^&|||TEST|||||||P|1|20260205120000\rP|1||12345\rL|1|N";

--- a/src/test/java/org/itech/ahb/normalizer/ASTMBridgeAdapterTest.java
+++ b/src/test/java/org/itech/ahb/normalizer/ASTMBridgeAdapterTest.java
@@ -1,0 +1,283 @@
+package org.itech.ahb.normalizer;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.*;
+
+import org.itech.ahb.lib.astm.concept.ASTMMessage;
+import org.itech.ahb.lib.astm.concept.DefaultASTMMessage;
+import org.itech.ahb.lib.astm.handling.ASTMHandlerResponse;
+import org.itech.ahb.lib.common.handling.HandleStatus;
+import org.itech.ahb.model.Protocol;
+import org.itech.ahb.model.Transport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for ASTMBridgeAdapter.
+ * <p>
+ * Tests the ASTM bridge adapter that implements ASTMHandler and delegates
+ * to MessageNormalizer for routing to OpenELIS.
+ * </p>
+ */
+@ExtendWith(MockitoExtension.class)
+class ASTMBridgeAdapterTest {
+
+    @Mock
+    private MessageNormalizer mockNormalizer;
+
+    @Mock
+    private ASTMMessage mockAstmMessage;
+
+    private ASTMBridgeAdapter adapter;
+
+    private static final String SAMPLE_ASTM_MESSAGE = "H|\\^&|||HOST^NAME|||||||LIS2-A2|20260205120000\r" +
+            "P|1||||Doe^John||19850101|M\r" +
+            "O|1|12345||^^^GLU\r" +
+            "R|1|^^^GLU|95|mg/dL||N||F||20260205120000\r" +
+            "L|1|N";
+
+    @BeforeEach
+    void setUp() {
+        adapter = new ASTMBridgeAdapter(mockNormalizer);
+        // Lenient: some tests override or do not call process
+        lenient().when(mockNormalizer.process(any(MessageEnvelope.class))).thenReturn(true);
+        lenient().when(mockAstmMessage.getMessage()).thenReturn(SAMPLE_ASTM_MESSAGE);
+    }
+
+    @Nested
+    @DisplayName("Handler Identification Tests")
+    class HandlerIdentificationTests {
+
+        @Test
+        @DisplayName("getName should return 'ASTM Bridge Adapter'")
+        void getNameShouldReturnCorrectName() {
+            String name = adapter.getName();
+            assertEquals("ASTM Bridge Adapter", name);
+        }
+
+        @Test
+        @DisplayName("matches should return true for DefaultASTMMessage")
+        void matchesShouldReturnTrueForDefaultASTMMessage() {
+            DefaultASTMMessage message = new DefaultASTMMessage(SAMPLE_ASTM_MESSAGE);
+
+            boolean matches = adapter.matches(message);
+
+            assertTrue(matches);
+        }
+
+        @Test
+        @DisplayName("matches should return false for non-DefaultASTMMessage")
+        void matchesShouldReturnFalseForNonDefaultASTMMessage() {
+            // Mock a different ASTMMessage implementation
+            ASTMMessage nonDefaultMessage = mock(ASTMMessage.class);
+
+            boolean matches = adapter.matches(nonDefaultMessage);
+
+            assertFalse(matches);
+        }
+    }
+
+    @Nested
+    @DisplayName("Message Handling Tests")
+    class MessageHandlingTests {
+
+        @Test
+        @DisplayName("Should create envelope with Protocol.ASTM and Transport.TCP")
+        void shouldCreateEnvelopeWithCorrectProtocolAndTransport() {
+            adapter.handle(mockAstmMessage, "192.168.1.10");
+
+            verify(mockNormalizer).process(argThat(envelope ->
+                envelope.getProtocol() == Protocol.ASTM &&
+                envelope.getTransport() == Transport.TCP
+            ));
+        }
+
+        @Test
+        @DisplayName("Should use provided sourceIp in envelope")
+        void shouldUseProvidedSourceIpInEnvelope() {
+            String sourceIp = "192.168.1.10";
+
+            adapter.handle(mockAstmMessage, sourceIp);
+
+            verify(mockNormalizer).process(argThat(envelope ->
+                sourceIp.equals(envelope.getSourceId())
+            ));
+        }
+
+        @Test
+        @DisplayName("Should use 'unknown' as sourceId when sourceIp is null")
+        void shouldUseUnknownWhenSourceIpIsNull() {
+            adapter.handle(mockAstmMessage, null);
+
+            verify(mockNormalizer).process(argThat(envelope ->
+                "unknown".equals(envelope.getSourceId())
+            ));
+        }
+
+        @Test
+        @DisplayName("Should include raw message in envelope")
+        void shouldIncludeRawMessageInEnvelope() {
+            adapter.handle(mockAstmMessage, "192.168.1.10");
+
+            verify(mockNormalizer).process(argThat(envelope ->
+                SAMPLE_ASTM_MESSAGE.equals(envelope.getRawMessage())
+            ));
+        }
+
+        @Test
+        @DisplayName("Should call normalizer.process() exactly once")
+        void shouldCallNormalizerProcessOnce() {
+            adapter.handle(mockAstmMessage, "192.168.1.10");
+
+            verify(mockNormalizer, times(1)).process(any(MessageEnvelope.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("Response Tests")
+    class ResponseTests {
+
+        @Test
+        @DisplayName("Should return SUCCESS status when normalizer returns true")
+        void shouldReturnSuccessWhenNormalizerReturnsTrue() {
+            when(mockNormalizer.process(any())).thenReturn(true);
+
+            ASTMHandlerResponse response = adapter.handle(mockAstmMessage, "192.168.1.10");
+
+            assertNotNull(response);
+            assertEquals(HandleStatus.SUCCESS, response.getStatus());
+        }
+
+        @Test
+        @DisplayName("Should return FORWARD_FAIL_ERROR status when normalizer returns false")
+        void shouldReturnForwardFailErrorWhenNormalizerReturnsFalse() {
+            when(mockNormalizer.process(any())).thenReturn(false);
+
+            ASTMHandlerResponse response = adapter.handle(mockAstmMessage, "192.168.1.10");
+
+            assertNotNull(response);
+            assertEquals(HandleStatus.FORWARD_FAIL_ERROR, response.getStatus());
+        }
+
+        @Test
+        @DisplayName("Should return empty response string")
+        void shouldReturnEmptyResponseString() {
+            ASTMHandlerResponse response = adapter.handle(mockAstmMessage, "192.168.1.10");
+
+            assertEquals("", response.getResponse());
+        }
+
+        @Test
+        @DisplayName("Should set communicateResponse to false")
+        void shouldSetCommunicateResponseToFalse() {
+            ASTMHandlerResponse response = adapter.handle(mockAstmMessage, "192.168.1.10");
+
+            assertFalse(response.getCommunicateResponse());
+        }
+
+        @Test
+        @DisplayName("Should return adapter instance as handler")
+        void shouldReturnAdapterInstanceAsHandler() {
+            ASTMHandlerResponse response = adapter.handle(mockAstmMessage, "192.168.1.10");
+
+            assertSame(adapter, response.getHandler());
+        }
+    }
+
+    @Nested
+    @DisplayName("Default handle(message) Method Tests")
+    class DefaultHandleMethodTests {
+
+        @Test
+        @DisplayName("Default handle method should call handle(message, null)")
+        void defaultHandleMethodShouldCallHandleWithNullSourceIp() {
+            // Use a real DefaultASTMMessage for this test
+            DefaultASTMMessage message = new DefaultASTMMessage(SAMPLE_ASTM_MESSAGE);
+
+            adapter.handle(message);
+
+            // Verify normalizer was called with "unknown" sourceId (null sourceIp → "unknown")
+            verify(mockNormalizer).process(argThat(envelope ->
+                "unknown".equals(envelope.getSourceId())
+            ));
+        }
+
+        @Test
+        @DisplayName("Default handle method should return same result as handle(message, null)")
+        void defaultHandleMethodShouldReturnSameResultAsHandleWithNull() {
+            DefaultASTMMessage message = new DefaultASTMMessage(SAMPLE_ASTM_MESSAGE);
+            when(mockNormalizer.process(any())).thenReturn(true);
+
+            ASTMHandlerResponse defaultResponse = adapter.handle(message);
+            ASTMHandlerResponse explicitResponse = adapter.handle(message, null);
+
+            assertEquals(defaultResponse.getStatus(), explicitResponse.getStatus());
+        }
+    }
+
+    @Nested
+    @DisplayName("Integration Tests with Real Messages")
+    class IntegrationTests {
+
+        @Test
+        @DisplayName("Should handle complete ASTM result message")
+        void shouldHandleCompleteASTMResultMessage() {
+            String completeMessage =
+                "H|\\^&|||MINDRAY^BC-5380^12345|||||||P|1|20260205120000\r" +
+                "P|1||PAT001||DOE^JOHN||19800101|M\r" +
+                "O|1|SAM001||^^^CBC|R||20260205120000\r" +
+                "R|1|^^^WBC|7.5|10^3/uL|4.0-11.0|N||F|||20260205120000\r" +
+                "R|2|^^^RBC|4.8|10^6/uL|4.5-5.5|N||F|||20260205120000\r" +
+                "R|3|^^^HGB|14.2|g/dL|12.0-16.0|N||F|||20260205120000\r" +
+                "L|1|N";
+
+            when(mockAstmMessage.getMessage()).thenReturn(completeMessage);
+
+            ASTMHandlerResponse response = adapter.handle(mockAstmMessage, "192.168.1.20");
+
+            assertEquals(HandleStatus.SUCCESS, response.getStatus());
+            verify(mockNormalizer).process(argThat(envelope ->
+                completeMessage.equals(envelope.getRawMessage()) &&
+                "192.168.1.20".equals(envelope.getSourceId())
+            ));
+        }
+
+        @Test
+        @DisplayName("Should handle message with special characters")
+        void shouldHandleMessageWithSpecialCharacters() {
+            String messageWithSpecialChars =
+                "H|\\^&|||TEST^with\\special|characters~here\r" +
+                "P|1||ID&with^special|chars\r" +
+                "L|1|N";
+
+            when(mockAstmMessage.getMessage()).thenReturn(messageWithSpecialChars);
+
+            ASTMHandlerResponse response = adapter.handle(mockAstmMessage, "192.168.1.30");
+
+            assertEquals(HandleStatus.SUCCESS, response.getStatus());
+            verify(mockNormalizer).process(argThat(envelope ->
+                messageWithSpecialChars.equals(envelope.getRawMessage())
+            ));
+        }
+
+        @Test
+        @DisplayName("Should handle IPv6 source address")
+        void shouldHandleIPv6SourceAddress() {
+            String ipv6Address = "2001:0db8:85a3:0000:0000:8a2e:0370:7334";
+
+            ASTMHandlerResponse response = adapter.handle(mockAstmMessage, ipv6Address);
+
+            assertEquals(HandleStatus.SUCCESS, response.getStatus());
+            verify(mockNormalizer).process(argThat(envelope ->
+                ipv6Address.equals(envelope.getSourceId())
+            ));
+        }
+    }
+}

--- a/src/test/java/org/itech/ahb/normalizer/AnalyzerIdentifierTest.java
+++ b/src/test/java/org/itech/ahb/normalizer/AnalyzerIdentifierTest.java
@@ -1,0 +1,356 @@
+package org.itech.ahb.normalizer;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.itech.ahb.config.AnalyzerRegistryConfig;
+import org.itech.ahb.model.Protocol;
+import org.itech.ahb.model.Transport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Unit tests for AnalyzerIdentifier.
+ * <p>
+ * Tests multi-strategy analyzer identification using registry lookups
+ * (direct match, pattern match, pre-identified, fallback to null).
+ * </p>
+ */
+class AnalyzerIdentifierTest {
+
+    private AnalyzerIdentifier identifier;
+    private AnalyzerRegistryConfig mockRegistry;
+
+    @Nested
+    @DisplayName("Pre-Identified Strategy Tests")
+    class PreIdentifiedTests {
+
+        @BeforeEach
+        void setUp() {
+            mockRegistry = mock(AnalyzerRegistryConfig.class);
+            identifier = new AnalyzerIdentifier(mockRegistry);
+        }
+
+        @Test
+        @DisplayName("Should return existing analyzer ID from envelope")
+        void shouldReturnExistingAnalyzerId() {
+            MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.ASTM)
+                .transport(Transport.SERIAL)
+                .sourceId("/dev/ttyUSB0")
+                .rawMessage("H|\\^&|||TEST")
+                .analyzerId("MINDRAY-001")
+                .build();
+
+            String result = identifier.identify(envelope);
+
+            assertEquals("MINDRAY-001", result);
+            // Should not call registry when envelope already has analyzer ID
+            verify(mockRegistry, never()).findAnalyzerId(anyString());
+        }
+
+        @Test
+        @DisplayName("Should not lookup registry when envelope has analyzer ID")
+        void shouldNotLookupRegistryWhenPreIdentified() {
+            MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.HL7)
+                .transport(Transport.MLLP)
+                .sourceId("192.168.1.10")
+                .rawMessage("MSH|^~\\&|||")
+                .analyzerId("SYSMEX-001")
+                .build();
+
+            identifier.identify(envelope);
+
+            // Constructor calls getAnalyzers() for logging; verify no lookup during identify
+            verify(mockRegistry, never()).findAnalyzerId(anyString());
+        }
+    }
+
+    @Nested
+    @DisplayName("Registry Lookup Strategy Tests")
+    class RegistryLookupTests {
+
+        @BeforeEach
+        void setUp() {
+            mockRegistry = mock(AnalyzerRegistryConfig.class);
+            identifier = new AnalyzerIdentifier(mockRegistry);
+        }
+
+        @Test
+        @DisplayName("Should return analyzer ID from direct IP match")
+        void shouldReturnAnalyzerIdFromIPMatch() {
+            when(mockRegistry.findAnalyzerId("192.168.1.10")).thenReturn(Optional.of("MINDRAY-001"));
+
+            MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.ASTM)
+                .transport(Transport.TCP)
+                .sourceId("192.168.1.10")
+                .rawMessage("H|\\^&|||TEST")
+                .build();
+
+            String result = identifier.identify(envelope);
+
+            assertEquals("MINDRAY-001", result);
+        }
+
+        @Test
+        @DisplayName("Should return analyzer ID from serial port match")
+        void shouldReturnAnalyzerIdFromSerialPortMatch() {
+            when(mockRegistry.findAnalyzerId("/dev/ttyUSB0")).thenReturn(Optional.of("HORIBA-001"));
+
+            MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.ASTM)
+                .transport(Transport.SERIAL)
+                .sourceId("/dev/ttyUSB0")
+                .rawMessage("H|\\^&|||TEST")
+                .build();
+
+            String result = identifier.identify(envelope);
+
+            assertEquals("HORIBA-001", result);
+        }
+
+        @Test
+        @DisplayName("Should return analyzer ID from file path pattern match")
+        void shouldReturnAnalyzerIdFromFilePathPattern() {
+            when(mockRegistry.findAnalyzerId("/mnt/analyzer/quantstudio-20260205.csv"))
+                .thenReturn(Optional.of("QUANTSTUDIO-001"));
+
+            MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.CSV)
+                .transport(Transport.FILE)
+                .sourceId("/mnt/analyzer/quantstudio-20260205.csv")
+                .rawMessage("SampleID,TestCode,Result")
+                .build();
+
+            String result = identifier.identify(envelope);
+
+            assertEquals("QUANTSTUDIO-001", result);
+        }
+
+        @Test
+        @DisplayName("Should return null when registry returns empty")
+        void shouldReturnNullWhenRegistryReturnsEmpty() {
+            when(mockRegistry.findAnalyzerId("192.168.1.99")).thenReturn(Optional.empty());
+
+            MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.HL7)
+                .transport(Transport.TCP)
+                .sourceId("192.168.1.99")
+                .rawMessage("MSH|^~\\&|||")
+                .build();
+
+            String result = identifier.identify(envelope);
+
+            assertNull(result);
+        }
+    }
+
+    @Nested
+    @DisplayName("Null Registry Tests")
+    class NullRegistryTests {
+
+        @BeforeEach
+        void setUp() {
+            // Create identifier with null registry (not configured)
+            identifier = new AnalyzerIdentifier(null);
+        }
+
+        @Test
+        @DisplayName("Should return null when registry is not configured")
+        void shouldReturnNullWhenRegistryIsNull() {
+            MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.ASTM)
+                .transport(Transport.TCP)
+                .sourceId("192.168.1.10")
+                .rawMessage("H|\\^&|||TEST")
+                .build();
+
+            String result = identifier.identify(envelope);
+
+            assertNull(result);
+        }
+
+        @Test
+        @DisplayName("Should still return pre-identified analyzer ID even with null registry")
+        void shouldReturnPreIdentifiedIdWithNullRegistry() {
+            MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.ASTM)
+                .transport(Transport.SERIAL)
+                .sourceId("/dev/ttyUSB0")
+                .rawMessage("H|\\^&|||TEST")
+                .analyzerId("MINDRAY-001")
+                .build();
+
+            String result = identifier.identify(envelope);
+
+            assertEquals("MINDRAY-001", result);
+        }
+    }
+
+    @Nested
+    @DisplayName("Edge Case Tests")
+    class EdgeCaseTests {
+
+        @BeforeEach
+        void setUp() {
+            mockRegistry = mock(AnalyzerRegistryConfig.class);
+            identifier = new AnalyzerIdentifier(mockRegistry);
+        }
+
+        @Test
+        @DisplayName("Should return null when sourceId is null")
+        void shouldReturnNullWhenSourceIdIsNull() {
+            MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.ASTM)
+                .transport(Transport.SERIAL)
+                .sourceId(null)
+                .rawMessage("H|\\^&|||TEST")
+                .build();
+
+            String result = identifier.identify(envelope);
+
+            assertNull(result);
+            verify(mockRegistry, never()).findAnalyzerId(anyString());
+        }
+
+        @Test
+        @DisplayName("Should return null when sourceId is empty")
+        void shouldReturnNullWhenSourceIdIsEmpty() {
+            MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.ASTM)
+                .transport(Transport.SERIAL)
+                .sourceId("")
+                .rawMessage("H|\\^&|||TEST")
+                .build();
+
+            String result = identifier.identify(envelope);
+
+            assertNull(result);
+            verify(mockRegistry, never()).findAnalyzerId(anyString());
+        }
+
+        @Test
+        @DisplayName("Should handle empty analyzer ID in envelope as not pre-identified")
+        void shouldHandleEmptyAnalyzerIdAsNotPreIdentified() {
+            when(mockRegistry.findAnalyzerId("192.168.1.10")).thenReturn(Optional.of("MINDRAY-001"));
+
+            MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.ASTM)
+                .transport(Transport.TCP)
+                .sourceId("192.168.1.10")
+                .rawMessage("H|\\^&|||TEST")
+                .analyzerId("")  // Empty string, not null
+                .build();
+
+            String result = identifier.identify(envelope);
+
+            // Empty string should trigger registry lookup
+            assertEquals("MINDRAY-001", result);
+            verify(mockRegistry).findAnalyzerId("192.168.1.10");
+        }
+    }
+
+    @Nested
+    @DisplayName("Integration with Real Registry Tests")
+    class RealRegistryTests {
+
+        private AnalyzerRegistryConfig realRegistry;
+
+        @BeforeEach
+        void setUp() {
+            realRegistry = new AnalyzerRegistryConfig();
+            Map<String, AnalyzerRegistryConfig.AnalyzerEntry> analyzers = new LinkedHashMap<>();
+
+            // Add test entries
+            AnalyzerRegistryConfig.AnalyzerEntry mindray = new AnalyzerRegistryConfig.AnalyzerEntry();
+            mindray.setId("MINDRAY-001");
+            mindray.setName("Mindray BC-5380");
+            mindray.setExpectedProtocol("ASTM");
+            analyzers.put("192.168.1.10", mindray);
+
+            AnalyzerRegistryConfig.AnalyzerEntry horiba = new AnalyzerRegistryConfig.AnalyzerEntry();
+            horiba.setId("HORIBA-001");
+            horiba.setName("Horiba Pentra 60");
+            horiba.setExpectedProtocol("ASTM");
+            analyzers.put("/dev/ttyUSB0", horiba);
+
+            AnalyzerRegistryConfig.AnalyzerEntry quantstudio = new AnalyzerRegistryConfig.AnalyzerEntry();
+            quantstudio.setId("QUANTSTUDIO-001");
+            quantstudio.setName("QuantStudio 7 Flex");
+            quantstudio.setExpectedProtocol("CSV");
+            quantstudio.setFilePattern(".*/quantstudio-.*\\.csv");
+            analyzers.put("quantstudio-*", quantstudio);
+
+            realRegistry.setAnalyzers(analyzers);
+            identifier = new AnalyzerIdentifier(realRegistry);
+        }
+
+        @Test
+        @DisplayName("Should identify analyzer by IP using real registry")
+        void shouldIdentifyByIPWithRealRegistry() {
+            MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.ASTM)
+                .transport(Transport.TCP)
+                .sourceId("192.168.1.10")
+                .rawMessage("H|\\^&|||TEST")
+                .build();
+
+            String result = identifier.identify(envelope);
+
+            assertEquals("MINDRAY-001", result);
+        }
+
+        @Test
+        @DisplayName("Should identify analyzer by serial port using real registry")
+        void shouldIdentifyBySerialPortWithRealRegistry() {
+            MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.ASTM)
+                .transport(Transport.SERIAL)
+                .sourceId("/dev/ttyUSB0")
+                .rawMessage("H|\\^&|||TEST")
+                .build();
+
+            String result = identifier.identify(envelope);
+
+            assertEquals("HORIBA-001", result);
+        }
+
+        @Test
+        @DisplayName("Should identify analyzer by glob pattern using real registry")
+        void shouldIdentifyByGlobPatternWithRealRegistry() {
+            MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.CSV)
+                .transport(Transport.FILE)
+                .sourceId("quantstudio-20260205.csv")
+                .rawMessage("SampleID,TestCode,Result")
+                .build();
+
+            String result = identifier.identify(envelope);
+
+            assertEquals("QUANTSTUDIO-001", result);
+        }
+
+        @Test
+        @DisplayName("Should return null for unregistered analyzer using real registry")
+        void shouldReturnNullForUnregisteredAnalyzerWithRealRegistry() {
+            MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.HL7)
+                .transport(Transport.TCP)
+                .sourceId("192.168.1.99")
+                .rawMessage("MSH|^~\\&|||")
+                .build();
+
+            String result = identifier.identify(envelope);
+
+            assertNull(result);
+        }
+    }
+}

--- a/src/test/java/org/itech/ahb/normalizer/MessageNormalizerTest.java
+++ b/src/test/java/org/itech/ahb/normalizer/MessageNormalizerTest.java
@@ -1,0 +1,296 @@
+package org.itech.ahb.normalizer;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.*;
+
+import org.itech.ahb.model.Protocol;
+import org.itech.ahb.model.Transport;
+import org.itech.ahb.routing.HttpForwardingRouter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for MessageNormalizer.
+ * <p>
+ * Tests the central orchestration service that implements MessageRouter
+ * and delegates to HttpForwardingRouter for actual routing.
+ * </p>
+ */
+@ExtendWith(MockitoExtension.class)
+class MessageNormalizerTest {
+
+    @Mock
+    private HttpForwardingRouter mockForwardingRouter;
+
+    @Mock
+    private AnalyzerIdentifier mockIdentifier;
+
+    private MessageNormalizer normalizer;
+
+    @BeforeEach
+    void setUp() {
+        normalizer = new MessageNormalizer(mockForwardingRouter, mockIdentifier);
+        // Lenient: some tests override these stubs
+        lenient().when(mockForwardingRouter.route(any(MessageEnvelope.class))).thenReturn(true);
+        lenient().when(mockIdentifier.identify(any(MessageEnvelope.class))).thenReturn(null);
+    }
+
+    @Nested
+    @DisplayName("Analyzer Identification Tests")
+    class AnalyzerIdentificationTests {
+
+        @Test
+        @DisplayName("Should use existing analyzer ID when envelope has one")
+        void shouldUseExistingAnalyzerId() {
+            MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.ASTM)
+                .transport(Transport.SERIAL)
+                .sourceId("/dev/ttyUSB0")
+                .rawMessage("H|\\^&|||TEST")
+                .analyzerId("MINDRAY-001")
+                .build();
+
+            boolean result = normalizer.process(envelope);
+
+            assertTrue(result);
+            // Verify forwardingRouter is called with original envelope (analyzer ID unchanged)
+            verify(mockForwardingRouter).route(argThat(e ->
+                "MINDRAY-001".equals(e.getAnalyzerId())
+            ));
+        }
+
+        @Test
+        @DisplayName("Should enrich envelope when identifier returns analyzer ID")
+        void shouldEnrichEnvelopeWithIdentifiedAnalyzerId() {
+            when(mockIdentifier.identify(any())).thenReturn("SYSMEX-001");
+
+            MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.HL7)
+                .transport(Transport.TCP)
+                .sourceId("192.168.1.10")
+                .rawMessage("MSH|^~\\&|||")
+                .build();
+
+            boolean result = normalizer.process(envelope);
+
+            assertTrue(result);
+            // Verify forwardingRouter is called with enriched envelope
+            verify(mockForwardingRouter).route(argThat(e ->
+                "SYSMEX-001".equals(e.getAnalyzerId()) &&
+                Protocol.HL7.equals(e.getProtocol()) &&
+                "192.168.1.10".equals(e.getSourceId())
+            ));
+        }
+
+        @Test
+        @DisplayName("Should use original envelope when identifier returns null")
+        void shouldUseOriginalEnvelopeWhenIdentifierReturnsNull() {
+            when(mockIdentifier.identify(any())).thenReturn(null);
+
+            MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.CSV)
+                .transport(Transport.FILE)
+                .sourceId("/mnt/analyzer/file.csv")
+                .rawMessage("SampleID,TestCode,Result")
+                .build();
+
+            boolean result = normalizer.process(envelope);
+
+            assertTrue(result);
+            // Verify forwardingRouter is called with original envelope
+            verify(mockForwardingRouter).route(argThat(e ->
+                e.getAnalyzerId() == null &&
+                Protocol.CSV.equals(e.getProtocol())
+            ));
+        }
+    }
+
+    @Nested
+    @DisplayName("Routing Tests")
+    class RoutingTests {
+
+        @Test
+        @DisplayName("Should return true when forwarding router succeeds")
+        void shouldReturnTrueWhenForwardingRouterSucceeds() {
+            when(mockForwardingRouter.route(any())).thenReturn(true);
+
+            MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.ASTM)
+                .transport(Transport.SERIAL)
+                .sourceId("/dev/ttyUSB0")
+                .rawMessage("H|\\^&|||TEST")
+                .build();
+
+            boolean result = normalizer.process(envelope);
+
+            assertTrue(result);
+        }
+
+        @Test
+        @DisplayName("Should return false when forwarding router fails")
+        void shouldReturnFalseWhenForwardingRouterFails() {
+            when(mockForwardingRouter.route(any())).thenReturn(false);
+
+            MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.ASTM)
+                .transport(Transport.SERIAL)
+                .sourceId("/dev/ttyUSB0")
+                .rawMessage("H|\\^&|||TEST")
+                .build();
+
+            boolean result = normalizer.process(envelope);
+
+            assertFalse(result);
+        }
+
+        @Test
+        @DisplayName("Should call forwardingRouter.route() exactly once")
+        void shouldCallForwardingRouterOnce() {
+            MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.HL7)
+                .transport(Transport.MLLP)
+                .sourceId("192.168.1.20")
+                .rawMessage("MSH|^~\\&|||")
+                .build();
+
+            normalizer.process(envelope);
+
+            verify(mockForwardingRouter, times(1)).route(any(MessageEnvelope.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("MessageRouter Implementation Tests")
+    class MessageRouterImplementationTests {
+
+        @Test
+        @DisplayName("route() method should delegate to process()")
+        void routeShouldDelegateToProcess() {
+            when(mockForwardingRouter.route(any())).thenReturn(true);
+
+            MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.ASTM)
+                .transport(Transport.TCP)
+                .sourceId("192.168.1.30")
+                .rawMessage("H|\\^&|||TEST")
+                .build();
+
+            // Call route() (MessageRouter interface method)
+            boolean result = normalizer.route(envelope);
+
+            assertTrue(result);
+            // Verify forwardingRouter was called (via process())
+            verify(mockForwardingRouter).route(any(MessageEnvelope.class));
+        }
+
+        @Test
+        @DisplayName("route() should return same result as process()")
+        void routeShouldReturnSameResultAsProcess() {
+            when(mockForwardingRouter.route(any())).thenReturn(false);
+
+            MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.CSV)
+                .transport(Transport.FILE)
+                .sourceId("/mnt/file.csv")
+                .rawMessage("SampleID,TestCode")
+                .build();
+
+            // Both should return same result
+            boolean routeResult = normalizer.route(envelope);
+            boolean processResult = normalizer.process(envelope);
+
+            assertEquals(routeResult, processResult);
+            assertFalse(routeResult);
+            assertFalse(processResult);
+        }
+    }
+
+    @Nested
+    @DisplayName("Envelope Preservation Tests")
+    class EnvelopePreservationTests {
+
+        @Test
+        @DisplayName("Should preserve protocol in enriched envelope")
+        void shouldPreserveProtocol() {
+            when(mockIdentifier.identify(any())).thenReturn("ANALYZER-001");
+
+            MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.HL7)
+                .transport(Transport.HTTP)
+                .sourceId("192.168.1.40")
+                .rawMessage("MSH|^~\\&|||")
+                .build();
+
+            normalizer.process(envelope);
+
+            verify(mockForwardingRouter).route(argThat(e ->
+                Protocol.HL7.equals(e.getProtocol())
+            ));
+        }
+
+        @Test
+        @DisplayName("Should preserve transport in enriched envelope")
+        void shouldPreserveTransport() {
+            when(mockIdentifier.identify(any())).thenReturn("ANALYZER-002");
+
+            MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.ASTM)
+                .transport(Transport.SERIAL)
+                .sourceId("/dev/ttyUSB1")
+                .rawMessage("H|\\^&|||TEST")
+                .build();
+
+            normalizer.process(envelope);
+
+            verify(mockForwardingRouter).route(argThat(e ->
+                Transport.SERIAL.equals(e.getTransport())
+            ));
+        }
+
+        @Test
+        @DisplayName("Should preserve sourceId in enriched envelope")
+        void shouldPreserveSourceId() {
+            when(mockIdentifier.identify(any())).thenReturn("ANALYZER-003");
+
+            MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.CSV)
+                .transport(Transport.FILE)
+                .sourceId("/mnt/quantstudio/results.csv")
+                .rawMessage("SampleID,TestCode,Result")
+                .build();
+
+            normalizer.process(envelope);
+
+            verify(mockForwardingRouter).route(argThat(e ->
+                "/mnt/quantstudio/results.csv".equals(e.getSourceId())
+            ));
+        }
+
+        @Test
+        @DisplayName("Should preserve rawMessage in enriched envelope")
+        void shouldPreserveRawMessage() {
+            when(mockIdentifier.identify(any())).thenReturn("ANALYZER-004");
+
+            String rawMessage = "H|\\^&|||TEST||||||P|1\rP|1||12345\rL|1|N";
+            MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.ASTM)
+                .transport(Transport.TCP)
+                .sourceId("192.168.1.50")
+                .rawMessage(rawMessage)
+                .build();
+
+            normalizer.process(envelope);
+
+            verify(mockForwardingRouter).route(argThat(e ->
+                rawMessage.equals(e.getRawMessage())
+            ));
+        }
+    }
+}

--- a/src/test/java/org/itech/ahb/serial/SerialIntegrationTest.java
+++ b/src/test/java/org/itech/ahb/serial/SerialIntegrationTest.java
@@ -16,6 +16,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.itech.ahb.config.properties.HTTPForwardServerConfigurationProperties;
 import org.itech.ahb.config.properties.SerialConfigurationProperties;
+import org.itech.ahb.normalizer.AnalyzerIdentifier;
+import org.itech.ahb.normalizer.MessageNormalizer;
+import org.itech.ahb.routing.HttpForwardingRouter;
 import org.itech.ahb.config.properties.SerialConfigurationProperties.Parity;
 import org.itech.ahb.config.properties.SerialConfigurationProperties.ProtocolMode;
 import org.itech.ahb.config.properties.SerialConfigurationProperties.SerialPortConfig;
@@ -77,11 +80,12 @@ class SerialIntegrationTest {
         serverPort = httpServer.getAddress().getPort();
 
         // Set up handler to capture messages
+        // HttpForwardingRouter sends to /api/OpenELIS-Global/analyzer/{protocol}
         httpServer.createContext("/api/OpenELIS-Global/analyzer/", exchange -> {
             String path = exchange.getRequestURI().getPath();
             String contentType = exchange.getRequestHeaders().getFirst("Content-Type");
-            String sourceId = exchange.getRequestHeaders().getFirst(SerialMessageHandler.SOURCE_ID_HEADER);
-            String transport = exchange.getRequestHeaders().getFirst(SerialMessageHandler.TRANSPORT_HEADER);
+            String sourceId = exchange.getRequestHeaders().getFirst(HttpForwardingRouter.HEADER_SOURCE_ID);
+            String transport = exchange.getRequestHeaders().getFirst(HttpForwardingRouter.HEADER_SOURCE_TRANSPORT);
 
             String body;
             try (InputStream is = exchange.getRequestBody()) {
@@ -156,12 +160,15 @@ class SerialIntegrationTest {
 
             config.getPorts().add(portConfig);
 
-            // Create HTTP config
+            // Create HTTP config and wire M7 pipeline: HttpForwardingRouter -> MessageNormalizer -> SerialMessageHandler
             HTTPForwardServerConfigurationProperties httpConfig = new HTTPForwardServerConfigurationProperties();
-            httpConfig.setUri(java.net.URI.create("http://localhost:" + serverPort));
+            httpConfig.setUri(java.net.URI.create("http://localhost:" + serverPort + "/api/OpenELIS-Global/analyzer"));
 
-            // Create and start listener
-            SerialMessageHandler handler = new SerialMessageHandler(httpConfig);
+            HttpForwardingRouter forwardingRouter = new HttpForwardingRouter(httpConfig, null);
+            AnalyzerIdentifier identifier = new AnalyzerIdentifier(null);
+            MessageNormalizer normalizer = new MessageNormalizer(forwardingRouter, identifier);
+            SerialMessageHandler handler = new SerialMessageHandler(normalizer);
+
             listener = new SerialPortListener(config, handler);
             listener.start();
 
@@ -202,9 +209,13 @@ class SerialIntegrationTest {
             config.getPorts().add(portConfig);
 
             HTTPForwardServerConfigurationProperties httpConfig = new HTTPForwardServerConfigurationProperties();
-            httpConfig.setUri(java.net.URI.create("http://localhost:" + serverPort));
+            httpConfig.setUri(java.net.URI.create("http://localhost:" + serverPort + "/api/OpenELIS-Global/analyzer"));
 
-            SerialMessageHandler handler = new SerialMessageHandler(httpConfig);
+            HttpForwardingRouter forwardingRouter = new HttpForwardingRouter(httpConfig, null);
+            AnalyzerIdentifier identifier = new AnalyzerIdentifier(null);
+            MessageNormalizer normalizer = new MessageNormalizer(forwardingRouter, identifier);
+            SerialMessageHandler handler = new SerialMessageHandler(normalizer);
+
             listener = new SerialPortListener(config, handler);
             listener.start();
 
@@ -239,9 +250,13 @@ class SerialIntegrationTest {
             config.getPorts().add(portConfig);
 
             HTTPForwardServerConfigurationProperties httpConfig = new HTTPForwardServerConfigurationProperties();
-            httpConfig.setUri(java.net.URI.create("http://localhost:" + serverPort));
+            httpConfig.setUri(java.net.URI.create("http://localhost:" + serverPort + "/api/OpenELIS-Global/analyzer"));
 
-            SerialMessageHandler handler = new SerialMessageHandler(httpConfig);
+            HttpForwardingRouter forwardingRouter = new HttpForwardingRouter(httpConfig, null);
+            AnalyzerIdentifier identifier = new AnalyzerIdentifier(null);
+            MessageNormalizer normalizer = new MessageNormalizer(forwardingRouter, identifier);
+            SerialMessageHandler handler = new SerialMessageHandler(normalizer);
+
             listener = new SerialPortListener(config, handler);
             listener.start();
 
@@ -370,9 +385,13 @@ class SerialIntegrationTest {
             config.setPorts(ports);
 
             HTTPForwardServerConfigurationProperties httpConfig = new HTTPForwardServerConfigurationProperties();
-            httpConfig.setUri(java.net.URI.create("http://localhost:" + serverPort));
+            httpConfig.setUri(java.net.URI.create("http://localhost:" + serverPort + "/api/OpenELIS-Global/analyzer"));
 
-            SerialMessageHandler handler = new SerialMessageHandler(httpConfig);
+            HttpForwardingRouter forwardingRouter = new HttpForwardingRouter(httpConfig, null);
+            AnalyzerIdentifier identifier = new AnalyzerIdentifier(null);
+            MessageNormalizer normalizer = new MessageNormalizer(forwardingRouter, identifier);
+            SerialMessageHandler handler = new SerialMessageHandler(normalizer);
+
             SerialPortListener listener = new SerialPortListener(config, handler);
 
             // Start should not throw
@@ -393,9 +412,13 @@ class SerialIntegrationTest {
             config.setEnabled(true);
 
             HTTPForwardServerConfigurationProperties httpConfig = new HTTPForwardServerConfigurationProperties();
-            httpConfig.setUri(java.net.URI.create("http://localhost:" + serverPort));
+            httpConfig.setUri(java.net.URI.create("http://localhost:" + serverPort + "/api/OpenELIS-Global/analyzer"));
 
-            SerialMessageHandler handler = new SerialMessageHandler(httpConfig);
+            HttpForwardingRouter forwardingRouter = new HttpForwardingRouter(httpConfig, null);
+            AnalyzerIdentifier identifier = new AnalyzerIdentifier(null);
+            MessageNormalizer normalizer = new MessageNormalizer(forwardingRouter, identifier);
+            SerialMessageHandler handler = new SerialMessageHandler(normalizer);
+
             SerialPortListener listener = new SerialPortListener(config, handler);
             listener.start();
 

--- a/src/test/java/org/itech/ahb/serial/SerialMessageHandlerTest.java
+++ b/src/test/java/org/itech/ahb/serial/SerialMessageHandlerTest.java
@@ -2,99 +2,43 @@ package org.itech.ahb.serial;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.*;
 
-import com.sun.net.httpserver.HttpServer;
-import com.sun.net.httpserver.HttpExchange;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.net.InetSocketAddress;
-import java.net.URI;
-import java.nio.charset.StandardCharsets;
-import java.util.concurrent.atomic.AtomicReference;
-import org.itech.ahb.config.properties.HTTPForwardServerConfigurationProperties;
 import org.itech.ahb.model.Protocol;
+import org.itech.ahb.model.Transport;
+import org.itech.ahb.normalizer.MessageEnvelope;
+import org.itech.ahb.normalizer.MessageNormalizer;
 import org.itech.ahb.serial.SerialMessageHandler.HandleResult;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * Unit tests for SerialMessageHandler class.
  * <p>
- * Uses an embedded HTTP server to test message forwarding without external dependencies.
+ * Tests protocol detection, envelope creation, and delegation to MessageNormalizer.
+ * After M7 refactoring, this handler no longer does direct HTTP forwarding —
+ * it creates a MessageEnvelope and delegates to the normalizer.
  * </p>
  */
+@ExtendWith(MockitoExtension.class)
 class SerialMessageHandlerTest {
 
-    private HttpServer httpServer;
-    private SerialMessageHandler handler;
-    private HTTPForwardServerConfigurationProperties httpConfig;
-    private int serverPort;
+    @Mock
+    private MessageNormalizer mockNormalizer;
 
-    // Capture received requests
-    private AtomicReference<String> receivedBody;
-    private AtomicReference<String> receivedContentType;
-    private AtomicReference<String> receivedSourceId;
-    private AtomicReference<String> receivedTransport;
-    private AtomicReference<String> receivedPath;
-    private int responseCode = 200;
-    private String responseBody = "OK";
+    private SerialMessageHandler handler;
 
     @BeforeEach
-    void setUp() throws IOException {
-        receivedBody = new AtomicReference<>();
-        receivedContentType = new AtomicReference<>();
-        receivedSourceId = new AtomicReference<>();
-        receivedTransport = new AtomicReference<>();
-        receivedPath = new AtomicReference<>();
-
-        // Start embedded HTTP server
-        httpServer = HttpServer.create(new InetSocketAddress(0), 0);
-        serverPort = httpServer.getAddress().getPort();
-
-        // Handle all analyzer endpoints
-        httpServer.createContext("/api/OpenELIS-Global/analyzer/", exchange -> {
-            handleRequest(exchange);
-        });
-
-        httpServer.start();
-
-        // Configure handler
-        httpConfig = new HTTPForwardServerConfigurationProperties();
-        httpConfig.setUri(URI.create("http://localhost:" + serverPort));
-
-        handler = new SerialMessageHandler(httpConfig);
-    }
-
-    @AfterEach
-    void tearDown() {
-        if (httpServer != null) {
-            httpServer.stop(0);
-        }
-    }
-
-    private void handleRequest(HttpExchange exchange) throws IOException {
-        // Capture request details
-        receivedPath.set(exchange.getRequestURI().getPath());
-        receivedContentType.set(exchange.getRequestHeaders().getFirst("Content-Type"));
-        receivedSourceId.set(exchange.getRequestHeaders().getFirst(SerialMessageHandler.SOURCE_ID_HEADER));
-        receivedTransport.set(exchange.getRequestHeaders().getFirst(SerialMessageHandler.TRANSPORT_HEADER));
-
-        // Read body
-        try (InputStream is = exchange.getRequestBody()) {
-            receivedBody.set(new String(is.readAllBytes(), StandardCharsets.UTF_8));
-        }
-
-        // Send response
-        byte[] response = responseBody.getBytes(StandardCharsets.UTF_8);
-        exchange.sendResponseHeaders(responseCode, response.length);
-        try (OutputStream os = exchange.getResponseBody()) {
-            os.write(response);
-        }
+    void setUp() {
+        handler = new SerialMessageHandler(mockNormalizer);
+        // Lenient: ErrorHandlingTests override or never call process
+        lenient().when(mockNormalizer.process(any(MessageEnvelope.class))).thenReturn(true);
     }
 
     @Nested
@@ -102,8 +46,8 @@ class SerialMessageHandlerTest {
     class ProtocolDetectionTests {
 
         @Test
-        @DisplayName("Should detect and route ASTM message")
-        void shouldDetectAndRouteASTMMessage() {
+        @DisplayName("Should detect ASTM protocol and create correct envelope")
+        void shouldDetectASTMProtocol() {
             String astmMessage = "H|\\^&|||ANALYZER|||||||P|1|20260205120000\r" +
                                 "P|1||12345\r" +
                                 "L|1|N";
@@ -111,14 +55,18 @@ class SerialMessageHandlerTest {
             HandleResult result = handler.handleMessage(astmMessage, "/dev/ttyUSB0", null);
 
             assertTrue(result.success());
-            assertEquals("/api/OpenELIS-Global/analyzer/astm", receivedPath.get());
-            assertEquals(astmMessage, receivedBody.get());
-            assertEquals("text/plain", receivedContentType.get());
+            verify(mockNormalizer).process(argThat(envelope ->
+                envelope.getProtocol() == Protocol.ASTM &&
+                envelope.getTransport() == Transport.SERIAL &&
+                "/dev/ttyUSB0".equals(envelope.getSourceId()) &&
+                astmMessage.equals(envelope.getRawMessage()) &&
+                envelope.getAnalyzerId() == null
+            ));
         }
 
         @Test
-        @DisplayName("Should detect and route HL7 message")
-        void shouldDetectAndRouteHL7Message() {
+        @DisplayName("Should detect HL7 protocol and create correct envelope")
+        void shouldDetectHL7Protocol() {
             String hl7Message = "MSH|^~\\&|TEST|LAB|OPENELIS|LAB|20260205120000||ORU^R01|MSG001|P|2.5.1\r" +
                                "PID|1||12345||DOE^JOHN\r" +
                                "OBX|1|NM|WBC||7.5|10^3/uL";
@@ -126,14 +74,17 @@ class SerialMessageHandlerTest {
             HandleResult result = handler.handleMessage(hl7Message, "/dev/ttyUSB0", null);
 
             assertTrue(result.success());
-            assertEquals("/api/OpenELIS-Global/analyzer/hl7", receivedPath.get());
-            assertEquals(hl7Message, receivedBody.get());
-            assertEquals("application/hl7-v2", receivedContentType.get());
+            verify(mockNormalizer).process(argThat(envelope ->
+                envelope.getProtocol() == Protocol.HL7 &&
+                envelope.getTransport() == Transport.SERIAL &&
+                "/dev/ttyUSB0".equals(envelope.getSourceId()) &&
+                hl7Message.equals(envelope.getRawMessage())
+            ));
         }
 
         @Test
-        @DisplayName("Should detect and route CSV message")
-        void shouldDetectAndRouteCSVMessage() {
+        @DisplayName("Should detect CSV protocol and create correct envelope")
+        void shouldDetectCSVProtocol() {
             String csvMessage = "SampleID,TestCode,Result,Unit,Flag\r\n" +
                                "12345,WBC,7.5,10^3/uL,N\r\n" +
                                "12345,RBC,4.8,10^6/uL,N";
@@ -141,66 +92,78 @@ class SerialMessageHandlerTest {
             HandleResult result = handler.handleMessage(csvMessage, "/dev/ttyUSB0", null);
 
             assertTrue(result.success());
-            assertEquals("/api/OpenELIS-Global/analyzer/csv", receivedPath.get());
-            assertEquals(csvMessage, receivedBody.get());
-            assertEquals("text/csv", receivedContentType.get());
+            verify(mockNormalizer).process(argThat(envelope ->
+                envelope.getProtocol() == Protocol.CSV &&
+                envelope.getTransport() == Transport.SERIAL &&
+                csvMessage.equals(envelope.getRawMessage())
+            ));
         }
 
         @Test
-        @DisplayName("Should route unknown protocol to raw endpoint")
-        void shouldRouteUnknownToRawEndpoint() {
+        @DisplayName("Should detect unknown protocol and create envelope")
+        void shouldDetectUnknownProtocol() {
             String unknownMessage = "This is some unknown format";
 
             HandleResult result = handler.handleMessage(unknownMessage, "/dev/ttyUSB0", null);
 
             assertTrue(result.success());
-            assertEquals("/api/OpenELIS-Global/analyzer/raw", receivedPath.get());
+            verify(mockNormalizer).process(argThat(envelope ->
+                envelope.getProtocol() == Protocol.UNKNOWN &&
+                envelope.getTransport() == Transport.SERIAL
+            ));
         }
     }
 
     @Nested
-    @DisplayName("Header Tests")
-    class HeaderTests {
+    @DisplayName("Envelope Metadata Tests")
+    class EnvelopeMetadataTests {
 
         @Test
-        @DisplayName("Should include source ID header")
-        void shouldIncludeSourceIdHeader() {
+        @DisplayName("Should include source ID in envelope")
+        void shouldIncludeSourceIdInEnvelope() {
             String message = "H|\\^&|||TEST";
 
             handler.handleMessage(message, "/dev/ttyUSB0", null);
 
-            assertEquals("/dev/ttyUSB0", receivedSourceId.get());
+            verify(mockNormalizer).process(argThat(envelope ->
+                "/dev/ttyUSB0".equals(envelope.getSourceId())
+            ));
         }
 
         @Test
-        @DisplayName("Should include transport header")
-        void shouldIncludeTransportHeader() {
+        @DisplayName("Should include SERIAL transport in envelope")
+        void shouldIncludeTransportInEnvelope() {
             String message = "H|\\^&|||TEST";
 
             handler.handleMessage(message, "/dev/ttyUSB0", null);
 
-            assertEquals("SERIAL", receivedTransport.get());
+            verify(mockNormalizer).process(argThat(envelope ->
+                envelope.getTransport() == Transport.SERIAL
+            ));
         }
 
         @Test
-        @DisplayName("Should include analyzer ID header when provided")
-        void shouldIncludeAnalyzerIdHeader() throws IOException {
-            // Create new server context to capture analyzer ID
-            AtomicReference<String> receivedAnalyzerId = new AtomicReference<>();
-
-            httpServer.createContext("/api/OpenELIS-Global/analyzer/astm", exchange -> {
-                receivedAnalyzerId.set(exchange.getRequestHeaders()
-                    .getFirst(SerialMessageHandler.ANALYZER_ID_HEADER));
-                exchange.sendResponseHeaders(200, 2);
-                try (OutputStream os = exchange.getResponseBody()) {
-                    os.write("OK".getBytes());
-                }
-            });
-
+        @DisplayName("Should include analyzer ID in envelope when provided")
+        void shouldIncludeAnalyzerIdInEnvelope() {
             String message = "H|\\^&|||TEST";
+
             handler.handleMessage(message, "/dev/ttyUSB0", "ANALYZER-001");
 
-            assertEquals("ANALYZER-001", receivedAnalyzerId.get());
+            verify(mockNormalizer).process(argThat(envelope ->
+                "ANALYZER-001".equals(envelope.getAnalyzerId())
+            ));
+        }
+
+        @Test
+        @DisplayName("Should have null analyzer ID when not provided")
+        void shouldHaveNullAnalyzerIdWhenNotProvided() {
+            String message = "H|\\^&|||TEST";
+
+            handler.handleMessage(message, "/dev/ttyUSB0", null);
+
+            verify(mockNormalizer).process(argThat(envelope ->
+                envelope.getAnalyzerId() == null
+            ));
         }
     }
 
@@ -215,6 +178,7 @@ class SerialMessageHandlerTest {
 
             assertFalse(result.success());
             assertEquals("Empty message", result.message());
+            verify(mockNormalizer, never()).process(any());
         }
 
         @Test
@@ -224,79 +188,31 @@ class SerialMessageHandlerTest {
 
             assertFalse(result.success());
             assertEquals("Empty message", result.message());
+            verify(mockNormalizer, never()).process(any());
         }
 
         @Test
-        @DisplayName("Should handle HTTP error response")
-        void shouldHandleHttpErrorResponse() {
-            responseCode = 500;
-            responseBody = "Internal Server Error";
+        @DisplayName("Should return failure when normalizer returns false")
+        void shouldReturnFailureWhenNormalizerReturnsFalse() {
+            when(mockNormalizer.process(any(MessageEnvelope.class))).thenReturn(false);
 
             String message = "H|\\^&|||TEST";
             HandleResult result = handler.handleMessage(message, "/dev/ttyUSB0", null);
 
             assertFalse(result.success());
-            assertTrue(result.message().contains("500"));
+            assertEquals("Routing failed", result.message());
         }
 
         @Test
-        @DisplayName("Should handle connection refused")
-        void shouldHandleConnectionRefused() {
-            // Stop the server to simulate connection refused
-            httpServer.stop(0);
+        @DisplayName("Should return success when normalizer returns true")
+        void shouldReturnSuccessWhenNormalizerReturnsTrue() {
+            when(mockNormalizer.process(any(MessageEnvelope.class))).thenReturn(true);
 
             String message = "H|\\^&|||TEST";
             HandleResult result = handler.handleMessage(message, "/dev/ttyUSB0", null);
 
-            assertFalse(result.success());
-            assertTrue(result.message().contains("Error") || result.message().contains("refused"));
-        }
-    }
-
-    @Nested
-    @DisplayName("Authentication Tests")
-    class AuthenticationTests {
-
-        @Test
-        @DisplayName("Should include basic auth when configured")
-        void shouldIncludeBasicAuthWhenConfigured() throws IOException {
-            // Set up auth
-            httpConfig.setUsername("testuser");
-            httpConfig.setPassword("testpass".toCharArray());
-            handler = new SerialMessageHandler(httpConfig);
-
-            AtomicReference<String> receivedAuth = new AtomicReference<>();
-            httpServer.createContext("/api/OpenELIS-Global/analyzer/astm", exchange -> {
-                receivedAuth.set(exchange.getRequestHeaders().getFirst("Authorization"));
-                exchange.sendResponseHeaders(200, 2);
-                try (OutputStream os = exchange.getResponseBody()) {
-                    os.write("OK".getBytes());
-                }
-            });
-
-            String message = "H|\\^&|||TEST";
-            handler.handleMessage(message, "/dev/ttyUSB0", null);
-
-            assertNotNull(receivedAuth.get());
-            assertTrue(receivedAuth.get().startsWith("Basic "));
-        }
-
-        @Test
-        @DisplayName("Should not include auth when not configured")
-        void shouldNotIncludeAuthWhenNotConfigured() throws IOException {
-            AtomicReference<String> receivedAuth = new AtomicReference<>();
-            httpServer.createContext("/api/OpenELIS-Global/analyzer/astm", exchange -> {
-                receivedAuth.set(exchange.getRequestHeaders().getFirst("Authorization"));
-                exchange.sendResponseHeaders(200, 2);
-                try (OutputStream os = exchange.getResponseBody()) {
-                    os.write("OK".getBytes());
-                }
-            });
-
-            String message = "H|\\^&|||TEST";
-            handler.handleMessage(message, "/dev/ttyUSB0", null);
-
-            assertNull(receivedAuth.get());
+            assertTrue(result.success());
+            assertEquals("Routed via normalizer", result.message());
         }
     }
 
@@ -321,7 +237,10 @@ class SerialMessageHandlerTest {
             HandleResult result = handler.handleMessage(astmMessage, "/dev/ttyUSB0", "MINDRAY-001");
 
             assertTrue(result.success());
-            assertEquals(astmMessage, receivedBody.get());
+            verify(mockNormalizer).process(argThat(envelope ->
+                astmMessage.equals(envelope.getRawMessage()) &&
+                "MINDRAY-001".equals(envelope.getAnalyzerId())
+            ));
         }
 
         @Test
@@ -340,8 +259,10 @@ class SerialMessageHandlerTest {
             HandleResult result = handler.handleMessage(hl7Message, "/dev/ttyUSB0", null);
 
             assertTrue(result.success());
-            assertEquals("/api/OpenELIS-Global/analyzer/hl7", receivedPath.get());
-            assertEquals(hl7Message, receivedBody.get());
+            verify(mockNormalizer).process(argThat(envelope ->
+                envelope.getProtocol() == Protocol.HL7 &&
+                hl7Message.equals(envelope.getRawMessage())
+            ));
         }
 
         @Test
@@ -354,7 +275,9 @@ class SerialMessageHandlerTest {
             HandleResult result = handler.handleMessage(message, "/dev/ttyUSB0", null);
 
             assertTrue(result.success());
-            assertEquals(message, receivedBody.get());
+            verify(mockNormalizer).process(argThat(envelope ->
+                message.equals(envelope.getRawMessage())
+            ));
         }
 
         @Test
@@ -375,7 +298,9 @@ class SerialMessageHandlerTest {
             HandleResult result = handler.handleMessage(message, "/dev/ttyUSB0", null);
 
             assertTrue(result.success());
-            assertEquals(message, receivedBody.get());
+            verify(mockNormalizer).process(argThat(envelope ->
+                message.equals(envelope.getRawMessage())
+            ));
         }
     }
 }


### PR DESCRIPTION
## Summary

- Implements the M7 Message Normalizer milestone: a central orchestration layer (MessageNormalizer, AnalyzerIdentifier, HttpForwardingRouter) that all 5 transport listeners (ASTM TCP, MLLP, Serial, File, HTTP Input) route through for consistent forwarding, retry/backoff, analyzer identification, and audit logging.
- Refactors Serial, File, HTTP Input, and ASTM TCP handlers to delegate to the normalizer instead of doing direct HTTP forwarding.
- Hardens security: removes PHI from trace logs, fixes credential handling in health indicator, adds defensive validation, makes `X-Source-Analyzer-IP` conditional on IP-like sources, and enforces consistent UNKNOWN protocol handling (route to `/raw`).
- Adds comprehensive tests: UnifiedRoutingTest (integration, all 5 transports), MessageNormalizerTest, AnalyzerIdentifierTest, ASTMBridgeAdapterTest, AnalyzerRegistryConfigTest, plus updates to existing Serial and Controller tests.

## Test plan

- [x] `mvn clean test` passes (254+ tests, 0 failures)
- [x] UnifiedRoutingTest verifies all 5 transports route through normalizer with correct path, headers, and metadata
- [x] AnalyzerRegistryConfigTest verifies glob matching works for file names and full paths
- [x] AnalyzerInputControllerTest updated for UNKNOWN-as-raw routing
- [x] SerialIntegrationTest updated for M7 pipeline wiring
- [x] Security: no raw message payloads in logs, no String from char[] password, defensive null checks


Made with [Cursor](https://cursor.com)