### PR TITLE
fix: classify QuantStudio control rows in FILE parser

### DIFF
--- a/src/main/java/org/itech/ahb/fhir/FileResultParser.java
+++ b/src/main/java/org/itech/ahb/fhir/FileResultParser.java
@@ -3,6 +3,7 @@ package org.itech.ahb.fhir;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -28,6 +29,9 @@ import org.itech.ahb.fhir.FhirBundleBuilder.AnalyzerResult;
  */
 @Slf4j
 public class FileResultParser {
+
+    private static final List<String> QUANTSTUDIO_CONTROL_PREFIXES = Arrays.asList(
+            "CNEG", "CPOS", "NTC", "PTC");
 
     /**
      * Parse an Excel file and extract results using column mappings.
@@ -83,6 +87,7 @@ public class FileResultParser {
                 String result = getCellValue(row, fieldIndex.get("result"), formatter);
                 String units = getCellValue(row, fieldIndex.get("units"), formatter);
                 String interpretation = getCellValue(row, fieldIndex.get("interpretation"), formatter);
+                String qcTask = getCellValue(row, fieldIndex.get("qcTask"), formatter);
 
                 if (sampleId == null || sampleId.isBlank()) continue;
                 if (testCode == null || testCode.isBlank()) continue;
@@ -95,6 +100,7 @@ public class FileResultParser {
                 AnalyzerResult ar = isNumeric
                         ? AnalyzerResult.numeric(testCode, testCode, value, units)
                         : AnalyzerResult.text(testCode, testCode, value);
+                ar = ar.withControl(isControlRow(sampleId, qcTask));
 
                 resultsByAccession.computeIfAbsent(sampleId, k -> new ArrayList<>()).add(ar);
             }
@@ -187,5 +193,17 @@ public class FileResultParser {
         } catch (NumberFormatException e) {
             return false;
         }
+    }
+
+    private static boolean isControlRow(String sampleId, String qcTask) {
+        if (qcTask != null && "CONTROL".equalsIgnoreCase(qcTask.trim())) {
+            return true;
+        }
+        if (sampleId == null) {
+            return false;
+        }
+        String normalizedSampleId = sampleId.trim().toUpperCase();
+        return QUANTSTUDIO_CONTROL_PREFIXES.stream()
+                .anyMatch(normalizedSampleId::startsWith);
     }
 }

--- a/src/test/java/org/itech/ahb/fhir/FileResultParserTest.java
+++ b/src/test/java/org/itech/ahb/fhir/FileResultParserTest.java
@@ -357,4 +357,56 @@ class FileResultParserTest {
             assertEquals("Positive", results.get(0).results().get(0).value());
         }
     }
+
+    @Nested
+    @DisplayName("QC classification")
+    class QcClassification {
+
+        @Test
+        @DisplayName("QuantStudio control accession is flagged as QC")
+        void quantStudioControlAccessionFlaggedAsQc() {
+            InputStream xlsx = buildXlsx("Results",
+                    new String[]{"Well", "Sample Name", "Target Name", "Quantity Mean", "Task"},
+                    new Object[][]{
+                            {"A1", "CNEG", "VIH-1", "1520.5", "Control"},
+                    });
+
+            Map<String, String> mappings = Map.of(
+                    "Sample Name", "sampleId",
+                    "Target Name", "testCode",
+                    "Quantity Mean", "result",
+                    "Task", "qcTask");
+
+            List<ParsedResults> results = FileResultParser.parse(xlsx, mappings);
+
+            assertNotNull(results);
+            assertEquals(1, results.size());
+            assertEquals("CNEG", results.get(0).accessionNumber());
+            assertTrue(results.get(0).results().get(0).isControl(),
+                    "QuantStudio control accession should be flagged as QC");
+        }
+
+        @Test
+        @DisplayName("QuantStudio patient accession remains non-QC")
+        void quantStudioPatientAccessionRemainsNonQc() {
+            InputStream xlsx = buildXlsx("Results",
+                    new String[]{"Well", "Sample Name", "Target Name", "Quantity Mean", "Task"},
+                    new Object[][]{
+                            {"A1", "HARN-QS7-2026-00001", "VIH-1", "1520.5", "UNKNOWN"},
+                    });
+
+            Map<String, String> mappings = Map.of(
+                    "Sample Name", "sampleId",
+                    "Target Name", "testCode",
+                    "Quantity Mean", "result",
+                    "Task", "qcTask");
+
+            List<ParsedResults> results = FileResultParser.parse(xlsx, mappings);
+
+            assertNotNull(results);
+            assertEquals(1, results.size());
+            assertFalse(results.get(0).results().get(0).isControl(),
+                    "Patient accession should not be flagged as QC");
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- classify QuantStudio control rows from workbook context using `Task` plus known control accession prefixes
- mark parsed FILE results as QC so downstream OpenELIS imports can distinguish control rows from patient rows
- add focused parser tests for control and patient accessions

## Test plan
- [x] `mvn -Dtest=FileResultParserTest test`

Made with [Cursor](https://cursor.com)