### PR TITLE
chore: complete astm-http-bridge → openelis-analyzer-bridge rename

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,4 +1,4 @@
 # Enable auto-env through sdkman_auto_env=true in ~/.sdkman/etc/config
-# Required Java version for astm-http-bridge
+# Required Java version for openelis-analyzer-bridge
 java=21.0.5-tem
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,14 +37,14 @@ RUN chown astm:astm /app
 
 
 #Deploy the jar into java image
-COPY --from=build /build/target/*.jar /app/astm-http-bridge.jar
+COPY --from=build /build/target/*.jar /app/openelis-analyzer-bridge.jar
 
 ADD healthcheck.sh /app/healthcheck.sh
 ADD docker-entrypoint.sh /app/docker-entrypoint.sh
 RUN chown astm:astm /app/docker-entrypoint.sh; \
   chmod 770 /app/docker-entrypoint.sh;  \
-  chown astm:astm /app/astm-http-bridge.jar; \
-  chmod 770 /app/astm-http-bridge.jar; \
+  chown astm:astm /app/openelis-analyzer-bridge.jar; \
+  chmod 770 /app/openelis-analyzer-bridge.jar; \
   chown astm:astm /app/healthcheck.sh; \
   chmod 770 /app/healthcheck.sh;
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -37,14 +37,14 @@ RUN mkdir /app
 RUN chown astm:astm /app 
 
 #Deploy the jar into java image
-COPY --from=build /build/target/*.jar /app/astm-http-bridge.jar
+COPY --from=build /build/target/*.jar /app/openelis-analyzer-bridge.jar
 
 ADD healthcheck.sh /app/healthcheck.sh
 ADD docker-entrypoint.sh /app/docker-entrypoint.sh
 RUN chown astm:astm /app/docker-entrypoint.sh; \
   chmod 770 /app/docker-entrypoint.sh;  \
-  chown astm:astm /app/astm-http-bridge.jar; \
-  chmod 770 /app/astm-http-bridge.jar; \
+  chown astm:astm /app/openelis-analyzer-bridge.jar; \
+  chmod 770 /app/openelis-analyzer-bridge.jar; \
   chown astm:astm /app/healthcheck.sh; \
   chmod 770 /app/healthcheck.sh; 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Middleware that receives analyzer messages over multiple **protocols/transports** and forwards them to **OpenELIS via HTTP**.
 
-This repository was previously named **ASTM-HTTP Bridge**. For **backward compatibility**, some technical identifiers (Maven `artifactId`, jar filename, and some Docker/Compose service naming) still use `astm-http-bridge`.
+This repository was previously named **ASTM-HTTP Bridge**. The internal rename to `openelis-analyzer-bridge` is complete across Maven, Docker, and scripts. The Docker Hub image `itechuw/astm-http-bridge` is still published as a legacy alias via CI.
 
 ## Architecture
 
@@ -41,7 +41,7 @@ git clone https://github.com/DIGI-UW/openelis-analyzer-bridge.git
 cd openelis-analyzer-bridge
 
 docker compose up -d --build
-docker logs --follow astm-http-bridge
+docker logs --follow openelis-analyzer-bridge
 ```
 
 ### Building from Source
@@ -53,7 +53,7 @@ mvn clean install
 cd ..
 mvn clean package
 
-java -jar target/astm-http-bridge-*.jar --spring.config.location=configuration.yml
+java -jar target/openelis-analyzer-bridge-*.jar --spring.config.location=configuration.yml
 ```
 
 ## Docker Deployment

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -26,12 +26,12 @@ x-loki-logging:
               - swarm_stack
 
 services:
-  astm-http-bridge:
-    container_name: astm-http-bridge
+  openelis-analyzer-bridge:
+    container_name: openelis-analyzer-bridge
     build:
       context: .
       dockerfile: ./Dockerfile.dev
-    image: astm-http-bridge
+    image: openelis-analyzer-bridge
     ports:
       - "8442:8443"
       - "12000:12001"

--- a/docker-compose-devhub.yml
+++ b/docker-compose-devhub.yml
@@ -7,8 +7,8 @@ x-logging: &local-logging
     max-file: "50"
 
 services:
-  astm-http-bridge:
-    container_name: astm-http-bridge
+  openelis-analyzer-bridge:
+    container_name: openelis-analyzer-bridge
     image: itechuw/openelis-analyzer-bridge:develop
     pull_policy: always
     ports:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -5,8 +5,8 @@ version: '3.8'
 # Uses WireMock as capture server for request verification
 
 services:
-  # ASTM-HTTP Bridge (under test)
-  astm-http-bridge:
+  # OpenELIS Analyzer Bridge (under test)
+  openelis-analyzer-bridge:
     build: .
     ports:
       - "12001:12001"   # ASTM LIS1-A listener

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,8 @@ x-logging: &local-logging
     max-file: "50"
 
 services:
-  astm-http-bridge:
-    container_name: astm-http-bridge
+  openelis-analyzer-bridge:
+    container_name: openelis-analyzer-bridge
     image: itechuw/openelis-analyzer-bridge:latest
     pull_policy: always
     ports:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,4 +3,4 @@ if [ -n "${SPRING_PROFILE}" ];then
 	JAVA_OPTS="${JAVA_OPTS} -Dspring.profiles.active=${SPRING_PROFILE}"
 fi
 
-exec java ${JAVA_OPTS} -jar /app/astm-http-bridge.jar
+exec java ${JAVA_OPTS} -jar /app/openelis-analyzer-bridge.jar

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "astm-http-bridge",
+  "name": "openelis-analyzer-bridge",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.itech</groupId>
-	<artifactId>astm-http-bridge</artifactId>
+	<artifactId>openelis-analyzer-bridge</artifactId>
 	<version>3.0.0</version>
 	<name>openelis-analyzer-bridge</name>
 	<description>OpenELIS Analyzer Bridge: transports/protocol mediation (ASTM, HL7/MLLP, serial, file) forwarding analyzer messages to OpenELIS via HTTP.</description>

--- a/scripts/e2e-tests/run-all.sh
+++ b/scripts/e2e-tests/run-all.sh
@@ -24,7 +24,7 @@ TIMEOUT=60
 ELAPSED=0
 while [ $ELAPSED -lt $TIMEOUT ]; do
     if docker compose -f docker-compose.test.yml ps --format json 2>/dev/null | \
-       jq -e 'select(.Service == "astm-http-bridge" and .Health == "healthy")' > /dev/null 2>&1; then
+       jq -e 'select(.Service == "openelis-analyzer-bridge" and .Health == "healthy")' > /dev/null 2>&1; then
         echo "Bridge is healthy!"
         break
     fi
@@ -35,7 +35,7 @@ done
 
 if [ $ELAPSED -ge $TIMEOUT ]; then
     echo "ERROR: Bridge did not become healthy within ${TIMEOUT}s"
-    docker compose -f docker-compose.test.yml logs astm-http-bridge | tail -30
+    docker compose -f docker-compose.test.yml logs openelis-analyzer-bridge | tail -30
     docker compose -f docker-compose.test.yml down
     exit 1
 fi

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -35,7 +35,7 @@ main() {
 
     # Step 1: Build the bridge
     log_info "Step 1: Building ASTM-HTTP Bridge..."
-    docker compose -f docker-compose.test.yml build astm-http-bridge
+    docker compose -f docker-compose.test.yml build openelis-analyzer-bridge
     
     # Step 2: Start test environment
     log_info "Step 2: Starting test environment..."
@@ -47,11 +47,11 @@ main() {
     
     # Step 3: Verify bridge is running
     log_info "Step 3: Verifying bridge health..."
-    if docker compose -f docker-compose.test.yml exec -T astm-http-bridge wget -q -O - http://localhost:8443/actuator/health | grep -q "UP"; then
+    if docker compose -f docker-compose.test.yml exec -T openelis-analyzer-bridge wget -q -O - http://localhost:8443/actuator/health | grep -q "UP"; then
         log_info "Bridge is healthy"
     else
         log_error "Bridge health check failed"
-        docker compose -f docker-compose.test.yml logs astm-http-bridge
+        docker compose -f docker-compose.test.yml logs openelis-analyzer-bridge
         exit 1
     fi
     
@@ -89,7 +89,7 @@ main() {
     
     # Step 5: View logs
     log_info "Step 5: Bridge logs (last 20 lines):"
-    docker compose -f docker-compose.test.yml logs --tail=20 astm-http-bridge
+    docker compose -f docker-compose.test.yml logs --tail=20 openelis-analyzer-bridge
     
     echo ""
     log_info "=== Integration Tests Complete ==="


### PR DESCRIPTION
## Summary
- Renames all internal `astm-http-bridge` references to `openelis-analyzer-bridge` to match the GitHub repo name
- Maven artifactId, Docker service/container names, JAR filenames, shell scripts, README
- `LEGACY_DOCKER_NAME` in CI workflows intentionally kept for backward compat with Docker Hub consumers

## Files changed (13)
- `pom.xml` — artifactId
- `Dockerfile`, `Dockerfile.dev`, `docker-entrypoint.sh` — JAR refs
- 4 docker-compose files — service/container names
- `scripts/integration-test.sh`, `scripts/e2e-tests/run-all.sh` — service refs
- `package-lock.json`, `.sdkmanrc`, `README.md` — metadata/docs

## Test plan
- [ ] `mvn test` passes (no code changes, only naming)
- [ ] `docker compose -f docker-compose.test.yml build` succeeds
- [ ] Bridge starts with `docker compose up -d`

🤖 Generated with [Claude Code](https://claude.com/claude-code)