### PR TITLE
refactor(file): bridge-owned FILE watcher lifecycle and direct OE import

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@ Middleware that receives analyzer messages over multiple **protocols/transports*
 
 This repository was previously named **ASTM-HTTP Bridge**. The internal rename to `openelis-analyzer-bridge` is complete across Maven, Docker, and scripts. The Docker Hub image `itechuw/astm-http-bridge` is still published as a legacy alias via CI.
 
+## FILE Ownership Model (014 Remediation)
+
+Bridge and OpenELIS responsibilities are explicitly separated:
+
+- Bridge owns FILE watcher runtime (directory watch/poll, stability checks,
+  archive/error handling, and delivery to OpenELIS).
+- OpenELIS owns analyzer configuration and ingestion/processing logic.
+
+If older sections describe OpenELIS as primary watcher owner, treat this section
+as the active remediation contract.
+
 ## Architecture
 
 ```

--- a/configuration.yml
+++ b/configuration.yml
@@ -72,8 +72,10 @@ bridge:
   #     filePattern: ".*/quantstudio-.*\\.csv"
 
   # File watcher configuration (M4)
+  # Runtime ownership note (014 remediation): Bridge is the active FILE watcher owner.
+  # OpenELIS app-side poller is fallback-only and disabled by default.
   file:
-    enabled: false  # Set to true to enable file watcher
+    enabled: false  # Bootstrap default; watcher is activated by FILE registration lifecycle during remediation
     watchDirectories:
       - /mnt/analyzer-import/quantstudio
       - /mnt/analyzer-import/hain

--- a/src/main/java/org/itech/ahb/controller/AnalyzerRegistrationController.java
+++ b/src/main/java/org/itech/ahb/controller/AnalyzerRegistrationController.java
@@ -1,10 +1,13 @@
 package org.itech.ahb.controller;
 
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.itech.ahb.config.AnalyzerRegistryConfig;
 import org.itech.ahb.config.AnalyzerRegistryConfig.AnalyzerEntry;
+import org.itech.ahb.file.FileWatcher;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,18 +19,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 /**
  * REST API for dynamic analyzer registration.
- * <p>
- * OpenELIS calls these endpoints when an analyzer is created, updated,
- * or deleted in the dashboard. The bridge uses the registry to tag incoming
- * traffic with the correct OE analyzer ID ({@code X-Analyzer-Id} header)
- * before forwarding to OpenELIS.
- * </p>
- * <p>
- * Registration binds a transport source (IP address, file watch directory,
- * serial port) to an OE analyzer ID. The bridge only needs the minimum
- * transport config — all business logic (test mappings, QC rules, etc.)
- * stays in OpenELIS.
- * </p>
  */
 @RestController
 @RequestMapping("/api/analyzers")
@@ -35,22 +26,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class AnalyzerRegistrationController {
 
     private final AnalyzerRegistryConfig registry;
+    private final FileWatcher fileWatcher;
 
-    public AnalyzerRegistrationController(AnalyzerRegistryConfig registry) {
+    public AnalyzerRegistrationController(AnalyzerRegistryConfig registry, FileWatcher fileWatcher) {
         this.registry = registry;
+        this.fileWatcher = fileWatcher;
     }
 
-    /**
-     * Register an analyzer's transport binding.
-     * <p>
-     * Called by OpenELIS when an analyzer is created or updated. The bridge
-     * stores the mapping and uses it to tag all traffic from the registered
-     * source with the OE analyzer ID.
-     * </p>
-     *
-     * @param request registration payload with transport config
-     * @return registration confirmation
-     */
     @PostMapping("/register")
     public ResponseEntity<Map<String, Object>> register(@RequestBody RegistrationRequest request) {
         if (request.oeAnalyzerId == null || request.oeAnalyzerId.isBlank()) {
@@ -72,52 +54,51 @@ public class AnalyzerRegistrationController {
 
         registry.register(request.sourceId, entry);
 
+        boolean fileWatchUpdated = false;
+        if ("FILE".equalsIgnoreCase(request.protocol)) {
+            try {
+                fileWatcher.addWatchDirectory(Path.of(request.sourceId), request.filePattern, request.oeAnalyzerId);
+                fileWatchUpdated = true;
+            } catch (IOException e) {
+                log.error("Failed to add runtime watch directory {} for analyzer {}", request.sourceId, request.oeAnalyzerId,
+                        e);
+                return ResponseEntity.internalServerError().body(Map.of(
+                        "registered", false,
+                        "error", "Bridge failed to register FILE watch directory: " + e.getMessage()));
+            }
+        }
+
         Map<String, Object> response = new LinkedHashMap<>();
         response.put("registered", true);
         response.put("oeAnalyzerId", request.oeAnalyzerId);
         response.put("sourceId", request.sourceId);
         response.put("protocol", request.protocol);
+        response.put("fileWatchUpdated", fileWatchUpdated);
         return ResponseEntity.ok(response);
     }
 
-    /**
-     * Unregister an analyzer by OE analyzer ID.
-     * Removes all source mappings that point to this analyzer.
-     */
     @DeleteMapping("/{oeAnalyzerId}")
     public ResponseEntity<Map<String, Object>> unregister(@PathVariable String oeAnalyzerId) {
         boolean removed = registry.unregisterByAnalyzerId(oeAnalyzerId);
+        int removedWatchDirs = fileWatcher.removeWatchDirectoriesByAnalyzerId(oeAnalyzerId);
+
         Map<String, Object> response = new LinkedHashMap<>();
-        response.put("removed", removed);
+        response.put("removed", removed || removedWatchDirs > 0);
         response.put("oeAnalyzerId", oeAnalyzerId);
+        response.put("removedWatchDirectories", removedWatchDirs);
         return ResponseEntity.ok(response);
     }
 
-    /**
-     * List all registered analyzers.
-     */
     @GetMapping
     public ResponseEntity<Map<String, AnalyzerEntry>> list() {
         return ResponseEntity.ok(registry.getRegisteredAnalyzers());
     }
 
-    /**
-     * Registration request payload.
-     */
     public static class RegistrationRequest {
-        /** OE analyzer ID (from the analyzer table in OpenELIS) */
         public String oeAnalyzerId;
-
-        /** Source identifier: IP address for TCP, directory path for FILE, serial port for SERIAL */
         public String sourceId;
-
-        /** Human-readable analyzer name */
         public String name;
-
-        /** Expected protocol: ASTM, HL7, CSV */
         public String protocol;
-
-        /** Optional file pattern for FILE transport (glob or regex) */
         public String filePattern;
     }
 }

--- a/src/main/java/org/itech/ahb/controller/AnalyzerRegistrationController.java
+++ b/src/main/java/org/itech/ahb/controller/AnalyzerRegistrationController.java
@@ -1,12 +1,14 @@
 package org.itech.ahb.controller;
 
 import java.io.IOException;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.itech.ahb.config.AnalyzerRegistryConfig;
 import org.itech.ahb.config.AnalyzerRegistryConfig.AnalyzerEntry;
+import org.itech.ahb.file.FileConfig;
 import org.itech.ahb.file.FileWatcher;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -27,10 +29,12 @@ public class AnalyzerRegistrationController {
 
     private final AnalyzerRegistryConfig registry;
     private final FileWatcher fileWatcher;
+    private final FileConfig fileConfig;
 
-    public AnalyzerRegistrationController(AnalyzerRegistryConfig registry, FileWatcher fileWatcher) {
+    public AnalyzerRegistrationController(AnalyzerRegistryConfig registry, FileWatcher fileWatcher, FileConfig fileConfig) {
         this.registry = registry;
         this.fileWatcher = fileWatcher;
+        this.fileConfig = fileConfig;
     }
 
     @PostMapping("/register")
@@ -55,10 +59,20 @@ public class AnalyzerRegistrationController {
         registry.register(request.sourceId, entry);
 
         boolean fileWatchUpdated = false;
-        if ("FILE".equalsIgnoreCase(request.protocol)) {
+        if (isFileTransport(request.protocol)) {
+            if (!fileConfig.isEnabled()) {
+                return ResponseEntity.badRequest().body(Map.of(
+                        "registered", false,
+                        "error", "FILE transport requires bridge.file.enabled=true"));
+            }
             try {
                 fileWatcher.addWatchDirectory(Path.of(request.sourceId), request.filePattern, request.oeAnalyzerId);
                 fileWatchUpdated = true;
+            } catch (InvalidPathException e) {
+                log.warn("Invalid FILE sourceId path for analyzer {}: {}", request.oeAnalyzerId, request.sourceId);
+                return ResponseEntity.badRequest().body(Map.of(
+                        "registered", false,
+                        "error", "Invalid directory path for FILE sourceId"));
             } catch (IOException e) {
                 log.error("Failed to add runtime watch directory {} for analyzer {}", request.sourceId, request.oeAnalyzerId,
                         e);
@@ -92,6 +106,14 @@ public class AnalyzerRegistrationController {
     @GetMapping
     public ResponseEntity<Map<String, AnalyzerEntry>> list() {
         return ResponseEntity.ok(registry.getRegisteredAnalyzers());
+    }
+
+    /**
+     * FILE analyzers may register with {@code protocol=FILE} or legacy {@code CSV}.
+     */
+    private static boolean isFileTransport(String protocol) {
+        return protocol != null
+                && ("FILE".equalsIgnoreCase(protocol) || "CSV".equalsIgnoreCase(protocol));
     }
 
     public static class RegistrationRequest {

--- a/src/main/java/org/itech/ahb/file/CSVParser.java
+++ b/src/main/java/org/itech/ahb/file/CSVParser.java
@@ -3,7 +3,6 @@ package org.itech.ahb.file;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVRecord;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import org.apache.commons.csv.CSVPrinter;
@@ -26,7 +25,6 @@ import java.util.Map;
  * </p>
  */
 @Component
-@ConditionalOnProperty(prefix = "bridge.file", name = "enabled", havingValue = "true")
 @Slf4j
 public class CSVParser {
 

--- a/src/main/java/org/itech/ahb/file/FileConfig.java
+++ b/src/main/java/org/itech/ahb/file/FileConfig.java
@@ -5,6 +5,7 @@ import org.itech.ahb.model.Protocol;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -36,14 +37,17 @@ public class FileConfig {
     private List<String> watchDirectories = new ArrayList<>();
 
     /**
-     * Directory where successfully processed files are moved
+     * Directory where successfully processed files are moved.
+     * Default uses the JVM temp directory so tests/local runs work without /mnt.
      */
-    private String archiveDirectory = "/mnt/analyzer-archive";
+    private String archiveDirectory = Paths.get(
+            System.getProperty("java.io.tmpdir"), "openelis-analyzer-bridge", "analyzer-archive").toString();
 
     /**
      * Directory where failed files are moved after max retry attempts
      */
-    private String errorDirectory = "/mnt/analyzer-error";
+    private String errorDirectory = Paths.get(
+            System.getProperty("java.io.tmpdir"), "openelis-analyzer-bridge", "analyzer-error").toString();
 
     /**
      * Polling interval in milliseconds for checking new files

--- a/src/main/java/org/itech/ahb/file/FileMessageHandler.java
+++ b/src/main/java/org/itech/ahb/file/FileMessageHandler.java
@@ -1,148 +1,146 @@
 package org.itech.ahb.file;
 
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
 import lombok.extern.slf4j.Slf4j;
 import org.itech.ahb.model.Protocol;
 import org.itech.ahb.model.Transport;
 import org.itech.ahb.normalizer.MessageEnvelope;
-import org.itech.ahb.normalizer.MessageNormalizer;
-import org.itech.ahb.util.ProtocolDetector;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 
 /**
  * Handles file-based analyzer messages.
- * <p>
- * Reads file content, detects protocol format, and delegates to
- * {@link MessageNormalizer} for routing to OpenELIS.
- * </p>
- * <p>
- * Part of M7: Message Normalizer milestone — all transport handlers delegate to
- * the normalizer for unified routing logic, retry/backoff, and audit logging.
- * </p>
  *
- * @see MessageNormalizer
- * @see MessageEnvelope
+ * For FILE transport, the bridge sends files directly to OpenELIS direct-import
+ * endpoint (`/rest/analyzers/{id}/import`) instead of routing through the
+ * message normalizer and legacy `/analyzer/csv` path.
  */
 @Component
-@ConditionalOnProperty(prefix = "bridge.file", name = "enabled", havingValue = "true")
 @Slf4j
 public class FileMessageHandler {
 
     private final CSVParser csvParser;
-    private final MessageNormalizer normalizer;
-    private final FileConfig fileConfig;
+    private final HttpClient httpClient = HttpClient.newHttpClient();
 
-    // Maximum file size to process (10MB default)
+    @Value("${bridge.openelis.url:http://localhost:8443}")
+    private String openelisBaseUrl;
+
+    @Value("${bridge.openelis.username:}")
+    private String openelisUsername;
+
+    @Value("${bridge.openelis.password:}")
+    private String openelisPassword;
+
     private static final long MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
 
-    /**
-     * Creates a new FileMessageHandler.
-     *
-     * @param csvParser the CSV parser for validation
-     * @param fileConfig the file watcher configuration
-     * @param normalizer the message normalizer for routing
-     */
-    public FileMessageHandler(
-            CSVParser csvParser,
-            FileConfig fileConfig,
-            MessageNormalizer normalizer) {
+    public FileMessageHandler(CSVParser csvParser) {
         this.csvParser = csvParser;
-        this.fileConfig = fileConfig;
-        this.normalizer = normalizer;
     }
 
-    /**
-     * Process a file and forward to OpenELIS via MessageNormalizer.
-     * <p>
-     * Reads the file, detects protocol, validates content, creates a MessageEnvelope,
-     * and delegates to the {@link MessageNormalizer} for routing to OpenELIS.
-     * </p>
-     *
-     * @param filePath   the file path to process
-     * @param analyzerId optional analyzer identifier (for CSV mapping lookup)
-     * @return MessageEnvelope with processing metadata
-     * @throws IOException              if file reading fails
-     * @throws FileProcessingException if protocol detection or forwarding fails
-     */
-    public MessageEnvelope processFile(Path filePath, String analyzerId) throws IOException, FileProcessingException {
-        log.info("Processing file: {} for analyzer: {}", filePath, analyzerId);
+    public FileMessageHandler(CSVParser csvParser, FileConfig ignoredFileConfig,
+            org.itech.ahb.normalizer.MessageNormalizer ignoredNormalizer) {
+        this.csvParser = csvParser;
+    }
 
-        // Check file size before reading
+    public MessageEnvelope processFile(Path filePath, String analyzerId) throws IOException, FileProcessingException {
+        if (analyzerId == null || analyzerId.isBlank()) {
+            throw new FileProcessingException("analyzerId is required for FILE delivery: " + filePath);
+        }
+
         long fileSize = Files.size(filePath);
         if (fileSize > MAX_FILE_SIZE_BYTES) {
-            log.warn("File size ({} bytes) exceeds maximum ({}), processing anyway with caution",
-                    fileSize, MAX_FILE_SIZE_BYTES);
+            log.warn("File size ({} bytes) exceeds max ({}), processing with caution", fileSize, MAX_FILE_SIZE_BYTES);
         }
         if (fileSize == 0) {
             throw new FileProcessingException("File is empty: " + filePath);
         }
 
-        // Read file content
-        String content = Files.readString(filePath);
-        if (content == null || content.trim().isEmpty()) {
+        byte[] content = Files.readAllBytes(filePath);
+        if (content.length == 0) {
             throw new FileProcessingException("File is empty: " + filePath);
         }
 
-        // Detect protocol
-        Protocol protocol = ProtocolDetector.detect(content);
-        log.debug("Detected protocol: {} for file: {}", protocol, filePath.getFileName());
+        postFileToOpenElis(filePath, analyzerId, content);
 
-        if (protocol == Protocol.UNKNOWN) {
-            log.warn("Unable to detect protocol for file {}, routing as raw", filePath.getFileName());
-        } else if (!validateFileContent(filePath, protocol)) {
-            throw new FileProcessingException("Invalid " + protocol + " content in file: " + filePath);
-        }
-
-        // Create envelope
-        MessageEnvelope envelope = MessageEnvelope.builder()
-                .protocol(protocol)
+        return MessageEnvelope.builder()
+                .protocol(Protocol.CSV)
                 .transport(Transport.FILE)
                 .sourceId(filePath.toString())
-                .rawMessage(content)
+                .rawMessage(filePath.getFileName().toString())
                 .analyzerId(analyzerId)
                 .build();
-
-        // Delegate to normalizer for routing
-        boolean success = normalizer.process(envelope);
-        if (!success) {
-            throw new FileProcessingException("Failed to route message for file: " + filePath);
-        }
-
-        return envelope;
     }
 
-    /**
-     * Validate file content before processing.
-     *
-     * @param filePath the file to validate
-     * @param protocol the detected protocol
-     * @return true if file content appears valid for the protocol
-     * @throws IOException if file reading fails
-     */
-    public boolean validateFileContent(Path filePath, Protocol protocol) throws IOException {
-        String content = Files.readString(filePath);
+    private void postFileToOpenElis(Path filePath, String analyzerId, byte[] content)
+            throws IOException, FileProcessingException {
+        String boundary = "----OpenElisBridgeBoundary" + System.currentTimeMillis();
+        String filename = filePath.getFileName().toString();
 
-        if (content == null || content.trim().isEmpty()) {
-            log.warn("File is empty: {}", filePath);
-            return false;
+        byte[] preamble = (
+                "--" + boundary + "\r\n" +
+                "Content-Disposition: form-data; name=\"file\"; filename=\"" + filename + "\"\r\n" +
+                "Content-Type: application/octet-stream\r\n\r\n"
+        ).getBytes(StandardCharsets.UTF_8);
+
+        byte[] closing = ("\r\n--" + boundary + "--\r\n").getBytes(StandardCharsets.UTF_8);
+
+        byte[] body = new byte[preamble.length + content.length + closing.length];
+        System.arraycopy(preamble, 0, body, 0, preamble.length);
+        System.arraycopy(content, 0, body, preamble.length, content.length);
+        System.arraycopy(closing, 0, body, preamble.length + content.length, closing.length);
+
+        String base = openelisBaseUrl.endsWith("/") ? openelisBaseUrl.substring(0, openelisBaseUrl.length() - 1)
+                : openelisBaseUrl;
+        URI uri = URI.create(base + "/rest/analyzers/" + analyzerId + "/import");
+
+        HttpRequest.Builder requestBuilder = HttpRequest.newBuilder(uri)
+                .header("Content-Type", "multipart/form-data; boundary=" + boundary)
+                .header("X-Analyzer-Id", analyzerId)
+                .POST(HttpRequest.BodyPublishers.ofByteArray(body));
+
+        if (openelisUsername != null && !openelisUsername.isBlank()) {
+            String token = Base64.getEncoder()
+                    .encodeToString((openelisUsername + ":" + (openelisPassword == null ? "" : openelisPassword))
+                            .getBytes(StandardCharsets.UTF_8));
+            requestBuilder.header("Authorization", "Basic " + token);
         }
 
-        // CSV-specific validation
+        HttpResponse<String> response;
+        try {
+            response = httpClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new FileProcessingException("Interrupted while forwarding file to OpenELIS", e);
+        }
+
+        if (response.statusCode() < 200 || response.statusCode() >= 300) {
+            throw new FileProcessingException(
+                    "OpenELIS direct import failed for analyzer " + analyzerId +
+                            " with status " + response.statusCode() + ": " + response.body());
+        }
+
+        log.info("Forwarded file {} to OpenELIS direct-import endpoint for analyzer {}", filename, analyzerId);
+    }
+
+    public boolean validateFileContent(Path filePath, Protocol protocol) throws IOException {
+        String content = Files.readString(filePath);
+        if (content == null || content.trim().isEmpty()) {
+            return false;
+        }
         if (protocol == Protocol.CSV) {
             return csvParser.isValidCSV(content);
         }
-
-        // Basic validation for ASTM/HL7 (has minimum structure)
-        return content.length() > 10 && !content.isBlank();
+        return true;
     }
 
-    /**
-     * Custom exception for file processing errors.
-     */
     public static class FileProcessingException extends Exception {
         public FileProcessingException(String message) {
             super(message);

--- a/src/main/java/org/itech/ahb/file/FileMessageHandler.java
+++ b/src/main/java/org/itech/ahb/file/FileMessageHandler.java
@@ -13,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.itech.ahb.model.Protocol;
 import org.itech.ahb.model.Transport;
 import org.itech.ahb.normalizer.MessageEnvelope;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -30,17 +31,19 @@ public class FileMessageHandler {
     private final CSVParser csvParser;
     private final HttpClient httpClient = HttpClient.newHttpClient();
 
+    /** Defaults support manual construction in tests; {@code @Value} overrides when Spring creates the bean. */
     @Value("${bridge.openelis.url:http://localhost:8443}")
-    private String openelisBaseUrl;
+    private String openelisBaseUrl = "http://localhost:8443";
 
     @Value("${bridge.openelis.username:}")
-    private String openelisUsername;
+    private String openelisUsername = "";
 
     @Value("${bridge.openelis.password:}")
-    private String openelisPassword;
+    private String openelisPassword = "";
 
     private static final long MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
 
+    @Autowired
     public FileMessageHandler(CSVParser csvParser) {
         this.csvParser = csvParser;
     }

--- a/src/main/java/org/itech/ahb/file/FileMessageHandler.java
+++ b/src/main/java/org/itech/ahb/file/FileMessageHandler.java
@@ -8,6 +8,7 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Base64;
 import lombok.extern.slf4j.Slf4j;
 import org.itech.ahb.model.Protocol;
@@ -29,7 +30,8 @@ import org.springframework.stereotype.Component;
 public class FileMessageHandler {
 
     private final CSVParser csvParser;
-    private final HttpClient httpClient = HttpClient.newHttpClient();
+
+    private volatile HttpClient httpClient;
 
     /** Defaults support manual construction in tests; {@code @Value} overrides when Spring creates the bean. */
     @Value("${bridge.openelis.url:http://localhost:8443}")
@@ -41,6 +43,12 @@ public class FileMessageHandler {
     @Value("${bridge.openelis.password:}")
     private String openelisPassword = "";
 
+    @Value("${bridge.openelis.connectTimeoutSeconds:30}")
+    private int connectTimeoutSeconds = 30;
+
+    @Value("${bridge.openelis.readTimeoutSeconds:30}")
+    private int readTimeoutSeconds = 30;
+
     private static final long MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
 
     @Autowired
@@ -51,6 +59,21 @@ public class FileMessageHandler {
     public FileMessageHandler(CSVParser csvParser, FileConfig ignoredFileConfig,
             org.itech.ahb.normalizer.MessageNormalizer ignoredNormalizer) {
         this.csvParser = csvParser;
+    }
+
+    private HttpClient httpClient() {
+        HttpClient existing = httpClient;
+        if (existing != null) {
+            return existing;
+        }
+        synchronized (this) {
+            if (httpClient == null) {
+                httpClient = HttpClient.newBuilder()
+                        .connectTimeout(Duration.ofSeconds(connectTimeoutSeconds))
+                        .build();
+            }
+            return httpClient;
+        }
     }
 
     public MessageEnvelope processFile(Path filePath, String analyzerId) throws IOException, FileProcessingException {
@@ -85,11 +108,11 @@ public class FileMessageHandler {
     private void postFileToOpenElis(Path filePath, String analyzerId, byte[] content)
             throws IOException, FileProcessingException {
         String boundary = "----OpenElisBridgeBoundary" + System.currentTimeMillis();
-        String filename = filePath.getFileName().toString();
+        String safeFilename = sanitizeMultipartFilename(filePath.getFileName().toString());
 
         byte[] preamble = (
                 "--" + boundary + "\r\n" +
-                "Content-Disposition: form-data; name=\"file\"; filename=\"" + filename + "\"\r\n" +
+                "Content-Disposition: form-data; name=\"file\"; filename=\"" + safeFilename + "\"\r\n" +
                 "Content-Type: application/octet-stream\r\n\r\n"
         ).getBytes(StandardCharsets.UTF_8);
 
@@ -105,6 +128,7 @@ public class FileMessageHandler {
         URI uri = URI.create(base + "/rest/analyzers/" + analyzerId + "/import");
 
         HttpRequest.Builder requestBuilder = HttpRequest.newBuilder(uri)
+                .timeout(Duration.ofSeconds(readTimeoutSeconds))
                 .header("Content-Type", "multipart/form-data; boundary=" + boundary)
                 .header("X-Analyzer-Id", analyzerId)
                 .POST(HttpRequest.BodyPublishers.ofByteArray(body));
@@ -118,7 +142,7 @@ public class FileMessageHandler {
 
         HttpResponse<String> response;
         try {
-            response = httpClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString());
+            response = httpClient().send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString());
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new FileProcessingException("Interrupted while forwarding file to OpenELIS", e);
@@ -130,18 +154,14 @@ public class FileMessageHandler {
                             " with status " + response.statusCode() + ": " + response.body());
         }
 
-        log.info("Forwarded file {} to OpenELIS direct-import endpoint for analyzer {}", filename, analyzerId);
+        log.info("Forwarded file {} to OpenELIS direct-import endpoint for analyzer {}", safeFilename, analyzerId);
     }
 
-    public boolean validateFileContent(Path filePath, Protocol protocol) throws IOException {
-        String content = Files.readString(filePath);
-        if (content == null || content.trim().isEmpty()) {
-            return false;
+    private static String sanitizeMultipartFilename(String filename) {
+        if (filename == null || filename.isBlank()) {
+            return "upload.bin";
         }
-        if (protocol == Protocol.CSV) {
-            return csvParser.isValidCSV(content);
-        }
-        return true;
+        return filename.replace("\r", "").replace("\n", "").replace("\"", "");
     }
 
     public static class FileProcessingException extends Exception {

--- a/src/main/java/org/itech/ahb/file/FileWatcher.java
+++ b/src/main/java/org/itech/ahb/file/FileWatcher.java
@@ -3,7 +3,6 @@ package org.itech.ahb.file;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -26,7 +25,6 @@ import java.util.stream.Stream;
  * </p>
  */
 @Component
-@ConditionalOnProperty(prefix = "bridge.file", name = "enabled", havingValue = "true")
 @Slf4j
 public class FileWatcher {
 
@@ -36,6 +34,8 @@ public class FileWatcher {
     private final Map<Path, FileMetadata> fileStabilityTracker = new ConcurrentHashMap<>();
     private final Set<String> processedFileHashes = ConcurrentHashMap.newKeySet();
     private final Map<Path, RetryInfo> retryTracker = new ConcurrentHashMap<>();
+    private final Map<Path, WatchKey> watchedDirectories = new ConcurrentHashMap<>();
+    private final Map<Path, String> directoryAnalyzerMap = new ConcurrentHashMap<>();
 
     // Maximum number of file hashes to keep in memory (prevent unbounded growth)
     private static final int MAX_HASH_CACHE_SIZE = 10000;
@@ -60,9 +60,8 @@ public class FileWatcher {
      * Start file watcher service.
      */
     @PostConstruct
-    public void start() throws IOException {
-        if (!fileConfig.isEnabled()) {
-            log.info("File watcher is disabled");
+    public synchronized void start() throws IOException {
+        if (running) {
             return;
         }
 
@@ -72,28 +71,18 @@ public class FileWatcher {
         Files.createDirectories(Paths.get(fileConfig.getArchiveDirectory()));
         Files.createDirectories(Paths.get(fileConfig.getErrorDirectory()));
 
-        // Initialize watch service
+        // Initialize watch service and executors
         watchService = FileSystems.getDefault().newWatchService();
-
-        // Register watch directories
-        for (String watchDir : fileConfig.getWatchDirectories()) {
-            Path dirPath = Paths.get(watchDir);
-            if (!Files.exists(dirPath)) {
-                log.warn("Watch directory does not exist, creating: {}", watchDir);
-                Files.createDirectories(dirPath);
-            }
-
-            dirPath.register(watchService, StandardWatchEventKinds.ENTRY_CREATE,
-                    StandardWatchEventKinds.ENTRY_MODIFY);
-            log.info("Registered watch directory: {}", dirPath);
-
-            // Process existing files in directory
-            processExistingFiles(dirPath);
-        }
-
-        // Start watcher thread
         watcherExecutor = Executors.newSingleThreadExecutor();
         processorExecutor = Executors.newFixedThreadPool(2);
+
+        // Register bootstrap directories (if any)
+        for (String watchDir : fileConfig.getWatchDirectories()) {
+            if (watchDir == null || watchDir.isBlank()) {
+                continue;
+            }
+            registerDirectoryInternal(Paths.get(watchDir).normalize(), null, true);
+        }
 
         running = true;
         watcherExecutor.submit(this::watchLoop);
@@ -106,7 +95,79 @@ public class FileWatcher {
                 TimeUnit.MILLISECONDS
         );
 
-        log.info("File watcher service started successfully");
+        log.info("File watcher service started successfully with {} watched directories", watchedDirectories.size());
+    }
+
+    /**
+     * Register a directory for runtime watching.
+     */
+    public synchronized void addWatchDirectory(Path dirPath, String filePattern, String analyzerId) throws IOException {
+        Path normalized = dirPath.normalize();
+        registerDirectoryInternal(normalized, analyzerId, true);
+        if (!fileConfig.getWatchDirectories().contains(normalized.toString())) {
+            List<String> mutableWatchDirs = new ArrayList<>(fileConfig.getWatchDirectories());
+            mutableWatchDirs.add(normalized.toString());
+            fileConfig.setWatchDirectories(mutableWatchDirs);
+        }
+        log.info("Runtime watch directory registered: {} (analyzerId={})", normalized, analyzerId);
+    }
+
+    /**
+     * Remove a directory from runtime watching.
+     */
+    public synchronized boolean removeWatchDirectory(Path dirPath) {
+        Path normalized = dirPath.normalize();
+        WatchKey key = watchedDirectories.remove(normalized);
+        directoryAnalyzerMap.remove(normalized);
+        List<String> mutableWatchDirs = new ArrayList<>(fileConfig.getWatchDirectories());
+        mutableWatchDirs.remove(normalized.toString());
+        fileConfig.setWatchDirectories(mutableWatchDirs);
+        if (key != null) {
+            key.cancel();
+            log.info("Runtime watch directory removed: {}", normalized);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Remove all watched directories for a given analyzer ID.
+     */
+    public synchronized int removeWatchDirectoriesByAnalyzerId(String analyzerId) {
+        int removed = 0;
+        for (Map.Entry<Path, String> entry : new ArrayList<>(directoryAnalyzerMap.entrySet())) {
+            if (Objects.equals(entry.getValue(), analyzerId) && removeWatchDirectory(entry.getKey())) {
+                removed++;
+            }
+        }
+        return removed;
+    }
+
+    /**
+     * Register a directory with WatchService and optionally process existing files.
+     */
+    private void registerDirectoryInternal(Path dirPath, String analyzerId, boolean processExisting) throws IOException {
+        if (!Files.exists(dirPath)) {
+            log.warn("Watch directory does not exist, creating: {}", dirPath);
+            Files.createDirectories(dirPath);
+        }
+
+        WatchKey oldKey = watchedDirectories.remove(dirPath);
+        if (oldKey != null) {
+            oldKey.cancel();
+        }
+
+        WatchKey key = dirPath.register(watchService, StandardWatchEventKinds.ENTRY_CREATE,
+                StandardWatchEventKinds.ENTRY_MODIFY);
+        watchedDirectories.put(dirPath, key);
+        if (analyzerId != null && !analyzerId.isBlank()) {
+            directoryAnalyzerMap.put(dirPath, analyzerId);
+        }
+
+        log.info("Registered watch directory: {}", dirPath);
+        if (processExisting && processorExecutor != null) {
+            processExistingFiles(dirPath);
+        }
     }
 
     /**
@@ -531,6 +592,14 @@ public class FileWatcher {
         String pathString = filePath.toString();
         String filename = filePath.getFileName().toString();
 
+        Path parent = filePath.getParent();
+        if (parent != null) {
+            String mappedAnalyzerId = directoryAnalyzerMap.get(parent.normalize());
+            if (mappedAnalyzerId != null && !mappedAnalyzerId.isBlank()) {
+                return mappedAnalyzerId;
+            }
+        }
+
         // Check configured analyzer patterns
         for (Map.Entry<String, FileConfig.AnalyzerConfig> entry : fileConfig.getAnalyzers().entrySet()) {
             String pattern = entry.getKey();
@@ -561,7 +630,6 @@ public class FileWatcher {
         }
 
         // Fallback: use parent directory name
-        Path parent = filePath.getParent();
         if (parent != null) {
             String dirName = parent.getFileName().toString().toUpperCase();
             log.debug("No pattern match for file {}, using directory name: {}", filename, dirName);

--- a/src/main/java/org/itech/ahb/file/FileWatcher.java
+++ b/src/main/java/org/itech/ahb/file/FileWatcher.java
@@ -36,6 +36,8 @@ public class FileWatcher {
     private final Map<Path, RetryInfo> retryTracker = new ConcurrentHashMap<>();
     private final Map<Path, WatchKey> watchedDirectories = new ConcurrentHashMap<>();
     private final Map<Path, String> directoryAnalyzerMap = new ConcurrentHashMap<>();
+    /** Per registered directory: glob for {@link #shouldProcessFile(Path)} (runtime FILE registration). */
+    private final Map<Path, String> directoryGlobPatternByDir = new ConcurrentHashMap<>();
 
     // Maximum number of file hashes to keep in memory (prevent unbounded growth)
     private static final int MAX_HASH_CACHE_SIZE = 10000;
@@ -62,6 +64,11 @@ public class FileWatcher {
     @PostConstruct
     public synchronized void start() throws IOException {
         if (running) {
+            return;
+        }
+
+        if (!fileConfig.isEnabled()) {
+            log.info("File watcher bootstrap skipped (bridge.file.enabled=false)");
             return;
         }
 
@@ -103,6 +110,8 @@ public class FileWatcher {
      */
     public synchronized void addWatchDirectory(Path dirPath, String filePattern, String analyzerId) throws IOException {
         Path normalized = dirPath.normalize();
+        String effectiveGlob = (filePattern == null || filePattern.isBlank()) ? "*" : filePattern;
+        directoryGlobPatternByDir.put(normalized, effectiveGlob);
         registerDirectoryInternal(normalized, analyzerId, true);
         if (!fileConfig.getWatchDirectories().contains(normalized.toString())) {
             List<String> mutableWatchDirs = new ArrayList<>(fileConfig.getWatchDirectories());
@@ -119,6 +128,7 @@ public class FileWatcher {
         Path normalized = dirPath.normalize();
         WatchKey key = watchedDirectories.remove(normalized);
         directoryAnalyzerMap.remove(normalized);
+        directoryGlobPatternByDir.remove(normalized);
         List<String> mutableWatchDirs = new ArrayList<>(fileConfig.getWatchDirectories());
         mutableWatchDirs.remove(normalized.toString());
         fileConfig.setWatchDirectories(mutableWatchDirs);
@@ -653,6 +663,20 @@ public class FileWatcher {
         // Skip hidden files, error detail files, and permanently failed files
         if (filename.startsWith(".") || filename.endsWith(".error") || filename.endsWith(".failed")) {
             return false;
+        }
+
+        Path parent = filePath.getParent();
+        if (parent != null) {
+            String perDirGlob = directoryGlobPatternByDir.get(parent.normalize());
+            if (perDirGlob != null) {
+                try {
+                    PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:" + perDirGlob);
+                    return matcher.matches(filePath.getFileName());
+                } catch (IllegalArgumentException e) {
+                    log.warn("Invalid per-directory glob '{}' for {}: {}", perDirGlob, parent, e.getMessage());
+                    return false;
+                }
+            }
         }
 
         // Check against configured patterns

--- a/src/main/java/org/itech/ahb/file/FileWatcher.java
+++ b/src/main/java/org/itech/ahb/file/FileWatcher.java
@@ -24,7 +24,7 @@ import java.util.stream.Stream;
  * retry logic with exponential backoff.
  * </p>
  */
-@Component
+@Component("analyzerFileWatcher")
 @Slf4j
 public class FileWatcher {
 

--- a/src/main/java/org/itech/ahb/health/FileWatcherHealthIndicator.java
+++ b/src/main/java/org/itech/ahb/health/FileWatcherHealthIndicator.java
@@ -1,6 +1,7 @@
 package org.itech.ahb.health;
 
 import lombok.extern.slf4j.Slf4j;
+import org.itech.ahb.file.FileConfig;
 import org.itech.ahb.file.FileWatcher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator;
@@ -14,9 +15,11 @@ import org.springframework.stereotype.Component;
 public class FileWatcherHealthIndicator implements HealthIndicator {
 
     private final FileWatcher watcher;
+    private final FileConfig fileConfig;
 
-    public FileWatcherHealthIndicator(@Autowired(required = false) FileWatcher watcher) {
+    public FileWatcherHealthIndicator(@Autowired(required = false) FileWatcher watcher, FileConfig fileConfig) {
         this.watcher = watcher;
+        this.fileConfig = fileConfig;
     }
 
     @Override
@@ -24,6 +27,12 @@ public class FileWatcherHealthIndicator implements HealthIndicator {
         if (watcher == null) {
             return Health.unknown()
                 .withDetail("reason", "File watcher not configured")
+                .build();
+        }
+
+        if (!fileConfig.isEnabled()) {
+            return Health.up()
+                .withDetail("status", "disabled (bridge.file.enabled=false)")
                 .build();
         }
 

--- a/src/test/java/org/itech/ahb/file/FileWatcherTest.java
+++ b/src/test/java/org/itech/ahb/file/FileWatcherTest.java
@@ -329,4 +329,30 @@ class FileWatcherTest {
         assertTrue(Files.exists(errorDir.resolve("test.csv")));  // Should be in error directory
         assertFalse(Files.exists(testFile));  // Original file should be moved
     }
+    @Test
+    void testRuntimeDirectoryRegistrationLifecycle() throws Exception {
+        fileWatcher.start();
+        Path dynamicDir = tempDir.resolve("dynamic-watch");
+        Files.createDirectories(dynamicDir);
+
+        fileWatcher.addWatchDirectory(dynamicDir, "*.csv", "ANALYZER-123");
+        int removed = fileWatcher.removeWatchDirectoriesByAnalyzerId("ANALYZER-123");
+
+        assertEquals(1, removed);
+    }
+
+    @Test
+    void testDetermineAnalyzerId_UsesRuntimeDirectoryMapping() throws Exception {
+        fileWatcher.start();
+        Path dynamicDir = tempDir.resolve("mapped-watch");
+        Files.createDirectories(dynamicDir);
+        Path payload = dynamicDir.resolve("input.csv");
+        Files.writeString(payload, CSV_CONTENT);
+
+        fileWatcher.addWatchDirectory(dynamicDir, "*.csv", "ANALYZER-MAPPED");
+
+        String analyzerId = (String) ReflectionTestUtils.invokeMethod(fileWatcher, "determineAnalyzerId", payload);
+        assertEquals("ANALYZER-MAPPED", analyzerId);
+    }
+
 }

--- a/src/test/java/org/itech/ahb/integration/UnifiedRoutingTest.java
+++ b/src/test/java/org/itech/ahb/integration/UnifiedRoutingTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.mockito.Mockito.*;
 
@@ -79,7 +80,7 @@ class UnifiedRoutingTest {
         httpServer = HttpServer.create(new InetSocketAddress(0), 0);
         serverPort = httpServer.getAddress().getPort();
 
-        httpServer.createContext("/api/OpenELIS-Global/analyzer/", exchange -> {
+        var captureHandler = (com.sun.net.httpserver.HttpHandler) exchange -> {
             String path = exchange.getRequestURI().getPath();
             String sourceProtocol = exchange.getRequestHeaders().getFirst(HttpForwardingRouter.HEADER_SOURCE_PROTOCOL);
             String sourceTransport = exchange.getRequestHeaders().getFirst(HttpForwardingRouter.HEADER_SOURCE_TRANSPORT);
@@ -104,7 +105,9 @@ class UnifiedRoutingTest {
             } finally {
                 exchange.close();
             }
-        });
+        };
+        httpServer.createContext("/api/OpenELIS-Global/analyzer/", captureHandler);
+        httpServer.createContext("/api/OpenELIS-Global/rest/analyzers/", captureHandler);
         httpServer.start();
 
         // Wire full M7 pipeline
@@ -121,6 +124,8 @@ class UnifiedRoutingTest {
         fileConfig.setEnabled(true);
         CSVParser csvParser = new CSVParser(fileConfig);
         fileHandler = new FileMessageHandler(csvParser, fileConfig, normalizer);
+        ReflectionTestUtils.setField(fileHandler, "openelisBaseUrl",
+                "http://127.0.0.1:" + serverPort + "/api/OpenELIS-Global");
 
         httpController = new AnalyzerInputController(normalizer);
 
@@ -203,7 +208,7 @@ class UnifiedRoutingTest {
     class FileHandlerTests {
 
         @Test
-        @DisplayName("File CSV drop routes to /analyzer/csv with correct headers")
+        @DisplayName("File CSV posts to OpenELIS direct-import REST path (bridge-owned FILE delivery)")
         void fileCsvRoutesCorrectly() throws Exception {
             resetLatch();
             Path csvFile = tempDir.resolve("results.csv");
@@ -213,11 +218,10 @@ class UnifiedRoutingTest {
             fileHandler.processFile(csvFile, "QUANTSTUDIO-001");
 
             CapturedRequest req = awaitRequest();
-            assertTrue(req.path().endsWith("/csv"), "Path should end with /csv, got: " + req.path());
-            assertEquals("CSV", req.sourceProtocol());
-            assertEquals("FILE", req.sourceTransport());
-            assertTrue(req.sourceId().contains("results.csv"));
+            assertTrue(req.path().contains("/rest/analyzers/QUANTSTUDIO-001/import"),
+                    "Path should include /rest/analyzers/{id}/import, got: " + req.path());
             assertEquals("QUANTSTUDIO-001", req.analyzerId());
+            assertTrue(req.body().contains("Content-Disposition: form-data"), "Expected multipart body");
         }
     }
 


### PR DESCRIPTION
## Summary
- make the bridge FILE watcher runtime registration-driven with add/remove directory lifecycle support
- wire analyzer registration/unregistration APIs to mutate live watcher state for FILE analyzers
- route FILE deliveries directly to OpenELIS direct-import endpoint instead of legacy normalizer CSV path

## Test plan
- [x] `mvn -q -Dtest=\"FileWatcherTest,AnalyzerRegistryConfigTest\" test`
- [x] verify runtime watch directory registration/removal tests pass
- [ ] run full bridge CI workflow

Made with [Cursor](https://cursor.com)