### PR TITLE
feat: analyzer registration API for OE integration

### DIFF
--- a/src/main/java/org/itech/ahb/config/AnalyzerRegistryConfig.java
+++ b/src/main/java/org/itech/ahb/config/AnalyzerRegistryConfig.java
@@ -141,6 +141,44 @@ public class AnalyzerRegistryConfig {
     }
 
     /**
+     * Registers an analyzer by source identifier.
+     * If an entry already exists for the sourceId, it is replaced.
+     *
+     * @param sourceId the source identifier (IP address, serial port, glob pattern)
+     * @param entry    the analyzer entry to register
+     */
+    public void register(String sourceId, AnalyzerEntry entry) {
+        analyzers.put(sourceId, entry);
+        log.info("Registered analyzer '{}' (id={}) for source '{}'",
+                entry.getName(), entry.getId(), sourceId);
+    }
+
+    /**
+     * Unregisters an analyzer by OE analyzer ID.
+     * Removes all source mappings that point to this analyzer.
+     *
+     * @param oeAnalyzerId the OE analyzer ID to unregister
+     * @return true if at least one mapping was removed
+     */
+    public boolean unregisterByAnalyzerId(String oeAnalyzerId) {
+        boolean removed = analyzers.entrySet()
+                .removeIf(e -> oeAnalyzerId.equals(e.getValue().getId()));
+        if (removed) {
+            log.info("Unregistered analyzer with OE ID '{}'", oeAnalyzerId);
+        }
+        return removed;
+    }
+
+    /**
+     * Returns all registered analyzers.
+     *
+     * @return unmodifiable view of the registry
+     */
+    public Map<String, AnalyzerEntry> getRegisteredAnalyzers() {
+        return Map.copyOf(analyzers);
+    }
+
+    /**
      * Analyzer entry with metadata.
      * <p>
      * Contains analyzer identification and configuration information.

--- a/src/main/java/org/itech/ahb/controller/AnalyzerRegistrationController.java
+++ b/src/main/java/org/itech/ahb/controller/AnalyzerRegistrationController.java
@@ -1,0 +1,123 @@
+package org.itech.ahb.controller;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.itech.ahb.config.AnalyzerRegistryConfig;
+import org.itech.ahb.config.AnalyzerRegistryConfig.AnalyzerEntry;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST API for dynamic analyzer registration.
+ * <p>
+ * OpenELIS calls these endpoints when an analyzer is created, updated,
+ * or deleted in the dashboard. The bridge uses the registry to tag incoming
+ * traffic with the correct OE analyzer ID ({@code X-Analyzer-Id} header)
+ * before forwarding to OpenELIS.
+ * </p>
+ * <p>
+ * Registration binds a transport source (IP address, file watch directory,
+ * serial port) to an OE analyzer ID. The bridge only needs the minimum
+ * transport config — all business logic (test mappings, QC rules, etc.)
+ * stays in OpenELIS.
+ * </p>
+ */
+@RestController
+@RequestMapping("/api/analyzers")
+@Slf4j
+public class AnalyzerRegistrationController {
+
+    private final AnalyzerRegistryConfig registry;
+
+    public AnalyzerRegistrationController(AnalyzerRegistryConfig registry) {
+        this.registry = registry;
+    }
+
+    /**
+     * Register an analyzer's transport binding.
+     * <p>
+     * Called by OpenELIS when an analyzer is created or updated. The bridge
+     * stores the mapping and uses it to tag all traffic from the registered
+     * source with the OE analyzer ID.
+     * </p>
+     *
+     * @param request registration payload with transport config
+     * @return registration confirmation
+     */
+    @PostMapping("/register")
+    public ResponseEntity<Map<String, Object>> register(@RequestBody RegistrationRequest request) {
+        if (request.oeAnalyzerId == null || request.oeAnalyzerId.isBlank()) {
+            return ResponseEntity.badRequest().body(Map.of(
+                    "registered", false,
+                    "error", "oeAnalyzerId is required"));
+        }
+        if (request.sourceId == null || request.sourceId.isBlank()) {
+            return ResponseEntity.badRequest().body(Map.of(
+                    "registered", false,
+                    "error", "sourceId is required (IP address, directory path, or serial port)"));
+        }
+
+        AnalyzerEntry entry = new AnalyzerEntry();
+        entry.setId(request.oeAnalyzerId);
+        entry.setName(request.name);
+        entry.setExpectedProtocol(request.protocol);
+        entry.setFilePattern(request.filePattern);
+
+        registry.register(request.sourceId, entry);
+
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("registered", true);
+        response.put("oeAnalyzerId", request.oeAnalyzerId);
+        response.put("sourceId", request.sourceId);
+        response.put("protocol", request.protocol);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * Unregister an analyzer by OE analyzer ID.
+     * Removes all source mappings that point to this analyzer.
+     */
+    @DeleteMapping("/{oeAnalyzerId}")
+    public ResponseEntity<Map<String, Object>> unregister(@PathVariable String oeAnalyzerId) {
+        boolean removed = registry.unregisterByAnalyzerId(oeAnalyzerId);
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("removed", removed);
+        response.put("oeAnalyzerId", oeAnalyzerId);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * List all registered analyzers.
+     */
+    @GetMapping
+    public ResponseEntity<Map<String, AnalyzerEntry>> list() {
+        return ResponseEntity.ok(registry.getRegisteredAnalyzers());
+    }
+
+    /**
+     * Registration request payload.
+     */
+    public static class RegistrationRequest {
+        /** OE analyzer ID (from the analyzer table in OpenELIS) */
+        public String oeAnalyzerId;
+
+        /** Source identifier: IP address for TCP, directory path for FILE, serial port for SERIAL */
+        public String sourceId;
+
+        /** Human-readable analyzer name */
+        public String name;
+
+        /** Expected protocol: ASTM, HL7, CSV */
+        public String protocol;
+
+        /** Optional file pattern for FILE transport (glob or regex) */
+        public String filePattern;
+    }
+}


### PR DESCRIPTION
## Summary

- POST /api/analyzers/register — OE calls this when an analyzer is created in the dashboard
- DELETE /api/analyzers/{oeAnalyzerId} — unregister
- GET /api/analyzers — list registered analyzers
- AnalyzerRegistryConfig: programmatic register/unregister/getAll methods

The bridge stores source→analyzerID mappings and stamps forwarded messages with `X-Analyzer-Id` for deterministic routing. No pattern matching needed.

**Paired with:** DIGI-UW/OpenELIS-Global-2#3070

## Test plan

- [x] All 280 bridge tests pass (3 skipped — serial hardware)
- [ ] E2E: create analyzer in OE → bridge registers → simulator push → results routed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)