### PR TITLE
fix: address PR #13 review comments — actuator rules, default password fail-fast, DelegatingPasswordEncoder, tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ environment:
   BRIDGE_AUTH_PASSWORD: your-secure-password
 ```
 
-Pre-hashed BCrypt passwords are supported: set `bridge.security.password={bcrypt}$2a$10$...` to avoid plaintext in config.
+Pre-encoded passwords are supported using Spring’s delegating form: set `bridge.security.password={bcrypt}$2a$10$...` (or another `{id}...` scheme) and the bridge stores that value as-is. Plaintext values are BCrypt-encoded once at startup—do not double-encode.
 
 ### Disabling Security
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Runtime configuration is read from `configuration.yml` (mounted into container a
 | **Security (M7.1)** | | |
 | `bridge.security.enabled` | Enable HTTP Basic auth on /input | true |
 | `bridge.security.username` | HTTP Basic username | bridge |
-| `bridge.security.password` | HTTP Basic password (use env var) | changeme |
+| `bridge.security.password` | HTTP Basic password: plaintext or `{bcrypt}...` (use env var in prod) | changeme |
 | **Server** | | |
 | `server.port` | HTTP server port | 8443 |
 
@@ -239,7 +239,7 @@ curl -X POST http://localhost:8442/input -d "test"
 
 ### Production Setup
 
-Set the password via environment variable:
+**Required:** Set the password via environment variable. The default `changeme` causes startup failure when `spring.profiles.active` is not `dev` or `test`.
 
 ```bash
 export BRIDGE_AUTH_PASSWORD=your-secure-password
