### PR TITLE
fix: forward source port in X-Source-Port header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ build/
 .classpath
 bin
 node_modules
+/id_file
 
 # Test tools (cloned separately)
 tools/astm-mock-server/

--- a/src/main/java/org/itech/ahb/controller/AnalyzerInputController.java
+++ b/src/main/java/org/itech/ahb/controller/AnalyzerInputController.java
@@ -110,11 +110,15 @@ public class AnalyzerInputController {
                 log.warn("Unable to detect protocol for message from {}, routing as raw", sourceIp);
             }
 
+            // Extract source port from HTTP request
+            int sourcePort = request.getRemotePort();
+
             // Create MessageEnvelope
             MessageEnvelope envelope = MessageEnvelope.builder()
                     .protocol(protocol)
                     .transport(Transport.HTTP)
                     .sourceId(sourceIp)
+                    .sourcePort(sourcePort)
                     .rawMessage(requestBody)
                     .build();
 

--- a/src/main/java/org/itech/ahb/controller/AnalyzerInputController.java
+++ b/src/main/java/org/itech/ahb/controller/AnalyzerInputController.java
@@ -76,7 +76,8 @@ public class AnalyzerInputController {
      * @param requestBody the raw message content (ASTM, HL7, or CSV)
      * @param contentType the Content-Type header (optional, used for protocol hints)
      * @param xForwardedFor the X-Forwarded-For header (optional, for proxy scenarios)
-     * @param request the HTTP servlet request (for extracting remote address)
+     * @param xForwardedPort the X-Forwarded-Port header (optional, for proxy scenarios)
+     * @param request the HTTP servlet request (for extracting remote address and port)
      * @return ResponseEntity with envelope details or error message
      */
     @PostMapping(consumes = MediaType.ALL_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
@@ -84,6 +85,7 @@ public class AnalyzerInputController {
             @RequestBody(required = false) String requestBody,
             @RequestHeader(value = "Content-Type", required = false) String contentType,
             @RequestHeader(value = "X-Forwarded-For", required = false) String xForwardedFor,
+            @RequestHeader(value = "X-Forwarded-Port", required = false) String xForwardedPort,
             HttpServletRequest request) {
 
         log.debug("Received HTTP input request");
@@ -110,8 +112,9 @@ public class AnalyzerInputController {
                 log.warn("Unable to detect protocol for message from {}, routing as raw", sourceIp);
             }
 
-            // Extract source port from HTTP request
-            int sourcePort = request.getRemotePort();
+            // Extract source port: prefer X-Forwarded-Port when request is proxied,
+            // fall back to the TCP remote port for direct connections.
+            Integer sourcePort = extractSourcePort(xForwardedFor, xForwardedPort, request);
 
             // Create MessageEnvelope
             MessageEnvelope envelope = MessageEnvelope.builder()
@@ -186,6 +189,53 @@ public class AnalyzerInputController {
         // Fall back to remote address
         String remoteAddr = request.getRemoteAddr();
         return remoteAddr != null ? remoteAddr : "unknown";
+    }
+
+    /**
+     * Extracts the source port for the originating client.
+     * <p>
+     * Priority:
+     * <ol>
+     *   <li>{@code X-Forwarded-Port} header — used when the request is forwarded by a proxy
+     *       (i.e. {@code X-Forwarded-For}, {@code X-Real-IP} or {@code X-Forwarded-Port}
+     *       is present). The proxy's TCP port is not meaningful for analyzer identification,
+     *       so {@code null} is returned when proxied and no port header is present.</li>
+     *   <li>{@code request.getRemotePort()} — used for direct (non-proxied) connections where
+     *       the TCP remote port reliably reflects the analyzer's port.</li>
+     * </ol>
+     * </p>
+     *
+     * @param xForwardedFor the X-Forwarded-For header value
+     * @param xForwardedPort the X-Forwarded-Port header value (original client port set by proxy)
+     * @param request the HTTP servlet request
+     * @return the source port, or {@code null} if proxied and no port header is available
+     */
+    Integer extractSourcePort(String xForwardedFor, String xForwardedPort, HttpServletRequest request) {
+        boolean hasXForwardedFor = xForwardedFor != null && !xForwardedFor.trim().isEmpty();
+        String xRealIp = request.getHeader("X-Real-IP");
+        boolean hasXRealIp = xRealIp != null && !xRealIp.trim().isEmpty();
+        boolean hasXForwardedPort = xForwardedPort != null && !xForwardedPort.trim().isEmpty();
+        boolean isProxied = hasXForwardedFor || hasXRealIp || hasXForwardedPort;
+
+        if (isProxied) {
+            // When proxied, request.getRemotePort() reflects the proxy's TCP port, not the
+            // original client's port. Use X-Forwarded-Port if available; otherwise unknown.
+            if (hasXForwardedPort) {
+                try {
+                    int parsedPort = Integer.parseInt(xForwardedPort.trim());
+                    if (parsedPort >= 1 && parsedPort <= 65_535) {
+                        return parsedPort;
+                    }
+                    log.warn("Out-of-range X-Forwarded-Port value: {}", xForwardedPort);
+                } catch (NumberFormatException e) {
+                    log.warn("Invalid X-Forwarded-Port value: {}", xForwardedPort);
+                }
+            }
+            return null;
+        }
+
+        // Direct connection: the TCP remote port is the analyzer's port
+        return request.getRemotePort();
     }
 
     /**

--- a/src/main/java/org/itech/ahb/controller/AnalyzerInputController.java
+++ b/src/main/java/org/itech/ahb/controller/AnalyzerInputController.java
@@ -235,7 +235,12 @@ public class AnalyzerInputController {
         }
 
         // Direct connection: the TCP remote port is the analyzer's port
-        return request.getRemotePort();
+        int remotePort = request.getRemotePort();
+        if (remotePort >= 1 && remotePort <= 65_535) {
+            return remotePort;
+        }
+        log.warn("Out-of-range remote port from direct connection: {}", remotePort);
+        return null;
     }
 
     /**

--- a/src/main/java/org/itech/ahb/mllp/HapiReceivingApplication.java
+++ b/src/main/java/org/itech/ahb/mllp/HapiReceivingApplication.java
@@ -87,11 +87,15 @@ public class HapiReceivingApplication implements ReceivingApplication<Message> {
                 sourceIp, analyzerId, rawMessage != null ? rawMessage.length() : 0);
             log.trace("HL7 message received ({} bytes)", rawMessage != null ? rawMessage.length() : 0);
 
+            // Extract source port from HAPI metadata
+            Integer sourcePort = extractSourcePort(metadata);
+
             // Create MessageEnvelope for routing
             MessageEnvelope envelope = MessageEnvelope.builder()
                 .protocol(Protocol.HL7)
                 .transport(Transport.MLLP)
                 .sourceId(sourceIp)
+                .sourcePort(sourcePort)
                 .rawMessage(rawMessage)
                 .receivedAt(Instant.now())
                 .analyzerId(analyzerId)
@@ -143,6 +147,27 @@ public class HapiReceivingApplication implements ReceivingApplication<Message> {
 
         log.warn("Could not extract source IP from HAPI metadata (keys: {})", metadata.keySet());
         return "unknown";
+    }
+
+    /**
+     * Extracts the source port number from HAPI connection metadata.
+     *
+     * @param metadata the HAPI metadata map
+     * @return the source port, or null if not available
+     */
+    Integer extractSourcePort(Map<String, Object> metadata) {
+        Object sendingPort = metadata.get(META_SENDING_PORT);
+        if (sendingPort instanceof Integer) {
+            return (Integer) sendingPort;
+        }
+        if (sendingPort != null) {
+            try {
+                return Integer.parseInt(sendingPort.toString());
+            } catch (NumberFormatException e) {
+                log.debug("Could not parse SENDING_PORT: {}", sendingPort);
+            }
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/org/itech/ahb/normalizer/MessageEnvelope.java
+++ b/src/main/java/org/itech/ahb/normalizer/MessageEnvelope.java
@@ -56,4 +56,13 @@ public class MessageEnvelope {
      * Optional analyzer identifier (if pre-configured or detected from message headers)
      */
     private final String analyzerId;
+
+    /**
+     * Source port number (TCP/MLLP: remote port from connection metadata; HTTP: remote port from request)
+     * <p>
+     * Forwarded to OpenELIS as {@code X-Source-Port} for deterministic analyzer identification
+     * when combined with sourceId (IP address).
+     * </p>
+     */
+    private final Integer sourcePort;
 }

--- a/src/main/java/org/itech/ahb/normalizer/MessageNormalizer.java
+++ b/src/main/java/org/itech/ahb/normalizer/MessageNormalizer.java
@@ -142,6 +142,7 @@ public class MessageNormalizer implements MessageRouter {
                 .protocol(envelope.getProtocol())
                 .transport(envelope.getTransport())
                 .sourceId(envelope.getSourceId())
+                .sourcePort(envelope.getSourcePort())
                 .rawMessage(envelope.getRawMessage())
                 .receivedAt(envelope.getReceivedAt())
                 .analyzerId(analyzerId)

--- a/src/main/java/org/itech/ahb/routing/HttpForwardingRouter.java
+++ b/src/main/java/org/itech/ahb/routing/HttpForwardingRouter.java
@@ -69,6 +69,9 @@ public class HttpForwardingRouter implements MessageRouter {
     /** HTTP header for source analyzer IP (for backward compatibility with ASTM) */
     public static final String HEADER_SOURCE_ANALYZER_IP = "X-Source-Analyzer-IP";
 
+    /** HTTP header for source port number */
+    public static final String HEADER_SOURCE_PORT = "X-Source-Port";
+
     private static final Pattern IPV4_PATTERN =
         Pattern.compile("^(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)){3}$");
     private static final Pattern IPV6_PATTERN =
@@ -300,6 +303,11 @@ public class HttpForwardingRouter implements MessageRouter {
         // Add analyzer ID header if available
         if (envelope.getAnalyzerId() != null && !envelope.getAnalyzerId().isEmpty()) {
             builder.header(HEADER_ANALYZER_ID, envelope.getAnalyzerId());
+        }
+
+        // Add source port header if available
+        if (envelope.getSourcePort() != null) {
+            builder.header(HEADER_SOURCE_PORT, String.valueOf(envelope.getSourcePort()));
         }
 
         // Backward compatibility: only set when sourceId looks like an IP address

--- a/src/main/java/org/itech/ahb/routing/HttpForwardingRouter.java
+++ b/src/main/java/org/itech/ahb/routing/HttpForwardingRouter.java
@@ -39,6 +39,7 @@ import org.springframework.stereotype.Component;
  *   <li>X-Source-Protocol: From envelope.protocol</li>
  *   <li>X-Source-Transport: From envelope.transport</li>
  *   <li>X-Source-Id: From envelope.sourceId</li>
+ *   <li>X-Source-Port: From envelope.sourcePort (when available)</li>
  *   <li>X-Source-Analyzer-IP: From envelope.sourceId (backward compatibility)</li>
  * </ul>
  * </p>

--- a/src/test/java/org/itech/ahb/controller/AnalyzerInputControllerTest.java
+++ b/src/test/java/org/itech/ahb/controller/AnalyzerInputControllerTest.java
@@ -72,7 +72,7 @@ class AnalyzerInputControllerTest {
         @DisplayName("Should detect HL7 from application/hl7-v2 Content-Type")
         void shouldDetectHL7FromContentType() {
             ResponseEntity<AnalyzerInputController.InputResponse> response =
-                    controller.receiveAnalyzerMessage(SAMPLE_HL7_MESSAGE, "application/hl7-v2", null, mockRequest);
+                    controller.receiveAnalyzerMessage(SAMPLE_HL7_MESSAGE, "application/hl7-v2", null, null, mockRequest);
 
             assertEquals(HttpStatus.OK, response.getStatusCode());
             assertNotNull(response.getBody());
@@ -84,7 +84,7 @@ class AnalyzerInputControllerTest {
         @DisplayName("Should detect HL7 from x-application/hl7-v2 Content-Type")
         void shouldDetectHL7FromAltContentType() {
             ResponseEntity<AnalyzerInputController.InputResponse> response =
-                    controller.receiveAnalyzerMessage(SAMPLE_HL7_MESSAGE, "x-application/hl7-v2", null, mockRequest);
+                    controller.receiveAnalyzerMessage(SAMPLE_HL7_MESSAGE, "x-application/hl7-v2", null, null, mockRequest);
 
             assertEquals(HttpStatus.OK, response.getStatusCode());
             assertNotNull(response.getBody());
@@ -95,7 +95,7 @@ class AnalyzerInputControllerTest {
         @DisplayName("Should detect CSV from text/csv Content-Type")
         void shouldDetectCSVFromContentType() {
             ResponseEntity<AnalyzerInputController.InputResponse> response =
-                    controller.receiveAnalyzerMessage(SAMPLE_CSV_MESSAGE, "text/csv", null, mockRequest);
+                    controller.receiveAnalyzerMessage(SAMPLE_CSV_MESSAGE, "text/csv", null, null, mockRequest);
 
             assertEquals(HttpStatus.OK, response.getStatusCode());
             assertNotNull(response.getBody());
@@ -106,7 +106,7 @@ class AnalyzerInputControllerTest {
         @DisplayName("Should detect CSV from application/csv Content-Type")
         void shouldDetectCSVFromApplicationCsvContentType() {
             ResponseEntity<AnalyzerInputController.InputResponse> response =
-                    controller.receiveAnalyzerMessage(SAMPLE_CSV_MESSAGE, "application/csv", null, mockRequest);
+                    controller.receiveAnalyzerMessage(SAMPLE_CSV_MESSAGE, "application/csv", null, null, mockRequest);
 
             assertEquals(HttpStatus.OK, response.getStatusCode());
             assertNotNull(response.getBody());
@@ -117,7 +117,7 @@ class AnalyzerInputControllerTest {
         @DisplayName("Should handle Content-Type with charset parameter")
         void shouldHandleContentTypeWithCharset() {
             ResponseEntity<AnalyzerInputController.InputResponse> response =
-                    controller.receiveAnalyzerMessage(SAMPLE_HL7_MESSAGE, "application/hl7-v2; charset=utf-8", null, mockRequest);
+                    controller.receiveAnalyzerMessage(SAMPLE_HL7_MESSAGE, "application/hl7-v2; charset=utf-8", null, null, mockRequest);
 
             assertEquals(HttpStatus.OK, response.getStatusCode());
             assertNotNull(response.getBody());
@@ -128,7 +128,7 @@ class AnalyzerInputControllerTest {
         @DisplayName("Should detect ASTM from astm content type")
         void shouldDetectASTMFromContentType() {
             ResponseEntity<AnalyzerInputController.InputResponse> response =
-                    controller.receiveAnalyzerMessage(SAMPLE_ASTM_MESSAGE, "application/x-astm", null, mockRequest);
+                    controller.receiveAnalyzerMessage(SAMPLE_ASTM_MESSAGE, "application/x-astm", null, null, mockRequest);
 
             assertEquals(HttpStatus.OK, response.getStatusCode());
             assertNotNull(response.getBody());
@@ -144,7 +144,7 @@ class AnalyzerInputControllerTest {
         @DisplayName("Should auto-detect ASTM from message content")
         void shouldAutoDetectASTM() {
             ResponseEntity<AnalyzerInputController.InputResponse> response =
-                    controller.receiveAnalyzerMessage(SAMPLE_ASTM_MESSAGE, "text/plain", null, mockRequest);
+                    controller.receiveAnalyzerMessage(SAMPLE_ASTM_MESSAGE, "text/plain", null, null, mockRequest);
 
             assertEquals(HttpStatus.OK, response.getStatusCode());
             assertNotNull(response.getBody());
@@ -155,7 +155,7 @@ class AnalyzerInputControllerTest {
         @DisplayName("Should auto-detect HL7 from message content (text/plain)")
         void shouldAutoDetectHL7() {
             ResponseEntity<AnalyzerInputController.InputResponse> response =
-                    controller.receiveAnalyzerMessage(SAMPLE_HL7_MESSAGE, "text/plain", null, mockRequest);
+                    controller.receiveAnalyzerMessage(SAMPLE_HL7_MESSAGE, "text/plain", null, null, mockRequest);
 
             assertEquals(HttpStatus.OK, response.getStatusCode());
             assertNotNull(response.getBody());
@@ -166,7 +166,7 @@ class AnalyzerInputControllerTest {
         @DisplayName("Should auto-detect CSV from message content (text/plain)")
         void shouldAutoDetectCSV() {
             ResponseEntity<AnalyzerInputController.InputResponse> response =
-                    controller.receiveAnalyzerMessage(SAMPLE_CSV_MESSAGE, "text/plain", null, mockRequest);
+                    controller.receiveAnalyzerMessage(SAMPLE_CSV_MESSAGE, "text/plain", null, null, mockRequest);
 
             assertEquals(HttpStatus.OK, response.getStatusCode());
             assertNotNull(response.getBody());
@@ -178,7 +178,7 @@ class AnalyzerInputControllerTest {
         void shouldAutoDetectASTMWithSTX() {
             String astmWithSTX = "\u0002" + SAMPLE_ASTM_MESSAGE;
             ResponseEntity<AnalyzerInputController.InputResponse> response =
-                    controller.receiveAnalyzerMessage(astmWithSTX, "text/plain", null, mockRequest);
+                    controller.receiveAnalyzerMessage(astmWithSTX, "text/plain", null, null, mockRequest);
 
             assertEquals(HttpStatus.OK, response.getStatusCode());
             assertNotNull(response.getBody());
@@ -189,7 +189,7 @@ class AnalyzerInputControllerTest {
         @DisplayName("Should auto-detect when Content-Type is null")
         void shouldAutoDetectWithNullContentType() {
             ResponseEntity<AnalyzerInputController.InputResponse> response =
-                    controller.receiveAnalyzerMessage(SAMPLE_HL7_MESSAGE, null, null, mockRequest);
+                    controller.receiveAnalyzerMessage(SAMPLE_HL7_MESSAGE, null, null, null, mockRequest);
 
             assertEquals(HttpStatus.OK, response.getStatusCode());
             assertNotNull(response.getBody());
@@ -205,7 +205,7 @@ class AnalyzerInputControllerTest {
         @DisplayName("Should extract source IP from X-Forwarded-For header")
         void shouldExtractFromXForwardedFor() {
             ResponseEntity<AnalyzerInputController.InputResponse> response =
-                    controller.receiveAnalyzerMessage(SAMPLE_ASTM_MESSAGE, "text/plain", "192.168.1.100", mockRequest);
+                    controller.receiveAnalyzerMessage(SAMPLE_ASTM_MESSAGE, "text/plain", "192.168.1.100", null, mockRequest);
 
             assertEquals(HttpStatus.OK, response.getStatusCode());
             assertNotNull(response.getBody());
@@ -217,7 +217,7 @@ class AnalyzerInputControllerTest {
         void shouldExtractFirstIPFromChain() {
             ResponseEntity<AnalyzerInputController.InputResponse> response =
                     controller.receiveAnalyzerMessage(SAMPLE_ASTM_MESSAGE, "text/plain",
-                            "192.168.1.100, 10.0.0.1, 172.16.0.1", mockRequest);
+                            "192.168.1.100, 10.0.0.1, 172.16.0.1", null, mockRequest);
 
             assertEquals(HttpStatus.OK, response.getStatusCode());
             assertNotNull(response.getBody());
@@ -230,7 +230,7 @@ class AnalyzerInputControllerTest {
             when(mockRequest.getHeader("X-Real-IP")).thenReturn("10.20.30.40");
 
             ResponseEntity<AnalyzerInputController.InputResponse> response =
-                    controller.receiveAnalyzerMessage(SAMPLE_ASTM_MESSAGE, "text/plain", null, mockRequest);
+                    controller.receiveAnalyzerMessage(SAMPLE_ASTM_MESSAGE, "text/plain", null, null, mockRequest);
 
             assertEquals(HttpStatus.OK, response.getStatusCode());
             assertNotNull(response.getBody());
@@ -244,7 +244,7 @@ class AnalyzerInputControllerTest {
 
             ResponseEntity<AnalyzerInputController.InputResponse> response =
                     controller.receiveAnalyzerMessage(SAMPLE_ASTM_MESSAGE, "text/plain",
-                            "192.168.1.100", mockRequest);
+                            "192.168.1.100", null, mockRequest);
 
             assertEquals(HttpStatus.OK, response.getStatusCode());
             assertNotNull(response.getBody());
@@ -255,7 +255,7 @@ class AnalyzerInputControllerTest {
         @DisplayName("Should fall back to remote address when headers are missing")
         void shouldFallBackToRemoteAddress() {
             ResponseEntity<AnalyzerInputController.InputResponse> response =
-                    controller.receiveAnalyzerMessage(SAMPLE_ASTM_MESSAGE, "text/plain", null, mockRequest);
+                    controller.receiveAnalyzerMessage(SAMPLE_ASTM_MESSAGE, "text/plain", null, null, mockRequest);
 
             assertEquals(HttpStatus.OK, response.getStatusCode());
             assertNotNull(response.getBody());
@@ -268,7 +268,7 @@ class AnalyzerInputControllerTest {
             when(mockRequest.getRemoteAddr()).thenReturn(null);
 
             ResponseEntity<AnalyzerInputController.InputResponse> response =
-                    controller.receiveAnalyzerMessage(SAMPLE_ASTM_MESSAGE, "text/plain", null, mockRequest);
+                    controller.receiveAnalyzerMessage(SAMPLE_ASTM_MESSAGE, "text/plain", null, null, mockRequest);
 
             assertEquals(HttpStatus.OK, response.getStatusCode());
             assertNotNull(response.getBody());
@@ -284,7 +284,7 @@ class AnalyzerInputControllerTest {
         @DisplayName("Should return 400 for null request body")
         void shouldRejectNullBody() {
             ResponseEntity<AnalyzerInputController.InputResponse> response =
-                    controller.receiveAnalyzerMessage(null, "text/plain", null, mockRequest);
+                    controller.receiveAnalyzerMessage(null, "text/plain", null, null, mockRequest);
 
             assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
             assertNotNull(response.getBody());
@@ -296,7 +296,7 @@ class AnalyzerInputControllerTest {
         @DisplayName("Should return 400 for empty request body")
         void shouldRejectEmptyBody() {
             ResponseEntity<AnalyzerInputController.InputResponse> response =
-                    controller.receiveAnalyzerMessage("", "text/plain", null, mockRequest);
+                    controller.receiveAnalyzerMessage("", "text/plain", null, null, mockRequest);
 
             assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
             assertNotNull(response.getBody());
@@ -308,7 +308,7 @@ class AnalyzerInputControllerTest {
         @DisplayName("Should return 400 for whitespace-only request body")
         void shouldRejectWhitespaceBody() {
             ResponseEntity<AnalyzerInputController.InputResponse> response =
-                    controller.receiveAnalyzerMessage("   \n\t  ", "text/plain", null, mockRequest);
+                    controller.receiveAnalyzerMessage("   \n\t  ", "text/plain", null, null, mockRequest);
 
             assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
             assertNotNull(response.getBody());
@@ -321,7 +321,7 @@ class AnalyzerInputControllerTest {
         void shouldRouteUnknownProtocol() {
             String unknownMessage = "This is not a valid ASTM, HL7, or CSV message";
             ResponseEntity<AnalyzerInputController.InputResponse> response =
-                    controller.receiveAnalyzerMessage(unknownMessage, "text/plain", null, mockRequest);
+                    controller.receiveAnalyzerMessage(unknownMessage, "text/plain", null, null, mockRequest);
 
             assertEquals(HttpStatus.OK, response.getStatusCode());
             assertNotNull(response.getBody());
@@ -338,7 +338,7 @@ class AnalyzerInputControllerTest {
         @DisplayName("Should include receivedAt timestamp in response")
         void shouldIncludeTimestamp() {
             ResponseEntity<AnalyzerInputController.InputResponse> response =
-                    controller.receiveAnalyzerMessage(SAMPLE_ASTM_MESSAGE, "text/plain", null, mockRequest);
+                    controller.receiveAnalyzerMessage(SAMPLE_ASTM_MESSAGE, "text/plain", null, null, mockRequest);
 
             assertEquals(HttpStatus.OK, response.getStatusCode());
             assertNotNull(response.getBody());
@@ -351,7 +351,7 @@ class AnalyzerInputControllerTest {
         void shouldReturnCompleteSuccessResponse() {
             ResponseEntity<AnalyzerInputController.InputResponse> response =
                     controller.receiveAnalyzerMessage(SAMPLE_HL7_MESSAGE, "application/hl7-v2",
-                            "192.168.1.50", mockRequest);
+                            "192.168.1.50", null, mockRequest);
 
             assertEquals(HttpStatus.OK, response.getStatusCode());
             assertNotNull(response.getBody());
@@ -428,6 +428,52 @@ class AnalyzerInputControllerTest {
             assertEquals("127.0.0.1",
                     controller.extractSourceIp("   ", mockRequest));
         }
+
+        @Test
+        @DisplayName("extractSourcePort should return remote port for direct connection")
+        void extractSourcePortDirectConnection() {
+            when(mockRequest.getRemotePort()).thenReturn(12345);
+            assertEquals(12345, controller.extractSourcePort(null, null, mockRequest));
+            assertEquals(12345, controller.extractSourcePort("", null, mockRequest));
+        }
+
+        @Test
+        @DisplayName("extractSourcePort should use X-Forwarded-Port when proxied")
+        void extractSourcePortProxied() {
+            assertEquals(54321,
+                    controller.extractSourcePort("192.168.1.10", "54321", mockRequest));
+        }
+
+        @Test
+        @DisplayName("extractSourcePort should treat X-Real-IP as proxied")
+        void extractSourcePortXRealIpProxy() {
+            when(mockRequest.getHeader("X-Real-IP")).thenReturn("192.168.1.10");
+            when(mockRequest.getRemotePort()).thenReturn(12345);
+
+            assertEquals(54321, controller.extractSourcePort(null, "54321", mockRequest));
+            assertNull(controller.extractSourcePort(null, null, mockRequest));
+        }
+
+        @Test
+        @DisplayName("extractSourcePort should return null when proxied without X-Forwarded-Port")
+        void extractSourcePortProxiedWithoutForwardedPort() {
+            assertNull(controller.extractSourcePort("192.168.1.10", null, mockRequest));
+            assertNull(controller.extractSourcePort("192.168.1.10", "", mockRequest));
+        }
+
+        @Test
+        @DisplayName("extractSourcePort should return null for invalid X-Forwarded-Port")
+        void extractSourcePortInvalidForwardedPort() {
+            assertNull(controller.extractSourcePort("192.168.1.10", "not-a-number", mockRequest));
+        }
+
+        @Test
+        @DisplayName("extractSourcePort should return null for out-of-range X-Forwarded-Port")
+        void extractSourcePortOutOfRangeForwardedPort() {
+            assertNull(controller.extractSourcePort("192.168.1.10", "0", mockRequest));
+            assertNull(controller.extractSourcePort("192.168.1.10", "-1", mockRequest));
+            assertNull(controller.extractSourcePort("192.168.1.10", "65536", mockRequest));
+        }
     }
 
     @Nested
@@ -438,7 +484,7 @@ class AnalyzerInputControllerTest {
         @DisplayName("Should call normalizer.process() for valid ASTM message")
         void shouldCallNormalizerForValidASTM() {
             ResponseEntity<AnalyzerInputController.InputResponse> response =
-                    controller.receiveAnalyzerMessage(SAMPLE_ASTM_MESSAGE, null, null, mockRequest);
+                    controller.receiveAnalyzerMessage(SAMPLE_ASTM_MESSAGE, null, null, null, mockRequest);
 
             assertEquals(HttpStatus.OK, response.getStatusCode());
             verify(mockNormalizer).process(any(MessageEnvelope.class));
@@ -448,7 +494,7 @@ class AnalyzerInputControllerTest {
         @DisplayName("Should call normalizer.process() for valid HL7 message")
         void shouldCallNormalizerForValidHL7() {
             ResponseEntity<AnalyzerInputController.InputResponse> response =
-                    controller.receiveAnalyzerMessage(SAMPLE_HL7_MESSAGE, "application/hl7-v2", null, mockRequest);
+                    controller.receiveAnalyzerMessage(SAMPLE_HL7_MESSAGE, "application/hl7-v2", null, null, mockRequest);
 
             assertEquals(HttpStatus.OK, response.getStatusCode());
             verify(mockNormalizer).process(any(MessageEnvelope.class));
@@ -458,7 +504,7 @@ class AnalyzerInputControllerTest {
         @DisplayName("Should call normalizer.process() for valid CSV message")
         void shouldCallNormalizerForValidCSV() {
             ResponseEntity<AnalyzerInputController.InputResponse> response =
-                    controller.receiveAnalyzerMessage(SAMPLE_CSV_MESSAGE, "text/csv", null, mockRequest);
+                    controller.receiveAnalyzerMessage(SAMPLE_CSV_MESSAGE, "text/csv", null, null, mockRequest);
 
             assertEquals(HttpStatus.OK, response.getStatusCode());
             verify(mockNormalizer).process(any(MessageEnvelope.class));
@@ -470,7 +516,7 @@ class AnalyzerInputControllerTest {
             when(mockNormalizer.process(any(MessageEnvelope.class))).thenReturn(false);
 
             ResponseEntity<AnalyzerInputController.InputResponse> response =
-                    controller.receiveAnalyzerMessage(SAMPLE_ASTM_MESSAGE, null, null, mockRequest);
+                    controller.receiveAnalyzerMessage(SAMPLE_ASTM_MESSAGE, null, null, null, mockRequest);
 
             assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
             assertNotNull(response.getBody());
@@ -484,7 +530,7 @@ class AnalyzerInputControllerTest {
             when(mockNormalizer.process(any(MessageEnvelope.class))).thenReturn(true);
 
             ResponseEntity<AnalyzerInputController.InputResponse> response =
-                    controller.receiveAnalyzerMessage(SAMPLE_ASTM_MESSAGE, null, null, mockRequest);
+                    controller.receiveAnalyzerMessage(SAMPLE_ASTM_MESSAGE, null, null, null, mockRequest);
 
             assertEquals(HttpStatus.OK, response.getStatusCode());
             assertNotNull(response.getBody());
@@ -496,7 +542,7 @@ class AnalyzerInputControllerTest {
         @DisplayName("Should not call normalizer for empty message")
         void shouldNotCallNormalizerForEmptyMessage() {
             ResponseEntity<AnalyzerInputController.InputResponse> response =
-                    controller.receiveAnalyzerMessage("", null, null, mockRequest);
+                    controller.receiveAnalyzerMessage("", null, null, null, mockRequest);
 
             assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
             verify(mockNormalizer, never()).process(any());
@@ -508,7 +554,7 @@ class AnalyzerInputControllerTest {
             String unknownMessage = "This is some random text that doesnt match any protocol";
 
             ResponseEntity<AnalyzerInputController.InputResponse> response =
-                    controller.receiveAnalyzerMessage(unknownMessage, null, null, mockRequest);
+                    controller.receiveAnalyzerMessage(unknownMessage, null, null, null, mockRequest);
 
             assertEquals(HttpStatus.OK, response.getStatusCode());
             verify(mockNormalizer, times(1)).process(any());

--- a/src/test/java/org/itech/ahb/integration/UnifiedRoutingTest.java
+++ b/src/test/java/org/itech/ahb/integration/UnifiedRoutingTest.java
@@ -87,6 +87,7 @@ class UnifiedRoutingTest {
             String analyzerId = exchange.getRequestHeaders().getFirst(HttpForwardingRouter.HEADER_ANALYZER_ID);
             String sourceAnalyzerIp = exchange.getRequestHeaders().getFirst(
                 HttpForwardingRouter.HEADER_SOURCE_ANALYZER_IP);
+            String sourcePort = exchange.getRequestHeaders().getFirst(HttpForwardingRouter.HEADER_SOURCE_PORT);
 
             String body;
             try (InputStream is = exchange.getRequestBody()) {
@@ -94,7 +95,7 @@ class UnifiedRoutingTest {
             }
 
             lastRequest.set(new CapturedRequest(
-                path, body, sourceProtocol, sourceTransport, sourceId, analyzerId, sourceAnalyzerIp));
+                path, body, sourceProtocol, sourceTransport, sourceId, analyzerId, sourceAnalyzerIp, sourcePort));
             requestLatch.countDown();
 
             try {
@@ -229,11 +230,12 @@ class UnifiedRoutingTest {
         void httpAstmRoutesCorrectly() throws Exception {
             resetLatch();
             when(mockHttpRequest.getRemoteAddr()).thenReturn("192.168.1.10");
+            when(mockHttpRequest.getRemotePort()).thenReturn(0);
             when(mockHttpRequest.getHeader("X-Real-IP")).thenReturn(null);
 
             String astmMessage = "H|\\^&|||TEST|||||||P|1|20260205120000\rP|1||12345\rL|1|N";
 
-            var response = httpController.receiveAnalyzerMessage(astmMessage, null, null, mockHttpRequest);
+            var response = httpController.receiveAnalyzerMessage(astmMessage, null, null, null, mockHttpRequest);
 
             assertEquals(200, response.getStatusCode().value());
             CapturedRequest req = awaitRequest();
@@ -249,12 +251,13 @@ class UnifiedRoutingTest {
         void httpHl7RoutesCorrectly() throws Exception {
             resetLatch();
             when(mockHttpRequest.getRemoteAddr()).thenReturn("192.168.1.20");
+            when(mockHttpRequest.getRemotePort()).thenReturn(0);
             when(mockHttpRequest.getHeader(anyString())).thenReturn(null);
 
             String hl7Message = "MSH|^~\\&|TEST|LAB|OPENELIS|LAB|20260205120000||ORU^R01|MSG001|P|2.5.1\r" +
                     "PID|1||12345\rOBX|1|NM|WBC||7.5";
 
-            var response = httpController.receiveAnalyzerMessage(hl7Message, "application/hl7-v2", null, mockHttpRequest);
+            var response = httpController.receiveAnalyzerMessage(hl7Message, "application/hl7-v2", null, null, mockHttpRequest);
 
             assertEquals(200, response.getStatusCode().value());
             CapturedRequest req = awaitRequest();
@@ -268,11 +271,12 @@ class UnifiedRoutingTest {
         void httpCsvRoutesCorrectly() throws Exception {
             resetLatch();
             when(mockHttpRequest.getRemoteAddr()).thenReturn("192.168.1.30");
+            when(mockHttpRequest.getRemotePort()).thenReturn(0);
             when(mockHttpRequest.getHeader(anyString())).thenReturn(null);
 
             String csvMessage = "SampleID,TestCode,Result\n12345,WBC,7.5\n12346,RBC,4.8";
 
-            var response = httpController.receiveAnalyzerMessage(csvMessage, "text/csv", null, mockHttpRequest);
+            var response = httpController.receiveAnalyzerMessage(csvMessage, "text/csv", null, null, mockHttpRequest);
 
             assertEquals(200, response.getStatusCode().value());
             CapturedRequest req = awaitRequest();
@@ -349,6 +353,125 @@ class UnifiedRoutingTest {
             assertNotNull(req.analyzerId());
             assertTrue(req.analyzerId().contains("ANALYZER-APP"), "X-Analyzer-Id should come from MSH-3");
         }
+
+        @Test
+        @DisplayName("MLLP message with SENDING_PORT metadata forwards X-Source-Port")
+        void mllpForwardsSourcePort() throws Exception {
+            resetLatch();
+            String hl7Message = "MSH|^~\\&|ANALYZER-APP|LAB-FAC|OPENELIS|LAB|20260205120000||ORU^R01|MSG002|P|2.5.1\r" +
+                    "PID|1||12345||Doe^John\r" +
+                    "OBX|1|NM|WBC||7.5|10^3/uL||||F";
+
+            Message message = new PipeParser().parse(hl7Message);
+            java.util.Map<String, Object> metadata = new java.util.HashMap<>();
+            metadata.put("SENDING_IP", "192.168.1.51");
+            metadata.put("SENDING_PORT", 54321);
+            metadata.put("raw-message", hl7Message);
+
+            mllpApplication.processMessage(message, metadata);
+
+            CapturedRequest req = awaitRequest();
+            assertEquals("54321", req.sourcePort(), "X-Source-Port should be forwarded from SENDING_PORT");
+        }
+    }
+
+    @Nested
+    @DisplayName("X-Source-Port Header Tests")
+    class SourcePortHeaderTests {
+
+        @Test
+        @DisplayName("HTTP direct connection forwards X-Source-Port")
+        void httpDirectConnectionForwardsSourcePort() throws Exception {
+            resetLatch();
+            when(mockHttpRequest.getRemoteAddr()).thenReturn("192.168.1.10");
+            when(mockHttpRequest.getRemotePort()).thenReturn(12345);
+            when(mockHttpRequest.getHeader(anyString())).thenReturn(null);
+
+            String astmMessage = "H|\\^&|||TEST|||||||P|1|20260205120000\rP|1||12345\rL|1|N";
+
+            httpController.receiveAnalyzerMessage(astmMessage, null, null, null, mockHttpRequest);
+
+            CapturedRequest req = awaitRequest();
+            assertEquals("12345", req.sourcePort(), "X-Source-Port should be set for direct connections");
+        }
+
+        @Test
+        @DisplayName("HTTP proxied connection uses X-Forwarded-Port when available")
+        void httpProxiedConnectionUsesXForwardedPort() throws Exception {
+            resetLatch();
+
+            String astmMessage = "H|\\^&|||TEST|||||||P|1|20260205120000\rP|1||12345\rL|1|N";
+
+            httpController.receiveAnalyzerMessage(
+                astmMessage, null, "192.168.1.10", "54321", mockHttpRequest);
+
+            CapturedRequest req = awaitRequest();
+            assertEquals("54321", req.sourcePort(), "X-Source-Port should use X-Forwarded-Port for proxied connections");
+        }
+
+        @Test
+        @DisplayName("HTTP proxied connection without X-Forwarded-Port omits X-Source-Port")
+        void httpProxiedConnectionWithoutForwardedPortOmitsSourcePort() throws Exception {
+            resetLatch();
+
+            String astmMessage = "H|\\^&|||TEST|||||||P|1|20260205120000\rP|1||12345\rL|1|N";
+
+            httpController.receiveAnalyzerMessage(
+                astmMessage, null, "192.168.1.10", null, mockHttpRequest);
+
+            CapturedRequest req = awaitRequest();
+            assertNull(req.sourcePort(), "X-Source-Port should be absent when proxied without X-Forwarded-Port");
+        }
+
+        @Test
+        @DisplayName("HTTP X-Real-IP proxy without X-Forwarded-Port omits X-Source-Port")
+        void httpXRealIpProxyWithoutForwardedPortOmitsSourcePort() throws Exception {
+            resetLatch();
+            when(mockHttpRequest.getHeader("X-Real-IP")).thenReturn("192.168.1.10");
+
+            String astmMessage = "H|\\^&|||TEST|||||||P|1|20260205120000\rP|1||12345\rL|1|N";
+
+            httpController.receiveAnalyzerMessage(
+                astmMessage, null, null, null, mockHttpRequest);
+
+            CapturedRequest req = awaitRequest();
+            assertNull(req.sourcePort(), "X-Source-Port should be absent when X-Real-IP indicates a proxied request without X-Forwarded-Port");
+        }
+
+        @Test
+        @DisplayName("HTTP proxied connection with out-of-range X-Forwarded-Port omits X-Source-Port")
+        void httpProxiedConnectionWithInvalidForwardedPortOmitsSourcePort() throws Exception {
+            resetLatch();
+
+            String astmMessage = "H|\\^&|||TEST|||||||P|1|20260205120000\rP|1||12345\rL|1|N";
+
+            httpController.receiveAnalyzerMessage(
+                astmMessage, null, "192.168.1.10", "65536", mockHttpRequest);
+
+            CapturedRequest req = awaitRequest();
+            assertNull(req.sourcePort(), "X-Source-Port should be absent when X-Forwarded-Port is out of range");
+        }
+
+        @Test
+        @DisplayName("X-Source-Port is preserved through normalizer enrichment when analyzerId is set")
+        void sourcePortPreservedThroughNormalizerEnrichment() throws Exception {
+            resetLatch();
+            when(mockHttpRequest.getRemoteAddr()).thenReturn("192.168.1.60");
+            when(mockHttpRequest.getRemotePort()).thenReturn(9999);
+            when(mockHttpRequest.getHeader(anyString())).thenReturn(null);
+
+            // Use an ASTM message that includes a recognizable sender so the normalizer
+            // may attempt to enrich the envelope with an analyzerId
+            String astmMessage = "H|\\^&|||MINDRAY^BC-5380|||||||P|1|20260205120000\r" +
+                    "P|1||PAT001||DOE^JOHN\r" +
+                    "L|1|N";
+
+            httpController.receiveAnalyzerMessage(astmMessage, null, null, null, mockHttpRequest);
+
+            CapturedRequest req = awaitRequest();
+            // The port must survive any normalizer envelope rebuild
+            assertEquals("9999", req.sourcePort(), "X-Source-Port must be preserved through normalizer enrichment");
+        }
     }
 
     private record CapturedRequest(
@@ -358,6 +481,7 @@ class UnifiedRoutingTest {
             String sourceTransport,
             String sourceId,
             String analyzerId,
-            String sourceAnalyzerIp
+            String sourceAnalyzerIp,
+            String sourcePort
     ) {}
 }

--- a/src/test/java/org/itech/ahb/normalizer/MessageNormalizerTest.java
+++ b/src/test/java/org/itech/ahb/normalizer/MessageNormalizerTest.java
@@ -292,5 +292,44 @@ class MessageNormalizerTest {
                 rawMessage.equals(e.getRawMessage())
             ));
         }
+
+        @Test
+        @DisplayName("Should preserve sourcePort in enriched envelope")
+        void shouldPreserveSourcePort() {
+            when(mockIdentifier.identify(any())).thenReturn("ANALYZER-005");
+
+            MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.HL7)
+                .transport(Transport.MLLP)
+                .sourceId("192.168.1.60")
+                .rawMessage("MSH|^~\\&|||")
+                .sourcePort(54321)
+                .build();
+
+            normalizer.process(envelope);
+
+            verify(mockForwardingRouter).route(argThat(e ->
+                Integer.valueOf(54321).equals(e.getSourcePort())
+            ));
+        }
+
+        @Test
+        @DisplayName("Should preserve null sourcePort in enriched envelope")
+        void shouldPreserveNullSourcePort() {
+            when(mockIdentifier.identify(any())).thenReturn("ANALYZER-006");
+
+            MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.ASTM)
+                .transport(Transport.TCP)
+                .sourceId("192.168.1.70")
+                .rawMessage("H|\\^&|||TEST")
+                .build();
+
+            normalizer.process(envelope);
+
+            verify(mockForwardingRouter).route(argThat(e ->
+                e.getSourcePort() == null
+            ));
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add `sourcePort` (Integer) field to `MessageEnvelope`
- Extract source port from HAPI `SENDING_PORT` metadata (MLLP) and `request.getRemotePort()` (HTTP input)
- Forward as `X-Source-Port` HTTP header in `HttpForwardingRouter` alongside existing `X-Source-Id`, `X-Source-Protocol`, `X-Source-Transport` headers

## Motivation
The bridge already sends source-identification headers to OpenELIS but was missing the source port. Combined with [DIGI-UW/OpenELIS-Global-2#TBD](paired PR), this enables deterministic analyzer identification by IP+port instead of fragile regex pattern matching.

## Test plan
- [ ] Verify `mvn test` passes (bridge repo)
- [ ] Verify `X-Source-Port` header is sent in HTTP requests to OpenELIS
- [ ] Integration test with paired OpenELIS PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)