### PR TITLE
fix: faster file watcher polling in dev profile

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -10,6 +10,13 @@ management:
     health:
       show-details: always
 
+# File watcher — faster polling for dev/CI (files are written atomically).
+# Production keeps FileConfig.java defaults (5000ms poll, 3000ms stability).
+bridge:
+  file:
+    poll-interval-ms: 1000
+    file-stability-timeout-ms: 500
+
 # MLLP Server Configuration (HL7 v2.x transport)
 org.itech.ahb.mllp:
   enabled: true


### PR DESCRIPTION
## Summary
- Set `bridge.file.poll-interval-ms` to 1000ms (from 5000ms default) in dev profile
- Set `bridge.file.file-stability-timeout-ms` to 500ms (from 3000ms default) in dev profile
- Files in dev/CI are written atomically, so the 3s stability timeout is unnecessary overhead
- Production keeps the safe defaults from `FileConfig.java` (5s poll, 3s stability)

## Context
Paired with DIGI-UW/OpenELIS-Global-2#3269 which also adds explicit CI env var overrides in the compose overlay.

## Test plan
- [ ] CI E2E Analyzer Harness tests pass with the faster polling
- [ ] Verify `FileWatcher` logs `interval=1000ms` on startup with `SPRING_PROFILES_ACTIVE=dev`