@@ -252,6 +252,8 @@ Or in Docker Compose:
 environment:
   BRIDGE_AUTH_PASSWORD: your-secure-password
 ```
+
+Pre-hashed BCrypt passwords are supported: set `bridge.security.password={bcrypt}$2a$10$...` to avoid plaintext in config.
 
 ### Disabling Security
 

--- a/configuration.yml
+++ b/configuration.yml
@@ -24,6 +24,10 @@ bridge:
   # Security configuration for the /input HTTP endpoint (M7.1)
   # Protects against unauthorized data injection via the HTTP transport.
   # Non-HTTP transports (ASTM/TCP, MLLP, Serial, File) are unaffected.
+  #
+  # Password: Provide plaintext (hashed at runtime) or pre-hashed with {bcrypt} prefix.
+  # In production, set BRIDGE_AUTH_PASSWORD env var. Default 'changeme' fails startup
+  # unless spring.profiles.active includes dev or test.
   security:
     enabled: true                               # Set to false to disable auth (not recommended)
     username: bridge                            # HTTP Basic username

--- a/configuration.yml
+++ b/configuration.yml
@@ -25,7 +25,8 @@ bridge:
   # Protects against unauthorized data injection via the HTTP transport.
   # Non-HTTP transports (ASTM/TCP, MLLP, Serial, File) are unaffected.
   #
-  # Password: Provide plaintext (hashed at runtime) or pre-hashed with {bcrypt} prefix.
+  # Password: Plaintext is BCrypt-encoded once at startup. Values already in delegating form
+  # ({bcrypt}$2a$..., {noop}..., etc.) are stored as-is — do not double-encode.
   # In production, set BRIDGE_AUTH_PASSWORD env var. Default 'changeme' fails startup
   # unless spring.profiles.active includes dev or test.
   security:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,9 @@ services:
     #   - /dev/ttyUSB0:/dev/ttyUSB0
     environment:
       LOGGING_LEVEL_ORG_ITECH: INFO
-      # Production: set BRIDGE_AUTH_PASSWORD; default changeme fails unless profile=dev|test
+      # Local compose defaults to dev so default password is allowed (prod fails fast on changeme).
+      SPRING_PROFILES_ACTIVE: dev
+      # Production: use profile prod and set BRIDGE_AUTH_PASSWORD (or bridge.security.password).
       # BRIDGE_AUTH_PASSWORD: ${BRIDGE_AUTH_PASSWORD}
     logging: *local-logging
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,8 @@ services:
     #   - /dev/ttyUSB0:/dev/ttyUSB0
     environment:
       LOGGING_LEVEL_ORG_ITECH: INFO
+      # Production: set BRIDGE_AUTH_PASSWORD; default changeme fails unless profile=dev|test
+      # BRIDGE_AUTH_PASSWORD: ${BRIDGE_AUTH_PASSWORD}
     logging: *local-logging
     healthcheck:
       test: ["CMD", "/app/healthcheck.sh"]

--- a/src/main/java/org/itech/ahb/config/SecurityConfig.java
+++ b/src/main/java/org/itech/ahb/config/SecurityConfig.java
@@ -1,20 +1,24 @@
 package org.itech.ahb.config;
 
+import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
+
+import java.util.Arrays;
 
 /**
  * Spring Security configuration for the analyzer bridge.
@@ -27,6 +31,12 @@ import org.springframework.security.web.SecurityFilterChain;
  * Enabled by default via {@code bridge.security.enabled=true}. Set to {@code false}
  * to disable authentication (not recommended for production).
  * </p>
+ * <p>
+ * <strong>Password semantics:</strong> The {@code bridge.security.password} property
+ * accepts either plaintext (hashed at runtime with BCrypt) or a pre-hashed value with
+ * {@code {bcrypt}} prefix (e.g. {@code {bcrypt}$2a$10$...}). Use plaintext for simple
+ * deployments; use pre-hashed for secret managers or when rotating without restarts.
+ * </p>
  *
  * @see org.itech.ahb.controller.AnalyzerInputController
  */
@@ -36,11 +46,37 @@ import org.springframework.security.web.SecurityFilterChain;
 @Slf4j
 public class SecurityConfig {
 
+    private static final String DEFAULT_PASSWORD = "changeme";
+
     @Value("${bridge.security.username:bridge}")
     private String username;
 
     @Value("${bridge.security.password:changeme}")
     private String password;
+
+    private final Environment environment;
+
+    public SecurityConfig(Environment environment) {
+        this.environment = environment;
+    }
+
+    @PostConstruct
+    void failFastOnDefaultPasswordInProduction() {
+        if (!DEFAULT_PASSWORD.equals(password)) {
+            return;
+        }
+        boolean isDevOrTest = Arrays.stream(environment.getActiveProfiles())
+                .anyMatch(p -> "dev".equals(p) || "test".equals(p));
+        if (isDevOrTest) {
+            log.warn("Bridge security using default password 'changeme' — acceptable for dev/test only");
+            return;
+        }
+        log.error("SECURITY: bridge.security.password must be set explicitly in production. "
+                + "Default 'changeme' is not allowed when spring.profiles.active is not dev/test.");
+        throw new IllegalStateException(
+                "bridge.security.password must be set explicitly in production. "
+                        + "Set BRIDGE_AUTH_PASSWORD env var or bridge.security.password in configuration.");
+    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -51,12 +87,14 @@ public class SecurityConfig {
             .sessionManagement(session -> session
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
-                // Actuator endpoints: health and info are public, others require auth
+                // Actuator: health, info, prometheus, metrics are public for monitoring
                 .requestMatchers("/actuator/health", "/actuator/info").permitAll()
                 .requestMatchers("/actuator/prometheus", "/actuator/metrics/**").permitAll()
+                // All other actuator endpoints require authentication
+                .requestMatchers("/actuator/**").authenticated()
                 // The /input endpoint requires authentication
                 .requestMatchers("/input/**").authenticated()
-                // All other endpoints are permitted (ASTM query endpoints, etc.)
+                // All other endpoints (ASTM query forwarding, etc.) are permitted
                 .anyRequest().permitAll()
             )
             .httpBasic(Customizer.withDefaults());
@@ -78,6 +116,6 @@ public class SecurityConfig {
 
     @Bean
     public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
     }
 }

--- a/src/main/java/org/itech/ahb/config/SecurityConfig.java
+++ b/src/main/java/org/itech/ahb/config/SecurityConfig.java
@@ -33,9 +33,11 @@ import java.util.Arrays;
  * </p>
  * <p>
  * <strong>Password semantics:</strong> The {@code bridge.security.password} property
- * accepts either plaintext (hashed at runtime with BCrypt) or a pre-hashed value with
- * {@code {bcrypt}} prefix (e.g. {@code {bcrypt}$2a$10$...}). Use plaintext for simple
- * deployments; use pre-hashed for secret managers or when rotating without restarts.
+ * accepts either plaintext (encoded at startup with the configured {@link PasswordEncoder})
+ * or an already-encoded value using the delegating-encoder form {@code {id}encoded} (e.g.
+ * {@code {bcrypt}$2a$10$...}) which is stored as-is. Pre-hashed values suit secret managers
+ * and plaintext-free config files. The bridge uses an in-memory user; changing credentials
+ * still requires an application restart to take effect.
  * </p>
  *
  * @see org.itech.ahb.controller.AnalyzerInputController
@@ -104,14 +106,37 @@ public class SecurityConfig {
 
     @Bean
     public UserDetailsService userDetailsService(PasswordEncoder passwordEncoder) {
+        String storedPassword = encodePasswordIfPlaintext(password, passwordEncoder);
         var user = User.builder()
                 .username(username)
-                .password(passwordEncoder.encode(password))
+                .password(storedPassword)
                 .roles("BRIDGE")
                 .build();
 
         log.info("Configured bridge security user: {}", username);
         return new InMemoryUserDetailsManager(user);
+    }
+
+    /**
+     * Delegating-password values ({@code {bcrypt}$2a$...}, etc.) must be kept as-is.
+     * Plaintext is encoded once at startup.
+     */
+    static String encodePasswordIfPlaintext(String rawPassword, PasswordEncoder passwordEncoder) {
+        if (rawPassword == null || rawPassword.isEmpty()) {
+            return passwordEncoder.encode("");
+        }
+        if (isDelegatingEncodedPassword(rawPassword)) {
+            return rawPassword;
+        }
+        return passwordEncoder.encode(rawPassword);
+    }
+
+    private static boolean isDelegatingEncodedPassword(String value) {
+        if (!value.startsWith("{")) {
+            return false;
+        }
+        int close = value.indexOf('}');
+        return close > 1;
     }
 
     @Bean

--- a/src/test/java/org/itech/ahb/AstmHttpBridgeApplicationTests.java
+++ b/src/test/java/org/itech/ahb/AstmHttpBridgeApplicationTests.java
@@ -10,7 +10,12 @@ import org.springframework.boot.test.mock.mockito.MockBean;
  * Uses MockBean to prevent ASTM servers from actually starting during tests,
  * which avoids port binding and shutdown timing issues.
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {
+        "spring.profiles.active=test",
+        "bridge.security.password=test-context-password"
+    })
 class AstmHttpBridgeApplicationTests {
 
   /**

--- a/src/test/java/org/itech/ahb/config/SecurityConfigPasswordEncodingTest.java
+++ b/src/test/java/org/itech/ahb/config/SecurityConfigPasswordEncodingTest.java
@@ -1,0 +1,26 @@
+package org.itech.ahb.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+class SecurityConfigPasswordEncodingTest {
+
+    private final PasswordEncoder passwordEncoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();
+
+    @Test
+    void plaintextIsEncoded() {
+        String stored = SecurityConfig.encodePasswordIfPlaintext("hello", passwordEncoder);
+        assertTrue(stored.startsWith("{bcrypt}"));
+        assertTrue(passwordEncoder.matches("hello", stored));
+    }
+
+    @Test
+    void delegatingEncodedPasswordIsUnchanged() {
+        String preEncoded = passwordEncoder.encode("secret");
+        assertEquals(preEncoded, SecurityConfig.encodePasswordIfPlaintext(preEncoded, passwordEncoder));
+    }
+}

--- a/src/test/java/org/itech/ahb/security/NoSecurityConfigTest.java
+++ b/src/test/java/org/itech/ahb/security/NoSecurityConfigTest.java
@@ -1,0 +1,54 @@
+package org.itech.ahb.security;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.itech.ahb.normalizer.MessageEnvelope;
+import org.itech.ahb.normalizer.MessageNormalizer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Integration tests for bridge security when disabled (NoSecurityConfig).
+ * <p>
+ * Verifies that when {@code bridge.security.enabled=false}, the /input endpoint
+ * accepts unauthenticated requests.
+ * </p>
+ */
+@SpringBootTest(properties = {
+    "bridge.security.enabled=false",
+    "org.itech.ahb.mllp.enabled=false",
+    "org.itech.ahb.serial.enabled=false",
+    "bridge.file.enabled=false"
+})
+@AutoConfigureMockMvc
+class NoSecurityConfigTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MessageNormalizer mockNormalizer;
+
+    private static final String SAMPLE_ASTM = "H|\\^&|||HOST^1.0|||||||LIS2-A2|20260206\r"
+            + "P|1||||Doe^John\rL|1|N";
+
+    @Test
+    @DisplayName("Unauthenticated POST to /input succeeds when security disabled")
+    void unauthenticatedInputSucceedsWhenSecurityDisabled() throws Exception {
+        when(mockNormalizer.process(any(MessageEnvelope.class))).thenReturn(true);
+
+        mockMvc.perform(post("/input")
+                .content(SAMPLE_ASTM)
+                .contentType(MediaType.TEXT_PLAIN))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/org/itech/ahb/security/PreHashedPasswordSecurityIT.java
+++ b/src/test/java/org/itech/ahb/security/PreHashedPasswordSecurityIT.java
@@ -1,0 +1,60 @@
+package org.itech.ahb.security;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.itech.ahb.normalizer.MessageEnvelope;
+import org.itech.ahb.normalizer.MessageNormalizer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Verifies {@code bridge.security.password} in delegating-encoded form works for HTTP Basic.
+ */
+@SpringBootTest(properties = {
+    "bridge.security.enabled=true",
+    "bridge.security.username=testuser",
+    "org.itech.ahb.mllp.enabled=false",
+    "org.itech.ahb.serial.enabled=false",
+    "bridge.file.enabled=false",
+})
+@AutoConfigureMockMvc
+class PreHashedPasswordSecurityIT {
+
+    private static final PasswordEncoder encoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();
+
+    @DynamicPropertySource
+    static void registerPreEncodedPassword(DynamicPropertyRegistry registry) {
+        registry.add("bridge.security.password", () -> encoder.encode("from-secret-manager"));
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MessageNormalizer mockNormalizer;
+
+    @Test
+    @DisplayName("HTTP Basic accepts plaintext that matches pre-encoded bridge.security.password")
+    void inputWithMatchingPlaintextSucceeds() throws Exception {
+        when(mockNormalizer.process(any(MessageEnvelope.class))).thenReturn(true);
+
+        mockMvc.perform(post("/input")
+                .with(httpBasic("testuser", "from-secret-manager"))
+                .content("H|\\^&\r")
+                .contentType("application/x-astm"))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/org/itech/ahb/security/SecurityConfigTest.java
+++ b/src/test/java/org/itech/ahb/security/SecurityConfigTest.java
@@ -106,9 +106,17 @@ class SecurityConfigTest {
         }
 
         @Test
-        @DisplayName("Prometheus endpoint is publicly accessible for monitoring")
+        @DisplayName("Prometheus scrape endpoint is publicly accessible for monitoring")
         void prometheusEndpointNoAuthRequired() throws Exception {
-            // Prometheus/metrics are public for monitoring; assert not 401/403
+            int status = mockMvc.perform(get("/actuator/prometheus"))
+                    .andReturn().getResponse().getStatus();
+            assertTrue(status != 401 && status != 403,
+                    "Prometheus endpoint should not require auth, but got " + status);
+        }
+
+        @Test
+        @DisplayName("Metrics endpoint is publicly accessible for monitoring")
+        void metricsEndpointNoAuthRequired() throws Exception {
             int status = mockMvc.perform(get("/actuator/metrics"))
                     .andReturn().getResponse().getStatus();
             assertTrue(status != 401 && status != 403,

--- a/src/test/java/org/itech/ahb/security/SecurityConfigTest.java
+++ b/src/test/java/org/itech/ahb/security/SecurityConfigTest.java
@@ -33,7 +33,8 @@ import org.springframework.test.web.servlet.MockMvc;
     "bridge.security.password=testpass",
     "org.itech.ahb.mllp.enabled=false",
     "org.itech.ahb.serial.enabled=false",
-    "bridge.file.enabled=false"
+    "bridge.file.enabled=false",
+    "management.endpoints.web.exposure.include=health,info,prometheus,metrics,loggers"
 })
 @AutoConfigureMockMvc
 class SecurityConfigTest {
@@ -102,6 +103,23 @@ class SecurityConfigTest {
                     .andReturn().getResponse().getStatus();
             assertTrue(status != 401 && status != 403,
                     "Info endpoint should not require auth, but got " + status);
+        }
+
+        @Test
+        @DisplayName("Prometheus endpoint is publicly accessible for monitoring")
+        void prometheusEndpointNoAuthRequired() throws Exception {
+            // Prometheus/metrics are public for monitoring; assert not 401/403
+            int status = mockMvc.perform(get("/actuator/metrics"))
+                    .andReturn().getResponse().getStatus();
+            assertTrue(status != 401 && status != 403,
+                    "Metrics endpoint should not require auth, but got " + status);
+        }
+
+        @Test
+        @DisplayName("Sensitive actuator endpoint requires authentication")
+        void loggersEndpointRequiresAuth() throws Exception {
+            mockMvc.perform(get("/actuator/loggers"))
+                    .andExpect(status().isUnauthorized());
         }
     }
 }


### PR DESCRIPTION
Addresses all four unresolved review comments from [PR #13](https://github.com/DIGI-UW/openelis-analyzer-bridge/pull/13) (merged).

## Changes

- **Actuator rules:** Require auth for `/actuator/**` except health, info, prometheus, metrics; align code with comment
- **Default password fail-fast:** When `bridge.security.password` is `changeme` and profile is not dev/test, fail startup with clear error
- **Password semantics:** Use `DelegatingPasswordEncoder` to support `{bcrypt}` pre-hashed passwords; document in Javadoc, README, configuration.yml
- **Tests:** Add `NoSecurityConfigTest` (unauthenticated POST to `/input` when security disabled); add prometheus/metrics and loggers actuator coverage to `SecurityConfigTest`
- **Harness:** Add `BRIDGE_AUTH_PASSWORD=changeme` to analyzer harness compose (main repo) for dev clarity

Made with [Cursor](https://cursor.com)