### PR TITLE
feat(bridge): unknown source DLQ, OE discovery, and OeApiClient

### DIFF
--- a/src/main/java/org/itech/ahb/normalizer/MessageNormalizer.java
+++ b/src/main/java/org/itech/ahb/normalizer/MessageNormalizer.java
@@ -2,10 +2,14 @@ package org.itech.ahb.normalizer;
 
 import io.micrometer.core.instrument.Timer;
 import lombok.extern.slf4j.Slf4j;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import org.itech.ahb.config.AnalyzerRegistryConfig;
 import org.itech.ahb.metrics.MetricsService;
 import org.itech.ahb.routing.HttpForwardingRouter;
 import org.itech.ahb.routing.MessageRouter;
+import org.itech.ahb.util.DeadLetterWriter;
+import org.itech.ahb.util.OeApiClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
@@ -46,6 +50,8 @@ public class MessageNormalizer implements MessageRouter {
     private final AnalyzerIdentifier identifier;
     private final AnalyzerRegistryConfig registry;  // optional — for diagnostic validation only
     private final MetricsService metricsService;  // nullable — optional dependency
+    private final OeApiClient oeApiClient;  // nullable — for discovered-source reporting
+    private final DeadLetterWriter deadLetterWriter;  // nullable — for DLQ on unknown sources
 
     /**
      * Constructs a new MessageNormalizer.
@@ -62,7 +68,7 @@ public class MessageNormalizer implements MessageRouter {
             HttpForwardingRouter forwardingRouter,
             AnalyzerIdentifier identifier,
             MetricsService metricsService) {
-        this(forwardingRouter, identifier, null, metricsService);
+        this(forwardingRouter, identifier, null, metricsService, null, null);
     }
 
     @Autowired
@@ -70,11 +76,15 @@ public class MessageNormalizer implements MessageRouter {
             HttpForwardingRouter forwardingRouter,
             AnalyzerIdentifier identifier,
             @Autowired(required = false) AnalyzerRegistryConfig registry,
-            @Autowired(required = false) MetricsService metricsService) {
+            @Autowired(required = false) MetricsService metricsService,
+            @Autowired(required = false) OeApiClient oeApiClient,
+            @Autowired(required = false) DeadLetterWriter deadLetterWriter) {
         this.forwardingRouter = forwardingRouter;
         this.identifier = identifier;
         this.registry = registry;
         this.metricsService = metricsService;
+        this.oeApiClient = oeApiClient;
+        this.deadLetterWriter = deadLetterWriter;
     }
 
     /**
@@ -150,6 +160,7 @@ public class MessageNormalizer implements MessageRouter {
         if (resolvedAnalyzerId == null || resolvedAnalyzerId.isBlank()) {
             log.warn("No registered analyzer for source '{}'; protocolHint='{}' — message will not be routed",
                 envelope.getSourceId(), protocolHint);
+            handleUnknownSource(envelope, protocolHint);
             if (metricsService != null) {
                 metricsService.recordRouted(sample, protocol, transport, false);
             }
@@ -206,6 +217,32 @@ public class MessageNormalizer implements MessageRouter {
         }
 
         return success;
+    }
+
+    private void handleUnknownSource(MessageEnvelope envelope, String protocolHint) {
+        // Report discovered source to OE (creates PENDING_REGISTRATION stub)
+        if (oeApiClient != null) {
+            try {
+                Map<String, String> body = new LinkedHashMap<>();
+                body.put("sourceId", envelope.getSourceId());
+                body.put("protocol", envelope.getProtocol() != null ? envelope.getProtocol().name() : null);
+                body.put("protocolHint", protocolHint);
+                body.put("transport", envelope.getTransport() != null ? envelope.getTransport().name() : null);
+                Map<String, Object> result = oeApiClient.post("/rest/analyzer/discovered-sources", body);
+                if (result != null) {
+                    log.info("Reported unknown source '{}' to OE: analyzerId={}, alreadyExists={}",
+                        envelope.getSourceId(), result.get("analyzerId"), result.get("alreadyExists"));
+                }
+            } catch (Exception e) {
+                log.warn("Failed to report unknown source '{}' to OE: {}",
+                    envelope.getSourceId(), e.getMessage());
+            }
+        }
+
+        // Write message to dead-letter directory
+        if (deadLetterWriter != null) {
+            deadLetterWriter.write(envelope, "UNREGISTERED_SOURCE");
+        }
     }
 
     private String firstNonBlank(String first, String second) {

--- a/src/main/java/org/itech/ahb/normalizer/MessageNormalizer.java
+++ b/src/main/java/org/itech/ahb/normalizer/MessageNormalizer.java
@@ -52,17 +52,10 @@ public class MessageNormalizer implements MessageRouter {
     private final MetricsService metricsService;  // nullable — optional dependency
     private final OeApiClient oeApiClient;  // nullable — for discovered-source reporting
     private final DeadLetterWriter deadLetterWriter;  // nullable — for DLQ on unknown sources
+    private final java.util.concurrent.Executor asyncExecutor;
 
     /**
-     * Constructs a new MessageNormalizer.
-     * <p>
-     * Injects {@link HttpForwardingRouter} by concrete type (not MessageRouter interface)
-     * to avoid circular injection ambiguity, since this class also implements MessageRouter.
-     * </p>
-     *
-     * @param forwardingRouter the HTTP forwarding router for sending to OpenELIS
-     * @param identifier the analyzer identification service
-     * @param metricsService optional metrics service (null if MetricsService bean is not created)
+     * Minimal constructor for tests and non-discovery use cases.
      */
     public MessageNormalizer(
             HttpForwardingRouter forwardingRouter,
@@ -79,12 +72,26 @@ public class MessageNormalizer implements MessageRouter {
             @Autowired(required = false) MetricsService metricsService,
             @Autowired(required = false) OeApiClient oeApiClient,
             @Autowired(required = false) DeadLetterWriter deadLetterWriter) {
+        this(forwardingRouter, identifier, registry, metricsService, oeApiClient, deadLetterWriter,
+                java.util.concurrent.ForkJoinPool.commonPool());
+    }
+
+    /** Test constructor — accepts a custom executor for deterministic async verification. */
+    public MessageNormalizer(
+            HttpForwardingRouter forwardingRouter,
+            AnalyzerIdentifier identifier,
+            AnalyzerRegistryConfig registry,
+            MetricsService metricsService,
+            OeApiClient oeApiClient,
+            DeadLetterWriter deadLetterWriter,
+            java.util.concurrent.Executor asyncExecutor) {
         this.forwardingRouter = forwardingRouter;
         this.identifier = identifier;
         this.registry = registry;
         this.metricsService = metricsService;
         this.oeApiClient = oeApiClient;
         this.deadLetterWriter = deadLetterWriter;
+        this.asyncExecutor = asyncExecutor;
     }
 
     /**
@@ -240,7 +247,7 @@ public class MessageNormalizer implements MessageRouter {
                 } catch (Exception e) {
                     log.warn("Failed to report unknown source '{}' to OE: {}", sourceId, e.getMessage());
                 }
-            });
+            }, asyncExecutor);
         }
 
         // DLQ write stays synchronous — local filesystem, fast

--- a/src/main/java/org/itech/ahb/normalizer/MessageNormalizer.java
+++ b/src/main/java/org/itech/ahb/normalizer/MessageNormalizer.java
@@ -220,26 +220,30 @@ public class MessageNormalizer implements MessageRouter {
     }
 
     private void handleUnknownSource(MessageEnvelope envelope, String protocolHint) {
-        // Report discovered source to OE (creates PENDING_REGISTRATION stub)
+        // Report discovered source to OE asynchronously (don't block message processing)
         if (oeApiClient != null) {
-            try {
-                Map<String, String> body = new LinkedHashMap<>();
-                body.put("sourceId", envelope.getSourceId());
-                body.put("protocol", envelope.getProtocol() != null ? envelope.getProtocol().name() : null);
-                body.put("protocolHint", protocolHint);
-                body.put("transport", envelope.getTransport() != null ? envelope.getTransport().name() : null);
-                Map<String, Object> result = oeApiClient.post("/rest/analyzer/discovered-sources", body);
-                if (result != null) {
-                    log.info("Reported unknown source '{}' to OE: analyzerId={}, alreadyExists={}",
-                        envelope.getSourceId(), result.get("analyzerId"), result.get("alreadyExists"));
+            final String sourceId = envelope.getSourceId();
+            final String protocolName = envelope.getProtocol() != null ? envelope.getProtocol().name() : null;
+            final String transportName = envelope.getTransport() != null ? envelope.getTransport().name() : null;
+            java.util.concurrent.CompletableFuture.runAsync(() -> {
+                try {
+                    Map<String, String> body = new LinkedHashMap<>();
+                    body.put("sourceId", sourceId);
+                    body.put("protocol", protocolName);
+                    body.put("protocolHint", protocolHint);
+                    body.put("transport", transportName);
+                    Map<String, Object> result = oeApiClient.post("/rest/analyzer/discovered-sources", body);
+                    if (result != null) {
+                        log.info("Reported unknown source '{}' to OE: analyzerId={}, alreadyExists={}",
+                            sourceId, result.get("analyzerId"), result.get("alreadyExists"));
+                    }
+                } catch (Exception e) {
+                    log.warn("Failed to report unknown source '{}' to OE: {}", sourceId, e.getMessage());
                 }
-            } catch (Exception e) {
-                log.warn("Failed to report unknown source '{}' to OE: {}",
-                    envelope.getSourceId(), e.getMessage());
-            }
+            });
         }
 
-        // Write message to dead-letter directory
+        // DLQ write stays synchronous — local filesystem, fast
         if (deadLetterWriter != null) {
             deadLetterWriter.write(envelope, "UNREGISTERED_SOURCE");
         }

--- a/src/main/java/org/itech/ahb/startup/AnalyzerRegistryBootstrap.java
+++ b/src/main/java/org/itech/ahb/startup/AnalyzerRegistryBootstrap.java
@@ -2,21 +2,15 @@ package org.itech.ahb.startup;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
-import java.nio.file.Path;
 import org.itech.ahb.config.AnalyzerRegistryConfig;
 import org.itech.ahb.config.AnalyzerRegistryConfig.AnalyzerEntry;
-import org.itech.ahb.config.properties.HTTPForwardServerConfigurationProperties;
 import org.itech.ahb.file.FileWatcher;
-import org.itech.ahb.util.HttpClientFactory;
+import org.itech.ahb.util.OeApiClient;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
@@ -40,73 +34,38 @@ import org.springframework.stereotype.Component;
 public class AnalyzerRegistryBootstrap {
 
     private final AnalyzerRegistryConfig registry;
-    private final HTTPForwardServerConfigurationProperties httpConfig;
+    private final OeApiClient oeApiClient;
     private final FileWatcher fileWatcher;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     public AnalyzerRegistryBootstrap(
             AnalyzerRegistryConfig registry,
-            HTTPForwardServerConfigurationProperties httpConfig,
+            OeApiClient oeApiClient,
             @org.springframework.beans.factory.annotation.Autowired(required = false)
             FileWatcher fileWatcher) {
         this.registry = registry;
-        this.httpConfig = httpConfig;
+        this.oeApiClient = oeApiClient;
         this.fileWatcher = fileWatcher;
     }
 
     @EventListener(ApplicationReadyEvent.class)
     public void pullAnalyzersFromOE() {
-        URI oeBaseUri = httpConfig.getUri();
-        if (oeBaseUri == null) {
+        if (!oeApiClient.isConfigured()) {
             log.warn("No OpenELIS URI configured — skipping analyzer registry bootstrap");
             return;
         }
 
-        // Build the analyzers API URL from the OE forward URI
-        // Forward URI is like: https://oe:8443/OpenELIS-Global/analyzer (for ASTM forwarding)
-        // Strip the /analyzer suffix to get the webapp base, then append REST path
-        String baseUrl = oeBaseUri.toString().replaceAll("/+$", "").replaceAll("/analyzer$", "");
-        String analyzersUrl = baseUrl + "/rest/analyzer/analyzers";
-
-        log.info("Pulling analyzer registry from OE: {}", analyzersUrl);
+        log.info("Pulling analyzer registry from OE...");
 
         try {
-            int connectTimeout = httpConfig.getConnectTimeoutSeconds();
-            int readTimeout = httpConfig.getReadTimeoutSeconds();
-
-            HttpClient client = HttpClientFactory.create(
-                    connectTimeout,
-                    httpConfig.isInsecureTls(),
-                    "registry-bootstrap");
-
-            HttpRequest.Builder builder = HttpRequest.newBuilder()
-                    .uri(URI.create(analyzersUrl))
-                    .GET()
-                    .timeout(java.time.Duration.ofSeconds(readTimeout))
-                    .header("Accept", "application/json");
-
-            // Add Basic auth
-            if (httpConfig.getUsername() != null && httpConfig.getPassword() != null) {
-                String credentials = httpConfig.getUsername() + ":"
-                        + new String(httpConfig.getPassword());
-                String encoded = Base64.getEncoder().encodeToString(
-                        credentials.getBytes(StandardCharsets.UTF_8));
-                builder.header("Authorization", "Basic " + encoded);
-            }
-
-            HttpResponse<String> response = client.send(
-                    builder.build(),
-                    HttpResponse.BodyHandlers.ofString());
-
-            if (response.statusCode() != 200) {
-                log.warn("OE returned {} for analyzer pull — registry not bootstrapped",
-                        response.statusCode());
+            String responseBody = oeApiClient.getString("/rest/analyzer/analyzers");
+            if (responseBody == null) {
+                log.warn("Failed to pull analyzers from OE — registry not bootstrapped");
                 return;
             }
 
-            // Parse response: {"analyzers": [...]}
             Map<String, Object> body = objectMapper.readValue(
-                    response.body(), new TypeReference<>() {
+                    responseBody, new TypeReference<>() {
                     });
 
             Object analyzersObj = body.get("analyzers");
@@ -118,7 +77,7 @@ public class AnalyzerRegistryBootstrap {
             @SuppressWarnings("unchecked")
             List<Map<String, Object>> analyzers = (List<Map<String, Object>>) analyzersObj;
 
-            java.util.LinkedHashMap<String, AnalyzerEntry> newRegistry = new java.util.LinkedHashMap<>();
+            LinkedHashMap<String, AnalyzerEntry> newRegistry = new LinkedHashMap<>();
             int fileCount = 0;
             for (Map<String, Object> analyzer : analyzers) {
                 Object idObj = analyzer.get("id");
@@ -136,7 +95,6 @@ public class AnalyzerRegistryBootstrap {
                 String protocol = (String) analyzer.get("protocolVersion");
 
                 if (ip != null && !ip.isBlank()) {
-                    // TCP analyzer (ASTM or HL7)
                     AnalyzerEntry entry = new AnalyzerEntry();
                     entry.setId(id);
                     entry.setName(name);
@@ -145,7 +103,6 @@ public class AnalyzerRegistryBootstrap {
                     newRegistry.put(ip, entry);
                 }
 
-                // FILE analyzer — register watch directory
                 String importDir = (String) analyzer.get("importDirectory");
                 if (importDir != null && !importDir.isBlank() && fileWatcher != null) {
                     String filePattern = (String) analyzer.get("filePattern");
@@ -156,7 +113,6 @@ public class AnalyzerRegistryBootstrap {
                     if (filePattern != null) {
                         entry.setFilePattern(filePattern);
                     }
-                    // Extract column mappings if present
                     @SuppressWarnings("unchecked")
                     Map<String, String> colMappings = (Map<String, String>) analyzer.get("columnMappings");
                     if (colMappings != null) {
@@ -180,11 +136,8 @@ public class AnalyzerRegistryBootstrap {
             }
 
         } catch (java.net.ConnectException e) {
-            log.warn("Cannot reach OE at {} — bridge starting without analyzer registry. "
-                    + "OE will push registrations when it starts.", analyzersUrl);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            log.warn("Bootstrap interrupted — bridge starting without analyzer registry");
+            log.warn("Cannot reach OE — bridge starting without analyzer registry. "
+                    + "OE will push registrations when it starts.");
         } catch (Exception e) {
             log.warn("Failed to pull analyzers from OE: {} — bridge starting without registry. "
                     + "OE will push registrations on next CRUD operation.", e.getMessage());

--- a/src/main/java/org/itech/ahb/util/DeadLetterWriter.java
+++ b/src/main/java/org/itech/ahb/util/DeadLetterWriter.java
@@ -1,0 +1,78 @@
+package org.itech.ahb.util;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import lombok.extern.slf4j.Slf4j;
+import org.itech.ahb.normalizer.MessageEnvelope;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Writes unroutable messages to a filesystem dead-letter directory.
+ * Each message produces two files: payload and metadata sidecar.
+ */
+@Component
+@Slf4j
+public class DeadLetterWriter {
+
+    private static final DateTimeFormatter TS_FORMAT = DateTimeFormatter
+            .ofPattern("yyyyMMdd'T'HHmmss.SSS")
+            .withZone(ZoneOffset.UTC);
+
+    @Value("${bridge.deadLetter.directory:${java.io.tmpdir}/openelis-analyzer-bridge/dead-letters}")
+    private String deadLetterDirectory;
+
+    /**
+     * Write a message to the dead-letter directory with a metadata sidecar.
+     *
+     * @return true if written successfully, false on failure
+     */
+    public boolean write(MessageEnvelope envelope, String reason) {
+        try {
+            Path dir = Path.of(deadLetterDirectory);
+            Files.createDirectories(dir);
+
+            String timestamp = TS_FORMAT.format(
+                    envelope.getReceivedAt() != null ? envelope.getReceivedAt() : Instant.now());
+            String sourceSlug = sanitize(envelope.getSourceId());
+            String baseName = String.format("%s_%s_%s",
+                    timestamp, envelope.getProtocol(), sourceSlug);
+
+            // Payload
+            Path payloadFile = dir.resolve(baseName + ".msg");
+            Files.writeString(payloadFile, envelope.getRawMessage());
+
+            // Metadata sidecar
+            Path metaFile = dir.resolve(baseName + ".meta");
+            String meta = String.join("\n",
+                    "sourceId=" + envelope.getSourceId(),
+                    "protocol=" + envelope.getProtocol(),
+                    "transport=" + envelope.getTransport(),
+                    "protocolHint=" + firstNonNull(envelope.getProtocolAnalyzerHint(), ""),
+                    "sourcePort=" + (envelope.getSourcePort() != null ? envelope.getSourcePort() : ""),
+                    "receivedAt=" + timestamp,
+                    "reason=" + reason);
+            Files.writeString(metaFile, meta);
+
+            log.info("Dead-lettered message: {} (reason: {})", payloadFile, reason);
+            return true;
+        } catch (IOException e) {
+            log.error("Failed to write dead letter for source '{}': {}",
+                    envelope.getSourceId(), e.getMessage());
+            return false;
+        }
+    }
+
+    private static String sanitize(String value) {
+        if (value == null) return "unknown";
+        return value.replaceAll("[^a-zA-Z0-9._-]", "_");
+    }
+
+    private static String firstNonNull(String a, String b) {
+        return a != null ? a : b;
+    }
+}

--- a/src/main/java/org/itech/ahb/util/DeadLetterWriter.java
+++ b/src/main/java/org/itech/ahb/util/DeadLetterWriter.java
@@ -2,13 +2,13 @@ package org.itech.ahb.util;
 
 import jakarta.annotation.PostConstruct;
 import java.io.IOException;
-import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.itech.ahb.normalizer.MessageEnvelope;
 import org.springframework.beans.factory.annotation.Value;
@@ -47,20 +47,14 @@ public class DeadLetterWriter {
             String timestamp = TS_FORMAT.format(
                     envelope.getReceivedAt() != null ? envelope.getReceivedAt() : Instant.now());
             String sourceSlug = sanitize(envelope.getSourceId());
-            String baseName = String.format("%s_%s_%s_%d",
-                    timestamp, envelope.getProtocol(), sourceSlug, System.nanoTime() % 100000);
+            String uniqueId = UUID.randomUUID().toString().substring(0, 8);
+            String baseName = String.format("%s_%s_%s_%s",
+                    timestamp, envelope.getProtocol(), sourceSlug, uniqueId);
 
-            // Payload — CREATE_NEW to detect collisions
+            // Payload + metadata — CREATE_NEW guarantees no overwrites
             Path payloadFile = dlqPath.resolve(baseName + ".msg");
-            try {
-                Files.writeString(payloadFile, envelope.getRawMessage(), StandardOpenOption.CREATE_NEW);
-            } catch (FileAlreadyExistsException e) {
-                baseName = baseName + "_" + System.nanoTime();
-                payloadFile = dlqPath.resolve(baseName + ".msg");
-                Files.writeString(payloadFile, envelope.getRawMessage());
-            }
+            Files.writeString(payloadFile, envelope.getRawMessage(), StandardOpenOption.CREATE_NEW);
 
-            // Metadata sidecar
             Path metaFile = dlqPath.resolve(baseName + ".meta");
             String meta = String.join("\n",
                     "sourceId=" + envelope.getSourceId(),
@@ -70,7 +64,7 @@ public class DeadLetterWriter {
                     "sourcePort=" + (envelope.getSourcePort() != null ? envelope.getSourcePort() : ""),
                     "receivedAt=" + timestamp,
                     "reason=" + reason);
-            Files.writeString(metaFile, meta);
+            Files.writeString(metaFile, meta, StandardOpenOption.CREATE_NEW);
 
             log.info("Dead-lettered message: {} (reason: {})", payloadFile, reason);
             return true;

--- a/src/main/java/org/itech/ahb/util/DeadLetterWriter.java
+++ b/src/main/java/org/itech/ahb/util/DeadLetterWriter.java
@@ -1,8 +1,11 @@
 package org.itech.ahb.util;
 
+import jakarta.annotation.PostConstruct;
 import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
@@ -26,6 +29,14 @@ public class DeadLetterWriter {
     @Value("${bridge.deadLetter.directory:${java.io.tmpdir}/openelis-analyzer-bridge/dead-letters}")
     private String deadLetterDirectory;
 
+    private Path dlqPath;
+
+    @PostConstruct
+    void init() throws IOException {
+        dlqPath = Path.of(deadLetterDirectory);
+        Files.createDirectories(dlqPath);
+    }
+
     /**
      * Write a message to the dead-letter directory with a metadata sidecar.
      *
@@ -33,21 +44,24 @@ public class DeadLetterWriter {
      */
     public boolean write(MessageEnvelope envelope, String reason) {
         try {
-            Path dir = Path.of(deadLetterDirectory);
-            Files.createDirectories(dir);
-
             String timestamp = TS_FORMAT.format(
                     envelope.getReceivedAt() != null ? envelope.getReceivedAt() : Instant.now());
             String sourceSlug = sanitize(envelope.getSourceId());
-            String baseName = String.format("%s_%s_%s",
-                    timestamp, envelope.getProtocol(), sourceSlug);
+            String baseName = String.format("%s_%s_%s_%d",
+                    timestamp, envelope.getProtocol(), sourceSlug, System.nanoTime() % 100000);
 
-            // Payload
-            Path payloadFile = dir.resolve(baseName + ".msg");
-            Files.writeString(payloadFile, envelope.getRawMessage());
+            // Payload — CREATE_NEW to detect collisions
+            Path payloadFile = dlqPath.resolve(baseName + ".msg");
+            try {
+                Files.writeString(payloadFile, envelope.getRawMessage(), StandardOpenOption.CREATE_NEW);
+            } catch (FileAlreadyExistsException e) {
+                baseName = baseName + "_" + System.nanoTime();
+                payloadFile = dlqPath.resolve(baseName + ".msg");
+                Files.writeString(payloadFile, envelope.getRawMessage());
+            }
 
             // Metadata sidecar
-            Path metaFile = dir.resolve(baseName + ".meta");
+            Path metaFile = dlqPath.resolve(baseName + ".meta");
             String meta = String.join("\n",
                     "sourceId=" + envelope.getSourceId(),
                     "protocol=" + envelope.getProtocol(),

--- a/src/main/java/org/itech/ahb/util/OeApiClient.java
+++ b/src/main/java/org/itech/ahb/util/OeApiClient.java
@@ -15,6 +15,10 @@ import org.springframework.stereotype.Component;
 /**
  * Shared HTTP client for OpenELIS REST API calls from the bridge.
  * Reuses the same base URL, auth, and TLS config as the forwarding router.
+ *
+ * <p>Used by {@link org.itech.ahb.normalizer.MessageNormalizer} for discovered-source
+ * reporting and by {@link org.itech.ahb.startup.AnalyzerRegistryBootstrap} for
+ * registry pull on startup.
  */
 @Component
 @Slf4j
@@ -27,6 +31,41 @@ public class OeApiClient {
         this.httpConfig = httpConfig;
     }
 
+    /** Returns true if the OE base URL is configured. */
+    public boolean isConfigured() {
+        return httpConfig.getUri() != null;
+    }
+
+    /**
+     * GET an OE REST API path. Returns the raw response body as a String,
+     * or null on non-2xx / failure.
+     */
+    public String getString(String restPath) {
+        String baseUrl = deriveOeBaseUrl();
+        if (baseUrl == null) {
+            log.warn("No OE base URL — cannot GET {}", restPath);
+            return null;
+        }
+        String url = baseUrl + restPath;
+        try {
+            HttpRequest request = newRequestBuilder(url).GET().build();
+            HttpResponse<String> response = newClient().send(request,
+                    HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() >= 200 && response.statusCode() < 300) {
+                return response.body();
+            }
+            log.warn("OE returned {} for GET {}", response.statusCode(), url);
+            return null;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("Interrupted during GET {}", url);
+            return null;
+        } catch (Exception e) {
+            log.warn("Failed to GET OE {}: {}", url, e.getMessage());
+            return null;
+        }
+    }
+
     /**
      * POST JSON to an OE REST API path. Returns the response body as a Map,
      * or null on failure.
@@ -34,51 +73,56 @@ public class OeApiClient {
     public Map<String, Object> post(String restPath, Map<String, String> body) {
         String baseUrl = deriveOeBaseUrl();
         if (baseUrl == null) {
-            log.warn("No OE base URL — cannot call {}", restPath);
+            log.warn("No OE base URL — cannot POST {}", restPath);
             return null;
         }
-
         String url = baseUrl + restPath;
         try {
-            HttpClient client = HttpClientFactory.create(
-                    httpConfig.getConnectTimeoutSeconds(),
-                    httpConfig.isInsecureTls(),
-                    "oe-api-client");
-
             String jsonBody = objectMapper.writeValueAsString(body);
-
-            HttpRequest.Builder builder = HttpRequest.newBuilder()
-                    .uri(URI.create(url))
+            HttpRequest request = newRequestBuilder(url)
                     .POST(HttpRequest.BodyPublishers.ofString(jsonBody))
-                    .timeout(java.time.Duration.ofSeconds(httpConfig.getReadTimeoutSeconds()))
                     .header("Content-Type", "application/json")
-                    .header("Accept", "application/json");
+                    .build();
 
-            if (httpConfig.getUsername() != null && httpConfig.getPassword() != null) {
-                String credentials = httpConfig.getUsername() + ":"
-                        + new String(httpConfig.getPassword());
-                String encoded = Base64.getEncoder().encodeToString(
-                        credentials.getBytes(StandardCharsets.UTF_8));
-                builder.header("Authorization", "Basic " + encoded);
-            }
-
-            HttpResponse<String> response = client.send(
-                    builder.build(),
+            HttpResponse<String> response = newClient().send(request,
                     HttpResponse.BodyHandlers.ofString());
 
             if (response.statusCode() >= 200 && response.statusCode() < 300) {
                 @SuppressWarnings("unchecked")
-                Map<String, Object> result = objectMapper.readValue(
-                        response.body(), Map.class);
+                Map<String, Object> result = objectMapper.readValue(response.body(), Map.class);
                 return result;
-            } else {
-                log.warn("OE returned {} for POST {}: {}", response.statusCode(), url, response.body());
-                return null;
             }
+            log.warn("OE returned {} for POST {}: {}", response.statusCode(), url, response.body());
+            return null;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("Interrupted during POST {}", url);
+            return null;
         } catch (Exception e) {
             log.warn("Failed to POST to OE {}: {}", url, e.getMessage());
             return null;
         }
+    }
+
+    private HttpClient newClient() {
+        return HttpClientFactory.create(
+                httpConfig.getConnectTimeoutSeconds(),
+                httpConfig.isInsecureTls(),
+                "oe-api-client");
+    }
+
+    private HttpRequest.Builder newRequestBuilder(String url) {
+        HttpRequest.Builder builder = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .timeout(java.time.Duration.ofSeconds(httpConfig.getReadTimeoutSeconds()))
+                .header("Accept", "application/json");
+
+        if (httpConfig.getUsername() != null && httpConfig.getPassword() != null) {
+            String credentials = httpConfig.getUsername() + ":" + new String(httpConfig.getPassword());
+            String encoded = Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+            builder.header("Authorization", "Basic " + encoded);
+        }
+        return builder;
     }
 
     private String deriveOeBaseUrl() {

--- a/src/main/java/org/itech/ahb/util/OeApiClient.java
+++ b/src/main/java/org/itech/ahb/util/OeApiClient.java
@@ -26,9 +26,14 @@ public class OeApiClient {
 
     private final HTTPForwardServerConfigurationProperties httpConfig;
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final HttpClient httpClient;
 
     public OeApiClient(HTTPForwardServerConfigurationProperties httpConfig) {
         this.httpConfig = httpConfig;
+        this.httpClient = HttpClientFactory.create(
+                httpConfig.getConnectTimeoutSeconds(),
+                httpConfig.isInsecureTls(),
+                "oe-api-client");
     }
 
     /** Returns true if the OE base URL is configured. */
@@ -49,7 +54,7 @@ public class OeApiClient {
         String url = baseUrl + restPath;
         try {
             HttpRequest request = newRequestBuilder(url).GET().build();
-            HttpResponse<String> response = newClient().send(request,
+            HttpResponse<String> response = httpClient.send(request,
                     HttpResponse.BodyHandlers.ofString());
             if (response.statusCode() >= 200 && response.statusCode() < 300) {
                 return response.body();
@@ -84,7 +89,7 @@ public class OeApiClient {
                     .header("Content-Type", "application/json")
                     .build();
 
-            HttpResponse<String> response = newClient().send(request,
+            HttpResponse<String> response = httpClient.send(request,
                     HttpResponse.BodyHandlers.ofString());
 
             if (response.statusCode() >= 200 && response.statusCode() < 300) {
@@ -102,13 +107,6 @@ public class OeApiClient {
             log.warn("Failed to POST to OE {}: {}", url, e.getMessage());
             return null;
         }
-    }
-
-    private HttpClient newClient() {
-        return HttpClientFactory.create(
-                httpConfig.getConnectTimeoutSeconds(),
-                httpConfig.isInsecureTls(),
-                "oe-api-client");
     }
 
     private HttpRequest.Builder newRequestBuilder(String url) {

--- a/src/main/java/org/itech/ahb/util/OeApiClient.java
+++ b/src/main/java/org/itech/ahb/util/OeApiClient.java
@@ -1,0 +1,91 @@
+package org.itech.ahb.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.itech.ahb.config.properties.HTTPForwardServerConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Shared HTTP client for OpenELIS REST API calls from the bridge.
+ * Reuses the same base URL, auth, and TLS config as the forwarding router.
+ */
+@Component
+@Slf4j
+public class OeApiClient {
+
+    private final HTTPForwardServerConfigurationProperties httpConfig;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public OeApiClient(HTTPForwardServerConfigurationProperties httpConfig) {
+        this.httpConfig = httpConfig;
+    }
+
+    /**
+     * POST JSON to an OE REST API path. Returns the response body as a Map,
+     * or null on failure.
+     */
+    public Map<String, Object> post(String restPath, Map<String, String> body) {
+        String baseUrl = deriveOeBaseUrl();
+        if (baseUrl == null) {
+            log.warn("No OE base URL — cannot call {}", restPath);
+            return null;
+        }
+
+        String url = baseUrl + restPath;
+        try {
+            HttpClient client = HttpClientFactory.create(
+                    httpConfig.getConnectTimeoutSeconds(),
+                    httpConfig.isInsecureTls(),
+                    "oe-api-client");
+
+            String jsonBody = objectMapper.writeValueAsString(body);
+
+            HttpRequest.Builder builder = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .POST(HttpRequest.BodyPublishers.ofString(jsonBody))
+                    .timeout(java.time.Duration.ofSeconds(httpConfig.getReadTimeoutSeconds()))
+                    .header("Content-Type", "application/json")
+                    .header("Accept", "application/json");
+
+            if (httpConfig.getUsername() != null && httpConfig.getPassword() != null) {
+                String credentials = httpConfig.getUsername() + ":"
+                        + new String(httpConfig.getPassword());
+                String encoded = Base64.getEncoder().encodeToString(
+                        credentials.getBytes(StandardCharsets.UTF_8));
+                builder.header("Authorization", "Basic " + encoded);
+            }
+
+            HttpResponse<String> response = client.send(
+                    builder.build(),
+                    HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() >= 200 && response.statusCode() < 300) {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> result = objectMapper.readValue(
+                        response.body(), Map.class);
+                return result;
+            } else {
+                log.warn("OE returned {} for POST {}: {}", response.statusCode(), url, response.body());
+                return null;
+            }
+        } catch (Exception e) {
+            log.warn("Failed to POST to OE {}: {}", url, e.getMessage());
+            return null;
+        }
+    }
+
+    private String deriveOeBaseUrl() {
+        URI uri = httpConfig.getUri();
+        if (uri == null) {
+            return null;
+        }
+        return uri.toString().replaceAll("/+$", "").replaceAll("/analyzer$", "");
+    }
+}

--- a/src/test/java/org/itech/ahb/normalizer/MessageNormalizerTest.java
+++ b/src/test/java/org/itech/ahb/normalizer/MessageNormalizerTest.java
@@ -432,9 +432,10 @@ class MessageNormalizerTest {
             AnalyzerIdentifier rejectingIdentifier = mock(AnalyzerIdentifier.class);
             when(rejectingIdentifier.identify(any())).thenReturn(null);
 
+            // Runnable::run executes on the calling thread — deterministic, no timeout needed
             normalizerWithDlq = new MessageNormalizer(
                 mockForwardingRouter, rejectingIdentifier,
-                null, null, mockOeApiClient, mockDeadLetterWriter);
+                null, null, mockOeApiClient, mockDeadLetterWriter, Runnable::run);
         }
 
         @Test
@@ -452,8 +453,7 @@ class MessageNormalizerTest {
             boolean result = normalizerWithDlq.process(envelope);
 
             assertFalse(result, "Unknown source should not route");
-            // OE call is async — use timeout to wait for CompletableFuture
-            verify(mockOeApiClient, timeout(2000)).post(eq("/rest/analyzer/discovered-sources"), argThat(body ->
+            verify(mockOeApiClient).post(eq("/rest/analyzer/discovered-sources"), argThat(body ->
                 "10.0.0.50".equals(body.get("sourceId"))
                     && "ASTM".equals(body.get("protocol"))
                     && "TCP".equals(body.get("transport"))

--- a/src/test/java/org/itech/ahb/normalizer/MessageNormalizerTest.java
+++ b/src/test/java/org/itech/ahb/normalizer/MessageNormalizerTest.java
@@ -452,7 +452,8 @@ class MessageNormalizerTest {
             boolean result = normalizerWithDlq.process(envelope);
 
             assertFalse(result, "Unknown source should not route");
-            verify(mockOeApiClient).post(eq("/rest/analyzer/discovered-sources"), argThat(body ->
+            // OE call is async — use timeout to wait for CompletableFuture
+            verify(mockOeApiClient, timeout(2000)).post(eq("/rest/analyzer/discovered-sources"), argThat(body ->
                 "10.0.0.50".equals(body.get("sourceId"))
                     && "ASTM".equals(body.get("protocol"))
                     && "TCP".equals(body.get("transport"))

--- a/src/test/java/org/itech/ahb/normalizer/MessageNormalizerTest.java
+++ b/src/test/java/org/itech/ahb/normalizer/MessageNormalizerTest.java
@@ -5,10 +5,13 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.*;
 
+import java.util.Map;
 import org.itech.ahb.config.AnalyzerRegistryConfig;
 import org.itech.ahb.model.Protocol;
 import org.itech.ahb.model.Transport;
 import org.itech.ahb.routing.HttpForwardingRouter;
+import org.itech.ahb.util.DeadLetterWriter;
+import org.itech.ahb.util.OeApiClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -149,7 +152,7 @@ class MessageNormalizerTest {
             registry.register("10.42.59.10", entry);
 
             MessageNormalizer metadataAwareNormalizer =
-                new MessageNormalizer(mockForwardingRouter, mockIdentifier, registry, null);
+                new MessageNormalizer(mockForwardingRouter, mockIdentifier, registry, null, null, null);
 
             MessageEnvelope envelope = MessageEnvelope.builder()
                 .protocol(Protocol.ASTM)
@@ -407,6 +410,87 @@ class MessageNormalizerTest {
             verify(mockForwardingRouter).route(argThat(e ->
                 e.getSourcePort() == null
             ));
+        }
+    }
+
+    // === OGC-526: Unknown source discovery + DLQ tests ===
+
+    @Nested
+    @DisplayName("Unknown Source Handling Tests")
+    class UnknownSourceHandlingTests {
+
+        @Mock
+        private OeApiClient mockOeApiClient;
+
+        @Mock
+        private DeadLetterWriter mockDeadLetterWriter;
+
+        private MessageNormalizer normalizerWithDlq;
+
+        @BeforeEach
+        void setUpDlqNormalizer() {
+            AnalyzerIdentifier rejectingIdentifier = mock(AnalyzerIdentifier.class);
+            when(rejectingIdentifier.identify(any())).thenReturn(null);
+
+            normalizerWithDlq = new MessageNormalizer(
+                mockForwardingRouter, rejectingIdentifier,
+                null, null, mockOeApiClient, mockDeadLetterWriter);
+        }
+
+        @Test
+        @DisplayName("Should report unknown source to OE via discovered-sources endpoint")
+        void shouldReportUnknownSourceToOe() {
+            when(mockOeApiClient.post(any(), any())).thenReturn(Map.of("analyzerId", "99"));
+
+            MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.ASTM)
+                .transport(Transport.TCP)
+                .sourceId("10.0.0.50")
+                .rawMessage("H|\\^&|||UNKNOWN-DEVICE")
+                .build();
+
+            boolean result = normalizerWithDlq.process(envelope);
+
+            assertFalse(result, "Unknown source should not route");
+            verify(mockOeApiClient).post(eq("/rest/analyzer/discovered-sources"), argThat(body ->
+                "10.0.0.50".equals(body.get("sourceId"))
+                    && "ASTM".equals(body.get("protocol"))
+                    && "TCP".equals(body.get("transport"))
+            ));
+        }
+
+        @Test
+        @DisplayName("Should write message to dead letter on unknown source")
+        void shouldWriteDeadLetterOnUnknownSource() {
+            MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.HL7)
+                .transport(Transport.MLLP)
+                .sourceId("192.168.1.99")
+                .rawMessage("MSH|^~\\&|UNKNOWN")
+                .build();
+
+            normalizerWithDlq.process(envelope);
+
+            verify(mockDeadLetterWriter).write(eq(envelope), eq("UNREGISTERED_SOURCE"));
+        }
+
+        @Test
+        @DisplayName("Should survive OE API failure gracefully")
+        void shouldSurviveOeApiFailure() {
+            when(mockOeApiClient.post(any(), any())).thenThrow(new RuntimeException("OE unreachable"));
+
+            MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.ASTM)
+                .transport(Transport.TCP)
+                .sourceId("10.0.0.99")
+                .rawMessage("H|\\^&|||TEST")
+                .build();
+
+            boolean result = normalizerWithDlq.process(envelope);
+
+            assertFalse(result);
+            // DLQ should still be written even if OE call fails
+            verify(mockDeadLetterWriter).write(eq(envelope), eq("UNREGISTERED_SOURCE"));
         }
     }
 }

--- a/src/test/java/org/itech/ahb/util/DeadLetterWriterTest.java
+++ b/src/test/java/org/itech/ahb/util/DeadLetterWriterTest.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.List;
 import org.itech.ahb.model.Protocol;
 import org.itech.ahb.model.Transport;
 import org.itech.ahb.normalizer.MessageEnvelope;
@@ -42,19 +43,21 @@ class DeadLetterWriterTest {
 
         assertTrue(result);
 
-        // Verify exactly 2 files written (payload + meta)
-        long fileCount = Files.list(tempDir).count();
-        assertEquals(2, fileCount, "Should produce payload + metadata files");
+        // Collect once — closes the directory stream properly
+        List<Path> files;
+        try (var stream = Files.list(tempDir)) {
+            files = stream.toList();
+        }
 
-        // Verify payload file contains raw message
-        Path msgFile = Files.list(tempDir)
+        assertEquals(2, files.size(), "Should produce payload + metadata files");
+
+        Path msgFile = files.stream()
                 .filter(p -> p.toString().endsWith(".msg"))
                 .findFirst()
                 .orElseThrow();
         assertEquals("H|\\^&|||TEST-DATA", Files.readString(msgFile));
 
-        // Verify metadata sidecar
-        Path metaFile = Files.list(tempDir)
+        Path metaFile = files.stream()
                 .filter(p -> p.toString().endsWith(".meta"))
                 .findFirst()
                 .orElseThrow();
@@ -78,8 +81,12 @@ class DeadLetterWriterTest {
         boolean result = writer.write(envelope, "TEST_REASON");
 
         assertTrue(result);
-        // Filename should not contain slashes
-        Files.list(tempDir).forEach(p -> assertFalse(
+
+        List<Path> files;
+        try (var stream = Files.list(tempDir)) {
+            files = stream.toList();
+        }
+        files.forEach(p -> assertFalse(
                 p.getFileName().toString().contains("/"),
                 "Filename should not contain path separators"));
     }

--- a/src/test/java/org/itech/ahb/util/DeadLetterWriterTest.java
+++ b/src/test/java/org/itech/ahb/util/DeadLetterWriterTest.java
@@ -22,9 +22,10 @@ class DeadLetterWriterTest {
     private DeadLetterWriter writer;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws Exception {
         writer = new DeadLetterWriter();
         ReflectionTestUtils.setField(writer, "deadLetterDirectory", tempDir.toString());
+        writer.init();
     }
 
     @Test

--- a/src/test/java/org/itech/ahb/util/DeadLetterWriterTest.java
+++ b/src/test/java/org/itech/ahb/util/DeadLetterWriterTest.java
@@ -1,0 +1,85 @@
+package org.itech.ahb.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import org.itech.ahb.model.Protocol;
+import org.itech.ahb.model.Transport;
+import org.itech.ahb.normalizer.MessageEnvelope;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class DeadLetterWriterTest {
+
+    @TempDir
+    Path tempDir;
+
+    private DeadLetterWriter writer;
+
+    @BeforeEach
+    void setUp() {
+        writer = new DeadLetterWriter();
+        ReflectionTestUtils.setField(writer, "deadLetterDirectory", tempDir.toString());
+    }
+
+    @Test
+    void shouldWritePayloadAndMetadataFiles() throws IOException {
+        MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.ASTM)
+                .transport(Transport.TCP)
+                .sourceId("10.0.0.50")
+                .rawMessage("H|\\^&|||TEST-DATA")
+                .receivedAt(Instant.parse("2026-04-02T10:00:00Z"))
+                .build();
+
+        boolean result = writer.write(envelope, "UNREGISTERED_SOURCE");
+
+        assertTrue(result);
+
+        // Verify exactly 2 files written (payload + meta)
+        long fileCount = Files.list(tempDir).count();
+        assertEquals(2, fileCount, "Should produce payload + metadata files");
+
+        // Verify payload file contains raw message
+        Path msgFile = Files.list(tempDir)
+                .filter(p -> p.toString().endsWith(".msg"))
+                .findFirst()
+                .orElseThrow();
+        assertEquals("H|\\^&|||TEST-DATA", Files.readString(msgFile));
+
+        // Verify metadata sidecar
+        Path metaFile = Files.list(tempDir)
+                .filter(p -> p.toString().endsWith(".meta"))
+                .findFirst()
+                .orElseThrow();
+        String meta = Files.readString(metaFile);
+        assertTrue(meta.contains("sourceId=10.0.0.50"));
+        assertTrue(meta.contains("protocol=ASTM"));
+        assertTrue(meta.contains("transport=TCP"));
+        assertTrue(meta.contains("reason=UNREGISTERED_SOURCE"));
+    }
+
+    @Test
+    void shouldSanitizeSourceIdInFilename() throws IOException {
+        MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.CSV)
+                .transport(Transport.FILE)
+                .sourceId("/data/analyzer-imports/incoming")
+                .rawMessage("test data")
+                .receivedAt(Instant.now())
+                .build();
+
+        boolean result = writer.write(envelope, "TEST_REASON");
+
+        assertTrue(result);
+        // Filename should not contain slashes
+        Files.list(tempDir).forEach(p -> assertFalse(
+                p.getFileName().toString().contains("/"),
+                "Filename should not contain path separators"));
+    }
+}


### PR DESCRIPTION
## Summary
- Report unknown analyzer sources to OE via `POST /rest/analyzer/discovered-sources` (creates PENDING_REGISTRATION stub)
- Write unroutable messages to filesystem dead-letter queue (`.msg` + `.meta` sidecar)
- Extract shared `OeApiClient` from `AnalyzerRegistryBootstrap` for all OE REST API calls
- Refactor `AnalyzerRegistryBootstrap` to use `OeApiClient` (eliminates duplicated URL derivation + auth)

## Key components
- `OeApiClient` — reusable HTTP client for OE REST, single `HttpClient` instance, shared auth/TLS config
- `DeadLetterWriter` — filesystem DLQ with collision-safe filenames (`nanotime` suffix + `CREATE_NEW`)
- `MessageNormalizer.handleUnknownSource()` — async OE report + synchronous DLQ write

## Paired with
Parent PR: DIGI-UW/OpenELIS-Global-2#3279 (OE side: PENDING_REGISTRATION status, discovered-sources endpoint, UNIQUE index)

## Test plan
- [x] `MessageNormalizerTest` — 3 new tests (OE report, DLQ write, OE failure resilience)
- [x] `DeadLetterWriterTest` — 2 tests (file output, filename sanitization)
- [x] Full bridge test suite: 398 tests, 0 failures