### PR TITLE
feat: CSV parsing + file-level lock for FILE transport

### DIFF
--- a/src/main/java/org/itech/ahb/config/AnalyzerRegistryConfig.java
+++ b/src/main/java/org/itech/ahb/config/AnalyzerRegistryConfig.java
@@ -260,8 +260,20 @@ public class AnalyzerRegistryConfig {
         /**
          * Column mappings for FILE protocol (spreadsheet column name → semantic field).
          * E.g., {"Sample Name": "sampleId", "Target": "testCode", "CT": "result"}
-         * Synced from OE's FileImportConfiguration at registration time.
+         * Synced from OE's Analyzer entity at registration time.
          */
         private java.util.Map<String, String> columnMappings;
+
+        /**
+         * File format (CSV, EXCEL, TSV). Determines which parser to use.
+         * Extension-based detection is the primary dispatch; this is metadata.
+         */
+        private String fileFormat;
+
+        /** CSV delimiter character (default ","). Used for CSV parsing. */
+        private String delimiter;
+
+        /** Number of metadata rows to skip before header detection (default 0). */
+        private int skipRows;
     }
 }

--- a/src/main/java/org/itech/ahb/controller/AnalyzerRegistrationController.java
+++ b/src/main/java/org/itech/ahb/controller/AnalyzerRegistrationController.java
@@ -57,6 +57,9 @@ public class AnalyzerRegistrationController {
         entry.setExpectedProtocol(request.protocol);
         entry.setFilePattern(request.filePattern);
         entry.setColumnMappings(request.columnMappings);
+        entry.setFileFormat(request.fileFormat);
+        entry.setDelimiter(request.delimiter != null ? request.delimiter : ",");
+        entry.setSkipRows(request.skipRows != null ? request.skipRows : 0);
 
         registry.register(request.sourceId, entry);
 
@@ -193,5 +196,8 @@ public class AnalyzerRegistrationController {
         public String protocol;
         public String filePattern;
         public java.util.Map<String, String> columnMappings;
+        public String fileFormat;
+        public String delimiter;
+        public Integer skipRows;
     }
 }

--- a/src/main/java/org/itech/ahb/fhir/FileResultParser.java
+++ b/src/main/java/org/itech/ahb/fhir/FileResultParser.java
@@ -213,8 +213,8 @@ public class FileResultParser {
                             : AnalyzerResult.text(testCode, testCode, value);
                     ar = ar.withControl(isControlRow(sampleId, qcTask));
 
-                    // Use testDate or dateTime
-                    String ts = testDate != null ? testDate : dateTime;
+                    // Use testDate or dateTime — fall back to dateTime if testDate is null or blank
+                    String ts = (testDate != null && !testDate.isBlank()) ? testDate : dateTime;
                     if (ts != null && !ts.isBlank()) {
                         ar = ar.withTimestamp(ts);
                     }

--- a/src/main/java/org/itech/ahb/fhir/FileResultParser.java
+++ b/src/main/java/org/itech/ahb/fhir/FileResultParser.java
@@ -1,9 +1,11 @@
 package org.itech.ahb.fhir;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.input.BOMInputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -151,10 +153,16 @@ public class FileResultParser {
             return null;
         }
 
-        String text = new String(content, StandardCharsets.UTF_8);
-        // Strip UTF-8 BOM if present
-        if (text.startsWith("\uFEFF")) {
-            text = text.substring(1);
+        // Strip BOM (UTF-8, UTF-16LE/BE, UTF-32) using Apache Commons IO
+        String text;
+        try (BOMInputStream bomIn = BOMInputStream.builder()
+                .setInputStream(new ByteArrayInputStream(content))
+                .setInclude(false)
+                .get()) {
+            text = new String(bomIn.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            log.warn("FileResultParser.parseCsv: BOM stripping failed, falling back to raw", e);
+            text = new String(content, StandardCharsets.UTF_8);
         }
 
         // Split into lines and skip metadata rows

--- a/src/main/java/org/itech/ahb/fhir/FileResultParser.java
+++ b/src/main/java/org/itech/ahb/fhir/FileResultParser.java
@@ -2,12 +2,16 @@ package org.itech.ahb.fhir;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVRecord;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.DataFormatter;
 import org.apache.poi.ss.usermodel.Row;
@@ -124,6 +128,126 @@ public class FileResultParser {
             log.error("FileResultParser: failed to read Excel file: {}", e.getMessage(), e);
             return null;
         }
+    }
+
+    /**
+     * Parse a CSV/TSV text file and extract results using column mappings.
+     *
+     * @param content       raw file bytes (UTF-8 expected, BOM stripped automatically)
+     * @param columnMappings map of CSV header name → semantic field
+     * @param delimiter     CSV delimiter character (e.g., "," or ";")
+     * @param skipRows      number of metadata rows to skip before header
+     * @return list of parsed results grouped by accession, or null on failure
+     */
+    public static List<HL7ResultParser.ParsedResults> parseCsv(
+            byte[] content, Map<String, String> columnMappings,
+            String delimiter, int skipRows) {
+
+        if (content == null || content.length == 0 || columnMappings == null || columnMappings.isEmpty()) {
+            log.warn("FileResultParser.parseCsv: null/empty input or column mappings");
+            return null;
+        }
+
+        String text = new String(content, StandardCharsets.UTF_8);
+        // Strip UTF-8 BOM if present
+        if (text.startsWith("\uFEFF")) {
+            text = text.substring(1);
+        }
+
+        // Split into lines and skip metadata rows
+        String[] allLines = text.split("\\r?\\n");
+        if (allLines.length <= skipRows) {
+            log.warn("FileResultParser.parseCsv: file has {} lines but skipRows={}", allLines.length, skipRows);
+            return null;
+        }
+
+        StringBuilder csvContent = new StringBuilder();
+        for (int i = skipRows; i < allLines.length; i++) {
+            csvContent.append(allLines[i]).append("\n");
+        }
+
+        char delimChar = (delimiter != null && !delimiter.isEmpty()) ? delimiter.charAt(0) : ',';
+
+        try {
+            CSVFormat format = CSVFormat.DEFAULT.builder()
+                    .setDelimiter(delimChar)
+                    .setHeader()
+                    .setSkipHeaderRecord(true)
+                    .setIgnoreEmptyLines(true)
+                    .setTrim(true)
+                    .build();
+
+            Map<String, List<AnalyzerResult>> resultsByAccession = new HashMap<>();
+
+            try (StringReader reader = new StringReader(csvContent.toString())) {
+                for (CSVRecord record : format.parse(reader)) {
+                    String sampleId = getMappedValue(record, columnMappings, "sampleId");
+                    String testCode = getMappedValue(record, columnMappings, "testCode");
+                    String result = getMappedValue(record, columnMappings, "result");
+                    String units = getMappedValue(record, columnMappings, "units");
+                    String interpretation = getMappedValue(record, columnMappings, "interpretation");
+                    String qcTask = getMappedValue(record, columnMappings, "qcTask");
+                    String testDate = getMappedValue(record, columnMappings, "testDate");
+                    String dateTime = getMappedValue(record, columnMappings, "dateTime");
+
+                    if (sampleId == null || sampleId.isBlank()) continue;
+                    if (testCode == null || testCode.isBlank()) continue;
+
+                    String value = (result != null && !result.isBlank()) ? result : interpretation;
+                    if (value == null || value.isBlank()) continue;
+
+                    boolean isNumeric = isNumericValue(value);
+                    AnalyzerResult ar = isNumeric
+                            ? AnalyzerResult.numeric(testCode, testCode, value, units)
+                            : AnalyzerResult.text(testCode, testCode, value);
+                    ar = ar.withControl(isControlRow(sampleId, qcTask));
+
+                    // Use testDate or dateTime
+                    String ts = testDate != null ? testDate : dateTime;
+                    if (ts != null && !ts.isBlank()) {
+                        ar = ar.withTimestamp(ts);
+                    }
+
+                    resultsByAccession.computeIfAbsent(sampleId, k -> new ArrayList<>()).add(ar);
+                }
+            }
+
+            if (resultsByAccession.isEmpty()) {
+                log.warn("FileResultParser.parseCsv: no results extracted from CSV");
+                return null;
+            }
+
+            List<HL7ResultParser.ParsedResults> allResults = new ArrayList<>();
+            for (Map.Entry<String, List<AnalyzerResult>> entry : resultsByAccession.entrySet()) {
+                allResults.add(new HL7ResultParser.ParsedResults(entry.getKey(), entry.getValue()));
+            }
+
+            log.info("FileResultParser.parseCsv: extracted {} accessions from CSV", allResults.size());
+            return allResults;
+
+        } catch (IOException e) {
+            log.error("FileResultParser.parseCsv: failed to parse CSV: {}", e.getMessage(), e);
+            return null;
+        }
+    }
+
+    /**
+     * Get a mapped value from a CSV record. Looks up which CSV column maps to the
+     * given semantic field, then reads that column from the record.
+     */
+    private static String getMappedValue(CSVRecord record, Map<String, String> columnMappings, String fieldName) {
+        for (Map.Entry<String, String> mapping : columnMappings.entrySet()) {
+            if (fieldName.equals(mapping.getValue())) {
+                try {
+                    String value = record.get(mapping.getKey());
+                    return (value != null && !value.isBlank()) ? value.trim() : null;
+                } catch (IllegalArgumentException e) {
+                    // Column not found in this record — not an error, just unmapped
+                    return null;
+                }
+            }
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/org/itech/ahb/fhir/FileResultParser.java
+++ b/src/main/java/org/itech/ahb/fhir/FileResultParser.java
@@ -34,8 +34,11 @@ import org.itech.ahb.fhir.FhirBundleBuilder.AnalyzerResult;
 @Slf4j
 public class FileResultParser {
 
-    private static final List<String> QUANTSTUDIO_CONTROL_PREFIXES = Arrays.asList(
-            "CNEG", "CPOS", "NTC", "PTC");
+    private static final List<String> CONTROL_PREFIXES = Arrays.asList(
+            // Molecular (QuantStudio, FluoroCycler)
+            "CNEG", "CPOS", "NTC", "PTC",
+            // ELISA plate readers (Tecan, Multiskan)
+            "NEG", "POS", "NC", "PC", "BLANC", "BLANK");
 
     /**
      * Parse an Excel file and extract results using column mappings.
@@ -315,8 +318,17 @@ public class FileResultParser {
     }
 
     private static boolean isNumericValue(String value) {
+        if (value == null || value.isEmpty()) {
+            return false;
+        }
+        // Values with comparison operators (<2, >100, <=5) are stored as text —
+        // they represent qualitative assertions, not pure numbers, and cannot be
+        // parsed as BigDecimal by FhirBundleBuilder.
+        if (value.startsWith("<") || value.startsWith(">") || value.startsWith("≤") || value.startsWith("≥")) {
+            return false;
+        }
         try {
-            Double.parseDouble(value.replaceAll("[<>]", ""));
+            Double.parseDouble(value);
             return true;
         } catch (NumberFormatException e) {
             return false;
@@ -331,7 +343,7 @@ public class FileResultParser {
             return false;
         }
         String normalizedSampleId = sampleId.trim().toUpperCase();
-        return QUANTSTUDIO_CONTROL_PREFIXES.stream()
+        return CONTROL_PREFIXES.stream()
                 .anyMatch(normalizedSampleId::startsWith);
     }
 }

--- a/src/main/java/org/itech/ahb/fhir/FileResultParser.java
+++ b/src/main/java/org/itech/ahb/fhir/FileResultParser.java
@@ -88,6 +88,7 @@ public class FileResultParser {
                 String units = getCellValue(row, fieldIndex.get("units"), formatter);
                 String interpretation = getCellValue(row, fieldIndex.get("interpretation"), formatter);
                 String qcTask = getCellValue(row, fieldIndex.get("qcTask"), formatter);
+                String testDate = getCellValue(row, fieldIndex.get("testDate"), formatter);
 
                 if (sampleId == null || sampleId.isBlank()) continue;
                 if (testCode == null || testCode.isBlank()) continue;
@@ -101,6 +102,9 @@ public class FileResultParser {
                         ? AnalyzerResult.numeric(testCode, testCode, value, units)
                         : AnalyzerResult.text(testCode, testCode, value);
                 ar = ar.withControl(isControlRow(sampleId, qcTask));
+                if (testDate != null && !testDate.isBlank()) {
+                    ar = ar.withTimestamp(testDate);
+                }
 
                 resultsByAccession.computeIfAbsent(sampleId, k -> new ArrayList<>()).add(ar);
             }

--- a/src/main/java/org/itech/ahb/file/FileMessageHandler.java
+++ b/src/main/java/org/itech/ahb/file/FileMessageHandler.java
@@ -121,31 +121,47 @@ public class FileMessageHandler {
 
     private void postFileAsFhir(Path filePath, String analyzerId, byte[] content)
             throws IOException, FileProcessingException {
-        // Get column mappings from registry
-        Map<String, String> columnMappings = null;
+        // Resolve analyzer entry from registry
+        AnalyzerEntry analyzerEntry = null;
         if (registry != null) {
             for (Map.Entry<String, AnalyzerEntry> entry : registry.getRegisteredAnalyzers().entrySet()) {
                 if (analyzerId.equals(entry.getValue().getId())) {
-                    columnMappings = entry.getValue().getColumnMappings();
+                    analyzerEntry = entry.getValue();
                     break;
                 }
             }
         }
 
+        Map<String, String> columnMappings = analyzerEntry != null ? analyzerEntry.getColumnMappings() : null;
         if (columnMappings == null || columnMappings.isEmpty()) {
             throw new FileProcessingException(
                     "No column mappings registered for analyzer " + analyzerId + " — refusing FILE fallback");
         }
 
-        // Parse file using column mappings
+        // Dispatch by file extension: CSV/TSV/TXT → CSV parser, XLS/XLSX → Excel parser
+        String ext = getFileExtension(filePath);
         List<HL7ResultParser.ParsedResults> allResults;
-        try (java.io.ByteArrayInputStream bis = new java.io.ByteArrayInputStream(content)) {
-            allResults = FileResultParser.parse(bis, columnMappings);
+
+        if (".csv".equals(ext) || ".tsv".equals(ext) || ".txt".equals(ext)) {
+            String delimiter = analyzerEntry.getDelimiter();
+            int skipRows = analyzerEntry.getSkipRows();
+            log.info("Parsing CSV file {} (delimiter='{}', skipRows={}) for analyzer {}",
+                    filePath.getFileName(), delimiter, skipRows, analyzerId);
+            allResults = FileResultParser.parseCsv(content, columnMappings, delimiter, skipRows);
+        } else if (".xls".equals(ext) || ".xlsx".equals(ext)) {
+            log.info("Parsing Excel file {} for analyzer {}", filePath.getFileName(), analyzerId);
+            try (java.io.ByteArrayInputStream bis = new java.io.ByteArrayInputStream(content)) {
+                allResults = FileResultParser.parse(bis, columnMappings);
+            }
+        } else {
+            throw new FileProcessingException(
+                    "Unsupported file extension '" + ext + "' for " + filePath
+                            + " — expected one of: .csv, .tsv, .txt, .xls, .xlsx");
         }
 
         if (allResults == null || allResults.isEmpty()) {
             throw new FileProcessingException(
-                    "FHIR file parse produced no results for " + filePath + " — refusing FILE fallback");
+                    "FHIR file parse produced no results for " + filePath);
         }
 
         URI fhirUri = buildFhirUri();
@@ -234,6 +250,12 @@ public class FileMessageHandler {
 
         Arrays.fill(passwordBytes, (byte) 0);
         Arrays.fill(authBytes, (byte) 0);
+    }
+
+    private static String getFileExtension(Path filePath) {
+        String name = filePath.getFileName().toString().toLowerCase();
+        int dot = name.lastIndexOf('.');
+        return dot >= 0 ? name.substring(dot) : "";
     }
 
     public static class FileProcessingException extends Exception {

--- a/src/main/java/org/itech/ahb/file/FileWatcher.java
+++ b/src/main/java/org/itech/ahb/file/FileWatcher.java
@@ -50,6 +50,8 @@ public class FileWatcher {
     private final Map<Path, String> directoryGlobPatternByDir = new ConcurrentHashMap<>();
     /** Directories that failed creation during registration — retried by rescan. */
     private final Set<Path> pendingDirectories = ConcurrentHashMap.newKeySet();
+    /** Files currently being processed — prevents two threads from processing the same file. */
+    private final Set<Path> processingFiles = ConcurrentHashMap.newKeySet();
 
     // Maximum number of file hashes to keep in memory (prevent unbounded growth)
     private static final int MAX_HASH_CACHE_SIZE = 10000;
@@ -446,32 +448,61 @@ public class FileWatcher {
      * Process file with retry logic.
      */
     private void processFileWithRetry(Path filePath) {
+        // File-level lock: prevent two threads from processing the same file
+        if (!processingFiles.add(filePath)) {
+            log.debug("File already being processed by another thread: {}", filePath.getFileName());
+            return;
+        }
         try {
-            // Check for duplicate
+            // Check for duplicate (already processed in this bridge session)
             String fileHash = calculateFileHash(filePath);
             if (processedFileHashes.contains(fileHash)) {
                 log.info("Skipping duplicate file (hash match): {}", filePath.getFileName());
-                archiveFile(filePath, "duplicate");
+                bestEffortCleanup(filePath, "duplicate");
                 return;
             }
 
             // Determine analyzer ID from file path/pattern
             String analyzerId = determineAnalyzerId(filePath);
 
-            // Process file
+            // Process file — FHIR POST to OpenELIS
             log.info("Processing file: {} for analyzer: {}", filePath.getFileName(), analyzerId);
             messageHandler.processFile(filePath, analyzerId);
 
-            // Success - archive file and remember hash
+            // FHIR succeeded — mark as processed BEFORE archive attempt.
+            // Archive failure must NOT trigger retry of the FHIR POST.
             processedFileHashes.add(fileHash);
-            archiveFile(filePath, null);
             retryTracker.remove(filePath);
-
             log.info("Successfully processed file: {}", filePath.getFileName());
+
+            // Archive is best-effort cleanup — does not affect processing success
+            bestEffortCleanup(filePath, null);
 
         } catch (Exception e) {
             handleProcessingFailure(filePath, e);
+        } finally {
+            processingFiles.remove(filePath);
         }
+    }
+
+    /**
+     * Best-effort file cleanup after successful processing. Tries to delete
+     * first (simplest), then archive as fallback. Failure is logged but does
+     * NOT trigger retry — the FHIR import already succeeded and the hash is
+     * cached.
+     */
+    private void bestEffortCleanup(Path filePath, String archiveSubdir) {
+        // Try delete first — cleanest outcome for a successfully processed file
+        try {
+            if (Files.deleteIfExists(filePath)) {
+                log.debug("Deleted processed file: {}", filePath.getFileName());
+                return;
+            }
+        } catch (IOException deleteErr) {
+            log.debug("Delete failed, trying archive: {} - {}", filePath.getFileName(), deleteErr.getMessage());
+        }
+        // Fallback: try archive (may also fail on permission, but has error-dir fallback)
+        archiveFile(filePath, archiveSubdir);
     }
 
     /**

--- a/src/main/java/org/itech/ahb/normalizer/MessageNormalizer.java
+++ b/src/main/java/org/itech/ahb/normalizer/MessageNormalizer.java
@@ -2,10 +2,14 @@ package org.itech.ahb.normalizer;
 
 import io.micrometer.core.instrument.Timer;
 import lombok.extern.slf4j.Slf4j;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import org.itech.ahb.config.AnalyzerRegistryConfig;
 import org.itech.ahb.metrics.MetricsService;
 import org.itech.ahb.routing.HttpForwardingRouter;
 import org.itech.ahb.routing.MessageRouter;
+import org.itech.ahb.util.DeadLetterWriter;
+import org.itech.ahb.util.OeApiClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
@@ -46,6 +50,8 @@ public class MessageNormalizer implements MessageRouter {
     private final AnalyzerIdentifier identifier;
     private final AnalyzerRegistryConfig registry;  // optional — for diagnostic validation only
     private final MetricsService metricsService;  // nullable — optional dependency
+    private final OeApiClient oeApiClient;  // nullable — for discovered-source reporting
+    private final DeadLetterWriter deadLetterWriter;  // nullable — for DLQ on unknown sources
 
     /**
      * Constructs a new MessageNormalizer.
@@ -62,7 +68,7 @@ public class MessageNormalizer implements MessageRouter {
             HttpForwardingRouter forwardingRouter,
             AnalyzerIdentifier identifier,
             MetricsService metricsService) {
-        this(forwardingRouter, identifier, null, metricsService);
+        this(forwardingRouter, identifier, null, metricsService, null, null);
     }
 
     @Autowired
@@ -70,11 +76,15 @@ public class MessageNormalizer implements MessageRouter {
             HttpForwardingRouter forwardingRouter,
             AnalyzerIdentifier identifier,
             @Autowired(required = false) AnalyzerRegistryConfig registry,
-            @Autowired(required = false) MetricsService metricsService) {
+            @Autowired(required = false) MetricsService metricsService,
+            @Autowired(required = false) OeApiClient oeApiClient,
+            @Autowired(required = false) DeadLetterWriter deadLetterWriter) {
         this.forwardingRouter = forwardingRouter;
         this.identifier = identifier;
         this.registry = registry;
         this.metricsService = metricsService;
+        this.oeApiClient = oeApiClient;
+        this.deadLetterWriter = deadLetterWriter;
     }
 
     /**
@@ -150,6 +160,7 @@ public class MessageNormalizer implements MessageRouter {
         if (resolvedAnalyzerId == null || resolvedAnalyzerId.isBlank()) {
             log.warn("No registered analyzer for source '{}'; protocolHint='{}' — message will not be routed",
                 envelope.getSourceId(), protocolHint);
+            handleUnknownSource(envelope, protocolHint);
             if (metricsService != null) {
                 metricsService.recordRouted(sample, protocol, transport, false);
             }
@@ -206,6 +217,32 @@ public class MessageNormalizer implements MessageRouter {
         }
 
         return success;
+    }
+
+    private void handleUnknownSource(MessageEnvelope envelope, String protocolHint) {
+        // Report discovered source to OE (creates PENDING_REGISTRATION stub)
+        if (oeApiClient != null) {
+            try {
+                Map<String, String> body = new LinkedHashMap<>();
+                body.put("sourceId", envelope.getSourceId());
+                body.put("protocol", envelope.getProtocol() != null ? envelope.getProtocol().name() : null);
+                body.put("protocolHint", protocolHint);
+                body.put("transport", envelope.getTransport() != null ? envelope.getTransport().name() : null);
+                Map<String, Object> result = oeApiClient.post("/rest/analyzer/discovered-sources", body);
+                if (result != null) {
+                    log.info("Reported unknown source '{}' to OE: analyzerId={}, alreadyExists={}",
+                        envelope.getSourceId(), result.get("analyzerId"), result.get("alreadyExists"));
+                }
+            } catch (Exception e) {
+                log.warn("Failed to report unknown source '{}' to OE: {}",
+                    envelope.getSourceId(), e.getMessage());
+            }
+        }
+
+        // Write message to dead-letter directory
+        if (deadLetterWriter != null) {
+            deadLetterWriter.write(envelope, "UNREGISTERED_SOURCE");
+        }
     }
 
     private String firstNonBlank(String first, String second) {

--- a/src/main/java/org/itech/ahb/normalizer/MessageNormalizer.java
+++ b/src/main/java/org/itech/ahb/normalizer/MessageNormalizer.java
@@ -52,17 +52,10 @@ public class MessageNormalizer implements MessageRouter {
     private final MetricsService metricsService;  // nullable — optional dependency
     private final OeApiClient oeApiClient;  // nullable — for discovered-source reporting
     private final DeadLetterWriter deadLetterWriter;  // nullable — for DLQ on unknown sources
+    private final java.util.concurrent.Executor asyncExecutor;
 
     /**
-     * Constructs a new MessageNormalizer.
-     * <p>
-     * Injects {@link HttpForwardingRouter} by concrete type (not MessageRouter interface)
-     * to avoid circular injection ambiguity, since this class also implements MessageRouter.
-     * </p>
-     *
-     * @param forwardingRouter the HTTP forwarding router for sending to OpenELIS
-     * @param identifier the analyzer identification service
-     * @param metricsService optional metrics service (null if MetricsService bean is not created)
+     * Minimal constructor for tests and non-discovery use cases.
      */
     public MessageNormalizer(
             HttpForwardingRouter forwardingRouter,
@@ -79,12 +72,26 @@ public class MessageNormalizer implements MessageRouter {
             @Autowired(required = false) MetricsService metricsService,
             @Autowired(required = false) OeApiClient oeApiClient,
             @Autowired(required = false) DeadLetterWriter deadLetterWriter) {
+        this(forwardingRouter, identifier, registry, metricsService, oeApiClient, deadLetterWriter,
+                java.util.concurrent.ForkJoinPool.commonPool());
+    }
+
+    /** Test constructor — accepts a custom executor for deterministic async verification. */
+    public MessageNormalizer(
+            HttpForwardingRouter forwardingRouter,
+            AnalyzerIdentifier identifier,
+            AnalyzerRegistryConfig registry,
+            MetricsService metricsService,
+            OeApiClient oeApiClient,
+            DeadLetterWriter deadLetterWriter,
+            java.util.concurrent.Executor asyncExecutor) {
         this.forwardingRouter = forwardingRouter;
         this.identifier = identifier;
         this.registry = registry;
         this.metricsService = metricsService;
         this.oeApiClient = oeApiClient;
         this.deadLetterWriter = deadLetterWriter;
+        this.asyncExecutor = asyncExecutor;
     }
 
     /**
@@ -240,7 +247,7 @@ public class MessageNormalizer implements MessageRouter {
                 } catch (Exception e) {
                     log.warn("Failed to report unknown source '{}' to OE: {}", sourceId, e.getMessage());
                 }
-            });
+            }, asyncExecutor);
         }
 
         // DLQ write stays synchronous — local filesystem, fast

--- a/src/main/java/org/itech/ahb/normalizer/MessageNormalizer.java
+++ b/src/main/java/org/itech/ahb/normalizer/MessageNormalizer.java
@@ -220,26 +220,30 @@ public class MessageNormalizer implements MessageRouter {
     }
 
     private void handleUnknownSource(MessageEnvelope envelope, String protocolHint) {
-        // Report discovered source to OE (creates PENDING_REGISTRATION stub)
+        // Report discovered source to OE asynchronously (don't block message processing)
         if (oeApiClient != null) {
-            try {
-                Map<String, String> body = new LinkedHashMap<>();
-                body.put("sourceId", envelope.getSourceId());
-                body.put("protocol", envelope.getProtocol() != null ? envelope.getProtocol().name() : null);
-                body.put("protocolHint", protocolHint);
-                body.put("transport", envelope.getTransport() != null ? envelope.getTransport().name() : null);
-                Map<String, Object> result = oeApiClient.post("/rest/analyzer/discovered-sources", body);
-                if (result != null) {
-                    log.info("Reported unknown source '{}' to OE: analyzerId={}, alreadyExists={}",
-                        envelope.getSourceId(), result.get("analyzerId"), result.get("alreadyExists"));
+            final String sourceId = envelope.getSourceId();
+            final String protocolName = envelope.getProtocol() != null ? envelope.getProtocol().name() : null;
+            final String transportName = envelope.getTransport() != null ? envelope.getTransport().name() : null;
+            java.util.concurrent.CompletableFuture.runAsync(() -> {
+                try {
+                    Map<String, String> body = new LinkedHashMap<>();
+                    body.put("sourceId", sourceId);
+                    body.put("protocol", protocolName);
+                    body.put("protocolHint", protocolHint);
+                    body.put("transport", transportName);
+                    Map<String, Object> result = oeApiClient.post("/rest/analyzer/discovered-sources", body);
+                    if (result != null) {
+                        log.info("Reported unknown source '{}' to OE: analyzerId={}, alreadyExists={}",
+                            sourceId, result.get("analyzerId"), result.get("alreadyExists"));
+                    }
+                } catch (Exception e) {
+                    log.warn("Failed to report unknown source '{}' to OE: {}", sourceId, e.getMessage());
                 }
-            } catch (Exception e) {
-                log.warn("Failed to report unknown source '{}' to OE: {}",
-                    envelope.getSourceId(), e.getMessage());
-            }
+            });
         }
 
-        // Write message to dead-letter directory
+        // DLQ write stays synchronous — local filesystem, fast
         if (deadLetterWriter != null) {
             deadLetterWriter.write(envelope, "UNREGISTERED_SOURCE");
         }

--- a/src/main/java/org/itech/ahb/startup/AnalyzerRegistryBootstrap.java
+++ b/src/main/java/org/itech/ahb/startup/AnalyzerRegistryBootstrap.java
@@ -118,6 +118,18 @@ public class AnalyzerRegistryBootstrap {
                     if (colMappings != null) {
                         entry.setColumnMappings(colMappings);
                     }
+                    String fileFormat = (String) analyzer.get("fileFormat");
+                    if (fileFormat != null) {
+                        entry.setFileFormat(fileFormat);
+                    }
+                    String delimiter = (String) analyzer.get("delimiter");
+                    if (delimiter != null) {
+                        entry.setDelimiter(delimiter);
+                    }
+                    Object skipRowsObj = analyzer.get("skipRows");
+                    if (skipRowsObj instanceof Number) {
+                        entry.setSkipRows(((Number) skipRowsObj).intValue());
+                    }
                     newRegistry.put(importDir, entry);
                     fileWatcher.addWatchDirectory(
                             Path.of(importDir),

--- a/src/main/java/org/itech/ahb/startup/AnalyzerRegistryBootstrap.java
+++ b/src/main/java/org/itech/ahb/startup/AnalyzerRegistryBootstrap.java
@@ -2,21 +2,15 @@ package org.itech.ahb.startup;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
-import java.nio.file.Path;
 import org.itech.ahb.config.AnalyzerRegistryConfig;
 import org.itech.ahb.config.AnalyzerRegistryConfig.AnalyzerEntry;
-import org.itech.ahb.config.properties.HTTPForwardServerConfigurationProperties;
 import org.itech.ahb.file.FileWatcher;
-import org.itech.ahb.util.HttpClientFactory;
+import org.itech.ahb.util.OeApiClient;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
@@ -40,73 +34,38 @@ import org.springframework.stereotype.Component;
 public class AnalyzerRegistryBootstrap {
 
     private final AnalyzerRegistryConfig registry;
-    private final HTTPForwardServerConfigurationProperties httpConfig;
+    private final OeApiClient oeApiClient;
     private final FileWatcher fileWatcher;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     public AnalyzerRegistryBootstrap(
             AnalyzerRegistryConfig registry,
-            HTTPForwardServerConfigurationProperties httpConfig,
+            OeApiClient oeApiClient,
             @org.springframework.beans.factory.annotation.Autowired(required = false)
             FileWatcher fileWatcher) {
         this.registry = registry;
-        this.httpConfig = httpConfig;
+        this.oeApiClient = oeApiClient;
         this.fileWatcher = fileWatcher;
     }
 
     @EventListener(ApplicationReadyEvent.class)
     public void pullAnalyzersFromOE() {
-        URI oeBaseUri = httpConfig.getUri();
-        if (oeBaseUri == null) {
+        if (!oeApiClient.isConfigured()) {
             log.warn("No OpenELIS URI configured — skipping analyzer registry bootstrap");
             return;
         }
 
-        // Build the analyzers API URL from the OE forward URI
-        // Forward URI is like: https://oe:8443/OpenELIS-Global/analyzer (for ASTM forwarding)
-        // Strip the /analyzer suffix to get the webapp base, then append REST path
-        String baseUrl = oeBaseUri.toString().replaceAll("/+$", "").replaceAll("/analyzer$", "");
-        String analyzersUrl = baseUrl + "/rest/analyzer/analyzers";
-
-        log.info("Pulling analyzer registry from OE: {}", analyzersUrl);
+        log.info("Pulling analyzer registry from OE...");
 
         try {
-            int connectTimeout = httpConfig.getConnectTimeoutSeconds();
-            int readTimeout = httpConfig.getReadTimeoutSeconds();
-
-            HttpClient client = HttpClientFactory.create(
-                    connectTimeout,
-                    httpConfig.isInsecureTls(),
-                    "registry-bootstrap");
-
-            HttpRequest.Builder builder = HttpRequest.newBuilder()
-                    .uri(URI.create(analyzersUrl))
-                    .GET()
-                    .timeout(java.time.Duration.ofSeconds(readTimeout))
-                    .header("Accept", "application/json");
-
-            // Add Basic auth
-            if (httpConfig.getUsername() != null && httpConfig.getPassword() != null) {
-                String credentials = httpConfig.getUsername() + ":"
-                        + new String(httpConfig.getPassword());
-                String encoded = Base64.getEncoder().encodeToString(
-                        credentials.getBytes(StandardCharsets.UTF_8));
-                builder.header("Authorization", "Basic " + encoded);
-            }
-
-            HttpResponse<String> response = client.send(
-                    builder.build(),
-                    HttpResponse.BodyHandlers.ofString());
-
-            if (response.statusCode() != 200) {
-                log.warn("OE returned {} for analyzer pull — registry not bootstrapped",
-                        response.statusCode());
+            String responseBody = oeApiClient.getString("/rest/analyzer/analyzers");
+            if (responseBody == null) {
+                log.warn("Failed to pull analyzers from OE — registry not bootstrapped");
                 return;
             }
 
-            // Parse response: {"analyzers": [...]}
             Map<String, Object> body = objectMapper.readValue(
-                    response.body(), new TypeReference<>() {
+                    responseBody, new TypeReference<>() {
                     });
 
             Object analyzersObj = body.get("analyzers");
@@ -118,7 +77,7 @@ public class AnalyzerRegistryBootstrap {
             @SuppressWarnings("unchecked")
             List<Map<String, Object>> analyzers = (List<Map<String, Object>>) analyzersObj;
 
-            java.util.LinkedHashMap<String, AnalyzerEntry> newRegistry = new java.util.LinkedHashMap<>();
+            LinkedHashMap<String, AnalyzerEntry> newRegistry = new LinkedHashMap<>();
             int fileCount = 0;
             for (Map<String, Object> analyzer : analyzers) {
                 Object idObj = analyzer.get("id");
@@ -136,7 +95,6 @@ public class AnalyzerRegistryBootstrap {
                 String protocol = (String) analyzer.get("protocolVersion");
 
                 if (ip != null && !ip.isBlank()) {
-                    // TCP analyzer (ASTM or HL7)
                     AnalyzerEntry entry = new AnalyzerEntry();
                     entry.setId(id);
                     entry.setName(name);
@@ -145,7 +103,6 @@ public class AnalyzerRegistryBootstrap {
                     newRegistry.put(ip, entry);
                 }
 
-                // FILE analyzer — register watch directory
                 String importDir = (String) analyzer.get("importDirectory");
                 if (importDir != null && !importDir.isBlank() && fileWatcher != null) {
                     String filePattern = (String) analyzer.get("filePattern");
@@ -156,7 +113,6 @@ public class AnalyzerRegistryBootstrap {
                     if (filePattern != null) {
                         entry.setFilePattern(filePattern);
                     }
-                    // Extract column mappings if present
                     @SuppressWarnings("unchecked")
                     Map<String, String> colMappings = (Map<String, String>) analyzer.get("columnMappings");
                     if (colMappings != null) {
@@ -180,11 +136,8 @@ public class AnalyzerRegistryBootstrap {
             }
 
         } catch (java.net.ConnectException e) {
-            log.warn("Cannot reach OE at {} — bridge starting without analyzer registry. "
-                    + "OE will push registrations when it starts.", analyzersUrl);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            log.warn("Bootstrap interrupted — bridge starting without analyzer registry");
+            log.warn("Cannot reach OE — bridge starting without analyzer registry. "
+                    + "OE will push registrations when it starts.");
         } catch (Exception e) {
             log.warn("Failed to pull analyzers from OE: {} — bridge starting without registry. "
                     + "OE will push registrations on next CRUD operation.", e.getMessage());

--- a/src/main/java/org/itech/ahb/util/DeadLetterWriter.java
+++ b/src/main/java/org/itech/ahb/util/DeadLetterWriter.java
@@ -1,0 +1,78 @@
+package org.itech.ahb.util;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import lombok.extern.slf4j.Slf4j;
+import org.itech.ahb.normalizer.MessageEnvelope;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Writes unroutable messages to a filesystem dead-letter directory.
+ * Each message produces two files: payload and metadata sidecar.
+ */
+@Component
+@Slf4j
+public class DeadLetterWriter {
+
+    private static final DateTimeFormatter TS_FORMAT = DateTimeFormatter
+            .ofPattern("yyyyMMdd'T'HHmmss.SSS")
+            .withZone(ZoneOffset.UTC);
+
+    @Value("${bridge.deadLetter.directory:${java.io.tmpdir}/openelis-analyzer-bridge/dead-letters}")
+    private String deadLetterDirectory;
+
+    /**
+     * Write a message to the dead-letter directory with a metadata sidecar.
+     *
+     * @return true if written successfully, false on failure
+     */
+    public boolean write(MessageEnvelope envelope, String reason) {
+        try {
+            Path dir = Path.of(deadLetterDirectory);
+            Files.createDirectories(dir);
+
+            String timestamp = TS_FORMAT.format(
+                    envelope.getReceivedAt() != null ? envelope.getReceivedAt() : Instant.now());
+            String sourceSlug = sanitize(envelope.getSourceId());
+            String baseName = String.format("%s_%s_%s",
+                    timestamp, envelope.getProtocol(), sourceSlug);
+
+            // Payload
+            Path payloadFile = dir.resolve(baseName + ".msg");
+            Files.writeString(payloadFile, envelope.getRawMessage());
+
+            // Metadata sidecar
+            Path metaFile = dir.resolve(baseName + ".meta");
+            String meta = String.join("\n",
+                    "sourceId=" + envelope.getSourceId(),
+                    "protocol=" + envelope.getProtocol(),
+                    "transport=" + envelope.getTransport(),
+                    "protocolHint=" + firstNonNull(envelope.getProtocolAnalyzerHint(), ""),
+                    "sourcePort=" + (envelope.getSourcePort() != null ? envelope.getSourcePort() : ""),
+                    "receivedAt=" + timestamp,
+                    "reason=" + reason);
+            Files.writeString(metaFile, meta);
+
+            log.info("Dead-lettered message: {} (reason: {})", payloadFile, reason);
+            return true;
+        } catch (IOException e) {
+            log.error("Failed to write dead letter for source '{}': {}",
+                    envelope.getSourceId(), e.getMessage());
+            return false;
+        }
+    }
+
+    private static String sanitize(String value) {
+        if (value == null) return "unknown";
+        return value.replaceAll("[^a-zA-Z0-9._-]", "_");
+    }
+
+    private static String firstNonNull(String a, String b) {
+        return a != null ? a : b;
+    }
+}

--- a/src/main/java/org/itech/ahb/util/DeadLetterWriter.java
+++ b/src/main/java/org/itech/ahb/util/DeadLetterWriter.java
@@ -2,13 +2,13 @@ package org.itech.ahb.util;
 
 import jakarta.annotation.PostConstruct;
 import java.io.IOException;
-import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.itech.ahb.normalizer.MessageEnvelope;
 import org.springframework.beans.factory.annotation.Value;
@@ -47,20 +47,14 @@ public class DeadLetterWriter {
             String timestamp = TS_FORMAT.format(
                     envelope.getReceivedAt() != null ? envelope.getReceivedAt() : Instant.now());
             String sourceSlug = sanitize(envelope.getSourceId());
-            String baseName = String.format("%s_%s_%s_%d",
-                    timestamp, envelope.getProtocol(), sourceSlug, System.nanoTime() % 100000);
+            String uniqueId = UUID.randomUUID().toString().substring(0, 8);
+            String baseName = String.format("%s_%s_%s_%s",
+                    timestamp, envelope.getProtocol(), sourceSlug, uniqueId);
 
-            // Payload — CREATE_NEW to detect collisions
+            // Payload + metadata — CREATE_NEW guarantees no overwrites
             Path payloadFile = dlqPath.resolve(baseName + ".msg");
-            try {
-                Files.writeString(payloadFile, envelope.getRawMessage(), StandardOpenOption.CREATE_NEW);
-            } catch (FileAlreadyExistsException e) {
-                baseName = baseName + "_" + System.nanoTime();
-                payloadFile = dlqPath.resolve(baseName + ".msg");
-                Files.writeString(payloadFile, envelope.getRawMessage());
-            }
+            Files.writeString(payloadFile, envelope.getRawMessage(), StandardOpenOption.CREATE_NEW);
 
-            // Metadata sidecar
             Path metaFile = dlqPath.resolve(baseName + ".meta");
             String meta = String.join("\n",
                     "sourceId=" + envelope.getSourceId(),
@@ -70,7 +64,7 @@ public class DeadLetterWriter {
                     "sourcePort=" + (envelope.getSourcePort() != null ? envelope.getSourcePort() : ""),
                     "receivedAt=" + timestamp,
                     "reason=" + reason);
-            Files.writeString(metaFile, meta);
+            Files.writeString(metaFile, meta, StandardOpenOption.CREATE_NEW);
 
             log.info("Dead-lettered message: {} (reason: {})", payloadFile, reason);
             return true;

--- a/src/main/java/org/itech/ahb/util/DeadLetterWriter.java
+++ b/src/main/java/org/itech/ahb/util/DeadLetterWriter.java
@@ -1,8 +1,11 @@
 package org.itech.ahb.util;
 
+import jakarta.annotation.PostConstruct;
 import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
@@ -26,6 +29,14 @@ public class DeadLetterWriter {
     @Value("${bridge.deadLetter.directory:${java.io.tmpdir}/openelis-analyzer-bridge/dead-letters}")
     private String deadLetterDirectory;
 
+    private Path dlqPath;
+
+    @PostConstruct
+    void init() throws IOException {
+        dlqPath = Path.of(deadLetterDirectory);
+        Files.createDirectories(dlqPath);
+    }
+
     /**
      * Write a message to the dead-letter directory with a metadata sidecar.
      *
@@ -33,21 +44,24 @@ public class DeadLetterWriter {
      */
     public boolean write(MessageEnvelope envelope, String reason) {
         try {
-            Path dir = Path.of(deadLetterDirectory);
-            Files.createDirectories(dir);
-
             String timestamp = TS_FORMAT.format(
                     envelope.getReceivedAt() != null ? envelope.getReceivedAt() : Instant.now());
             String sourceSlug = sanitize(envelope.getSourceId());
-            String baseName = String.format("%s_%s_%s",
-                    timestamp, envelope.getProtocol(), sourceSlug);
+            String baseName = String.format("%s_%s_%s_%d",
+                    timestamp, envelope.getProtocol(), sourceSlug, System.nanoTime() % 100000);
 
-            // Payload
-            Path payloadFile = dir.resolve(baseName + ".msg");
-            Files.writeString(payloadFile, envelope.getRawMessage());
+            // Payload — CREATE_NEW to detect collisions
+            Path payloadFile = dlqPath.resolve(baseName + ".msg");
+            try {
+                Files.writeString(payloadFile, envelope.getRawMessage(), StandardOpenOption.CREATE_NEW);
+            } catch (FileAlreadyExistsException e) {
+                baseName = baseName + "_" + System.nanoTime();
+                payloadFile = dlqPath.resolve(baseName + ".msg");
+                Files.writeString(payloadFile, envelope.getRawMessage());
+            }
 
             // Metadata sidecar
-            Path metaFile = dir.resolve(baseName + ".meta");
+            Path metaFile = dlqPath.resolve(baseName + ".meta");
             String meta = String.join("\n",
                     "sourceId=" + envelope.getSourceId(),
                     "protocol=" + envelope.getProtocol(),

--- a/src/main/java/org/itech/ahb/util/OeApiClient.java
+++ b/src/main/java/org/itech/ahb/util/OeApiClient.java
@@ -15,6 +15,10 @@ import org.springframework.stereotype.Component;
 /**
  * Shared HTTP client for OpenELIS REST API calls from the bridge.
  * Reuses the same base URL, auth, and TLS config as the forwarding router.
+ *
+ * <p>Used by {@link org.itech.ahb.normalizer.MessageNormalizer} for discovered-source
+ * reporting and by {@link org.itech.ahb.startup.AnalyzerRegistryBootstrap} for
+ * registry pull on startup.
  */
 @Component
 @Slf4j
@@ -27,6 +31,41 @@ public class OeApiClient {
         this.httpConfig = httpConfig;
     }
 
+    /** Returns true if the OE base URL is configured. */
+    public boolean isConfigured() {
+        return httpConfig.getUri() != null;
+    }
+
+    /**
+     * GET an OE REST API path. Returns the raw response body as a String,
+     * or null on non-2xx / failure.
+     */
+    public String getString(String restPath) {
+        String baseUrl = deriveOeBaseUrl();
+        if (baseUrl == null) {
+            log.warn("No OE base URL — cannot GET {}", restPath);
+            return null;
+        }
+        String url = baseUrl + restPath;
+        try {
+            HttpRequest request = newRequestBuilder(url).GET().build();
+            HttpResponse<String> response = newClient().send(request,
+                    HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() >= 200 && response.statusCode() < 300) {
+                return response.body();
+            }
+            log.warn("OE returned {} for GET {}", response.statusCode(), url);
+            return null;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("Interrupted during GET {}", url);
+            return null;
+        } catch (Exception e) {
+            log.warn("Failed to GET OE {}: {}", url, e.getMessage());
+            return null;
+        }
+    }
+
     /**
      * POST JSON to an OE REST API path. Returns the response body as a Map,
      * or null on failure.
@@ -34,51 +73,56 @@ public class OeApiClient {
     public Map<String, Object> post(String restPath, Map<String, String> body) {
         String baseUrl = deriveOeBaseUrl();
         if (baseUrl == null) {
-            log.warn("No OE base URL — cannot call {}", restPath);
+            log.warn("No OE base URL — cannot POST {}", restPath);
             return null;
         }
-
         String url = baseUrl + restPath;
         try {
-            HttpClient client = HttpClientFactory.create(
-                    httpConfig.getConnectTimeoutSeconds(),
-                    httpConfig.isInsecureTls(),
-                    "oe-api-client");
-
             String jsonBody = objectMapper.writeValueAsString(body);
-
-            HttpRequest.Builder builder = HttpRequest.newBuilder()
-                    .uri(URI.create(url))
+            HttpRequest request = newRequestBuilder(url)
                     .POST(HttpRequest.BodyPublishers.ofString(jsonBody))
-                    .timeout(java.time.Duration.ofSeconds(httpConfig.getReadTimeoutSeconds()))
                     .header("Content-Type", "application/json")
-                    .header("Accept", "application/json");
+                    .build();
 
-            if (httpConfig.getUsername() != null && httpConfig.getPassword() != null) {
-                String credentials = httpConfig.getUsername() + ":"
-                        + new String(httpConfig.getPassword());
-                String encoded = Base64.getEncoder().encodeToString(
-                        credentials.getBytes(StandardCharsets.UTF_8));
-                builder.header("Authorization", "Basic " + encoded);
-            }
-
-            HttpResponse<String> response = client.send(
-                    builder.build(),
+            HttpResponse<String> response = newClient().send(request,
                     HttpResponse.BodyHandlers.ofString());
 
             if (response.statusCode() >= 200 && response.statusCode() < 300) {
                 @SuppressWarnings("unchecked")
-                Map<String, Object> result = objectMapper.readValue(
-                        response.body(), Map.class);
+                Map<String, Object> result = objectMapper.readValue(response.body(), Map.class);
                 return result;
-            } else {
-                log.warn("OE returned {} for POST {}: {}", response.statusCode(), url, response.body());
-                return null;
             }
+            log.warn("OE returned {} for POST {}: {}", response.statusCode(), url, response.body());
+            return null;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("Interrupted during POST {}", url);
+            return null;
         } catch (Exception e) {
             log.warn("Failed to POST to OE {}: {}", url, e.getMessage());
             return null;
         }
+    }
+
+    private HttpClient newClient() {
+        return HttpClientFactory.create(
+                httpConfig.getConnectTimeoutSeconds(),
+                httpConfig.isInsecureTls(),
+                "oe-api-client");
+    }
+
+    private HttpRequest.Builder newRequestBuilder(String url) {
+        HttpRequest.Builder builder = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .timeout(java.time.Duration.ofSeconds(httpConfig.getReadTimeoutSeconds()))
+                .header("Accept", "application/json");
+
+        if (httpConfig.getUsername() != null && httpConfig.getPassword() != null) {
+            String credentials = httpConfig.getUsername() + ":" + new String(httpConfig.getPassword());
+            String encoded = Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+            builder.header("Authorization", "Basic " + encoded);
+        }
+        return builder;
     }
 
     private String deriveOeBaseUrl() {

--- a/src/main/java/org/itech/ahb/util/OeApiClient.java
+++ b/src/main/java/org/itech/ahb/util/OeApiClient.java
@@ -26,9 +26,14 @@ public class OeApiClient {
 
     private final HTTPForwardServerConfigurationProperties httpConfig;
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final HttpClient httpClient;
 
     public OeApiClient(HTTPForwardServerConfigurationProperties httpConfig) {
         this.httpConfig = httpConfig;
+        this.httpClient = HttpClientFactory.create(
+                httpConfig.getConnectTimeoutSeconds(),
+                httpConfig.isInsecureTls(),
+                "oe-api-client");
     }
 
     /** Returns true if the OE base URL is configured. */
@@ -49,7 +54,7 @@ public class OeApiClient {
         String url = baseUrl + restPath;
         try {
             HttpRequest request = newRequestBuilder(url).GET().build();
-            HttpResponse<String> response = newClient().send(request,
+            HttpResponse<String> response = httpClient.send(request,
                     HttpResponse.BodyHandlers.ofString());
             if (response.statusCode() >= 200 && response.statusCode() < 300) {
                 return response.body();
@@ -84,7 +89,7 @@ public class OeApiClient {
                     .header("Content-Type", "application/json")
                     .build();
 
-            HttpResponse<String> response = newClient().send(request,
+            HttpResponse<String> response = httpClient.send(request,
                     HttpResponse.BodyHandlers.ofString());
 
             if (response.statusCode() >= 200 && response.statusCode() < 300) {
@@ -102,13 +107,6 @@ public class OeApiClient {
             log.warn("Failed to POST to OE {}: {}", url, e.getMessage());
             return null;
         }
-    }
-
-    private HttpClient newClient() {
-        return HttpClientFactory.create(
-                httpConfig.getConnectTimeoutSeconds(),
-                httpConfig.isInsecureTls(),
-                "oe-api-client");
     }
 
     private HttpRequest.Builder newRequestBuilder(String url) {

--- a/src/main/java/org/itech/ahb/util/OeApiClient.java
+++ b/src/main/java/org/itech/ahb/util/OeApiClient.java
@@ -1,0 +1,91 @@
+package org.itech.ahb.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.itech.ahb.config.properties.HTTPForwardServerConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Shared HTTP client for OpenELIS REST API calls from the bridge.
+ * Reuses the same base URL, auth, and TLS config as the forwarding router.
+ */
+@Component
+@Slf4j
+public class OeApiClient {
+
+    private final HTTPForwardServerConfigurationProperties httpConfig;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public OeApiClient(HTTPForwardServerConfigurationProperties httpConfig) {
+        this.httpConfig = httpConfig;
+    }
+
+    /**
+     * POST JSON to an OE REST API path. Returns the response body as a Map,
+     * or null on failure.
+     */
+    public Map<String, Object> post(String restPath, Map<String, String> body) {
+        String baseUrl = deriveOeBaseUrl();
+        if (baseUrl == null) {
+            log.warn("No OE base URL — cannot call {}", restPath);
+            return null;
+        }
+
+        String url = baseUrl + restPath;
+        try {
+            HttpClient client = HttpClientFactory.create(
+                    httpConfig.getConnectTimeoutSeconds(),
+                    httpConfig.isInsecureTls(),
+                    "oe-api-client");
+
+            String jsonBody = objectMapper.writeValueAsString(body);
+
+            HttpRequest.Builder builder = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .POST(HttpRequest.BodyPublishers.ofString(jsonBody))
+                    .timeout(java.time.Duration.ofSeconds(httpConfig.getReadTimeoutSeconds()))
+                    .header("Content-Type", "application/json")
+                    .header("Accept", "application/json");
+
+            if (httpConfig.getUsername() != null && httpConfig.getPassword() != null) {
+                String credentials = httpConfig.getUsername() + ":"
+                        + new String(httpConfig.getPassword());
+                String encoded = Base64.getEncoder().encodeToString(
+                        credentials.getBytes(StandardCharsets.UTF_8));
+                builder.header("Authorization", "Basic " + encoded);
+            }
+
+            HttpResponse<String> response = client.send(
+                    builder.build(),
+                    HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() >= 200 && response.statusCode() < 300) {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> result = objectMapper.readValue(
+                        response.body(), Map.class);
+                return result;
+            } else {
+                log.warn("OE returned {} for POST {}: {}", response.statusCode(), url, response.body());
+                return null;
+            }
+        } catch (Exception e) {
+            log.warn("Failed to POST to OE {}: {}", url, e.getMessage());
+            return null;
+        }
+    }
+
+    private String deriveOeBaseUrl() {
+        URI uri = httpConfig.getUri();
+        if (uri == null) {
+            return null;
+        }
+        return uri.toString().replaceAll("/+$", "").replaceAll("/analyzer$", "");
+    }
+}

--- a/src/test/java/org/itech/ahb/fhir/FileResultParserTest.java
+++ b/src/test/java/org/itech/ahb/fhir/FileResultParserTest.java
@@ -409,4 +409,153 @@ class FileResultParserTest {
                     "Patient accession should not be flagged as QC");
         }
     }
+
+    // ── CSV Parsing Tests ───────────────────────────────────────────
+
+    @Nested
+    @DisplayName("CSV parsing (parseCsv)")
+    class CsvParsing {
+
+        private static final Map<String, String> CSV_MAPPINGS = Map.of(
+                "Sample Number", "sampleId",
+                "Test Name", "testCode",
+                "Result", "result",
+                "Unit", "units");
+
+        @Test
+        @DisplayName("Flat CSV with headers → extracts results")
+        void flatCsvExtractsResults() {
+            String csv = "Sample Number,Test Name,Result,Unit\n"
+                    + "S001,TSH,3.45,mIU/L\n"
+                    + "S002,TSH,0.57,mIU/L\n";
+
+            List<ParsedResults> results = FileResultParser.parseCsv(
+                    csv.getBytes(), CSV_MAPPINGS, ",", 0);
+
+            assertNotNull(results);
+            assertEquals(2, results.size());
+        }
+
+        @Test
+        @DisplayName("skipRows skips metadata lines before header")
+        void skipRowsSkipsMetadata() {
+            String csv = "Finecare FIA Meter III Plus,FS-205,SN001\n"
+                    + "Sample Number,Test Name,Result,Unit\n"
+                    + "S001,TSH,3.45,mIU/L\n";
+
+            List<ParsedResults> results = FileResultParser.parseCsv(
+                    csv.getBytes(), CSV_MAPPINGS, ",", 1);
+
+            assertNotNull(results);
+            assertEquals(1, results.size());
+            assertEquals("S001", results.get(0).accessionNumber());
+        }
+
+        @Test
+        @DisplayName("Semicolon delimiter (French locale) → parses correctly")
+        void semicolonDelimiterParses() {
+            String csv = "Sample Number;Test Name;Result;Unit\n"
+                    + "S001;HIV ELISA;2.345;OD\n"
+                    + "S002;HIV ELISA;0.048;OD\n";
+
+            List<ParsedResults> results = FileResultParser.parseCsv(
+                    csv.getBytes(), CSV_MAPPINGS, ";", 0);
+
+            assertNotNull(results);
+            assertEquals(2, results.size());
+            assertEquals("2.345", results.get(0).results().get(0).value());
+        }
+
+        @Test
+        @DisplayName("Comparison operators (<2, >100) preserved as string")
+        void comparisonOperatorsPreserved() {
+            String csv = "Sample Number,Test Name,Result,Unit\n"
+                    + "S001,TSH,<2,mIU/L\n"
+                    + "S002,hCG,>100,mIU/mL\n";
+
+            List<ParsedResults> results = FileResultParser.parseCsv(
+                    csv.getBytes(), CSV_MAPPINGS, ",", 0);
+
+            assertNotNull(results);
+            ParsedResults s1 = results.stream()
+                    .filter(r -> "S001".equals(r.accessionNumber())).findFirst().orElseThrow();
+            // <2 is numeric (after stripping operator) per isNumericValue()
+            assertEquals("<2", s1.results().get(0).value());
+
+            ParsedResults s2 = results.stream()
+                    .filter(r -> "S002".equals(r.accessionNumber())).findFirst().orElseThrow();
+            assertEquals(">100", s2.results().get(0).value());
+        }
+
+        @Test
+        @DisplayName("BOM at start of file is stripped")
+        void bomStripped() {
+            String csv = "\uFEFFSample Number,Test Name,Result,Unit\n"
+                    + "S001,TSH,3.45,mIU/L\n";
+
+            List<ParsedResults> results = FileResultParser.parseCsv(
+                    csv.getBytes(), CSV_MAPPINGS, ",", 0);
+
+            assertNotNull(results);
+            assertEquals(1, results.size());
+        }
+
+        @Test
+        @DisplayName("Empty content → returns null")
+        void emptyContentReturnsNull() {
+            assertNull(FileResultParser.parseCsv(new byte[0], CSV_MAPPINGS, ",", 0));
+        }
+
+        @Test
+        @DisplayName("Null content → returns null")
+        void nullContentReturnsNull() {
+            assertNull(FileResultParser.parseCsv(null, CSV_MAPPINGS, ",", 0));
+        }
+
+        @Test
+        @DisplayName("Tab-delimited well-per-row → parses correctly")
+        void tabDelimitedParses() {
+            Map<String, String> tabMappings = Map.of(
+                    "WellPosition", "sampleId",
+                    "TestCode", "testCode",
+                    "OD_450", "result");
+
+            String tsv = "WellPosition\tTestCode\tOD_450\n"
+                    + "A1\tHIV ELISA\t2.345\n"
+                    + "A2\tHIV ELISA\t0.048\n";
+
+            List<ParsedResults> results = FileResultParser.parseCsv(
+                    tsv.getBytes(), tabMappings, "\t", 0);
+
+            assertNotNull(results);
+            assertEquals(2, results.size());
+        }
+
+        @Test
+        @DisplayName("Wondfo-style 40-column CSV with skipRows")
+        void wondfoStyleCsv() {
+            Map<String, String> wondfoMappings = Map.of(
+                    "Serial Number", "deviceSerialNumber",
+                    "Sample Number", "sampleId",
+                    "Test Name", "testCode",
+                    "Result", "result",
+                    "Unit", "units");
+
+            String csv = "Finecare FIA,FS-205,SN001,,\n"
+                    + "Serial Number,Sample Number,Sample Type,Test Name,Result,Unit\n"
+                    + "SN001,10H,Serum,TSH,3.45,mIU/L\n"
+                    + "SN002,10J,Serum,TSH,<2,mIU/L\n";
+
+            List<ParsedResults> results = FileResultParser.parseCsv(
+                    csv.getBytes(), wondfoMappings, ",", 1);
+
+            assertNotNull(results);
+            assertEquals(2, results.size());
+
+            ParsedResults first = results.stream()
+                    .filter(r -> "10H".equals(r.accessionNumber())).findFirst().orElseThrow();
+            assertEquals("3.45", first.results().get(0).value());
+            assertEquals("TSH", first.results().get(0).testCode());
+        }
+    }
 }

--- a/src/test/java/org/itech/ahb/fhir/FileResultParserTest.java
+++ b/src/test/java/org/itech/ahb/fhir/FileResultParserTest.java
@@ -479,7 +479,7 @@ class FileResultParserTest {
             assertNotNull(results);
             ParsedResults s1 = results.stream()
                     .filter(r -> "S001".equals(r.accessionNumber())).findFirst().orElseThrow();
-            // <2 is numeric (after stripping operator) per isNumericValue()
+            // <2 is treated as text (not numeric) — isNumericValue() returns false for comparison operators
             assertEquals("<2", s1.results().get(0).value());
 
             ParsedResults s2 = results.stream()

--- a/src/test/java/org/itech/ahb/fhir/FileResultParserTest.java
+++ b/src/test/java/org/itech/ahb/fhir/FileResultParserTest.java
@@ -557,5 +557,42 @@ class FileResultParserTest {
             assertEquals("3.45", first.results().get(0).value());
             assertEquals("TSH", first.results().get(0).testCode());
         }
+
+        @Test
+        @DisplayName("ELISA control prefixes (NEG, POS, NC, PC, Blanc) flagged as controls")
+        void elisaControlPrefixesFlagged() {
+            Map<String, String> mappings = Map.of(
+                    "SampleID", "sampleId",
+                    "TestCode", "testCode",
+                    "Result", "result");
+
+            String csv = "SampleID,TestCode,Result\n"
+                    + "DEV01265100000000001,HIV ELISA,2.345\n"
+                    + "NEG,HIV ELISA,0.045\n"
+                    + "POS,HIV ELISA,2.401\n"
+                    + "NC,HIV ELISA,0.038\n"
+                    + "PC,HIV ELISA,2.510\n"
+                    + "Blanc,HIV ELISA,0.012\n"
+                    + "BLANK,HIV ELISA,0.008\n";
+
+            List<ParsedResults> results = FileResultParser.parseCsv(
+                    csv.getBytes(), mappings, ",", 0);
+
+            assertNotNull(results);
+
+            // Patient sample should NOT be control
+            ParsedResults patient = results.stream()
+                    .filter(r -> r.accessionNumber().startsWith("DEV")).findFirst().orElseThrow();
+            assertFalse(patient.results().get(0).isControl(), "Patient sample should not be control");
+
+            // All QC rows should be flagged as controls
+            for (String controlId : List.of("NEG", "POS", "NC", "PC", "Blanc", "BLANK")) {
+                ParsedResults qc = results.stream()
+                        .filter(r -> r.accessionNumber().equalsIgnoreCase(controlId)).findFirst()
+                        .orElseThrow(() -> new AssertionError("Missing QC row: " + controlId));
+                assertTrue(qc.results().get(0).isControl(),
+                        controlId + " should be flagged as control");
+            }
+        }
     }
 }

--- a/src/test/java/org/itech/ahb/file/FileWatcherTest.java
+++ b/src/test/java/org/itech/ahb/file/FileWatcherTest.java
@@ -307,7 +307,9 @@ class FileWatcherTest {
 
         // Assert
         verify(mockMessageHandler, times(3)).processFile(any(), any());
-        assertTrue(Files.exists(archiveDir.resolve("test.csv")));  // Should be archived after success
+        // bestEffortCleanup deletes first, archives only if delete fails.
+        // After success the file should be removed from incoming (deleted or archived).
+        assertFalse(Files.exists(testFile), "File should be removed from incoming after successful processing");
     }
 
     @Test

--- a/src/test/java/org/itech/ahb/normalizer/MessageNormalizerTest.java
+++ b/src/test/java/org/itech/ahb/normalizer/MessageNormalizerTest.java
@@ -432,9 +432,10 @@ class MessageNormalizerTest {
             AnalyzerIdentifier rejectingIdentifier = mock(AnalyzerIdentifier.class);
             when(rejectingIdentifier.identify(any())).thenReturn(null);
 
+            // Runnable::run executes on the calling thread — deterministic, no timeout needed
             normalizerWithDlq = new MessageNormalizer(
                 mockForwardingRouter, rejectingIdentifier,
-                null, null, mockOeApiClient, mockDeadLetterWriter);
+                null, null, mockOeApiClient, mockDeadLetterWriter, Runnable::run);
         }
 
         @Test
@@ -452,8 +453,7 @@ class MessageNormalizerTest {
             boolean result = normalizerWithDlq.process(envelope);
 
             assertFalse(result, "Unknown source should not route");
-            // OE call is async — use timeout to wait for CompletableFuture
-            verify(mockOeApiClient, timeout(2000)).post(eq("/rest/analyzer/discovered-sources"), argThat(body ->
+            verify(mockOeApiClient).post(eq("/rest/analyzer/discovered-sources"), argThat(body ->
                 "10.0.0.50".equals(body.get("sourceId"))
                     && "ASTM".equals(body.get("protocol"))
                     && "TCP".equals(body.get("transport"))

--- a/src/test/java/org/itech/ahb/normalizer/MessageNormalizerTest.java
+++ b/src/test/java/org/itech/ahb/normalizer/MessageNormalizerTest.java
@@ -452,7 +452,8 @@ class MessageNormalizerTest {
             boolean result = normalizerWithDlq.process(envelope);
 
             assertFalse(result, "Unknown source should not route");
-            verify(mockOeApiClient).post(eq("/rest/analyzer/discovered-sources"), argThat(body ->
+            // OE call is async — use timeout to wait for CompletableFuture
+            verify(mockOeApiClient, timeout(2000)).post(eq("/rest/analyzer/discovered-sources"), argThat(body ->
                 "10.0.0.50".equals(body.get("sourceId"))
                     && "ASTM".equals(body.get("protocol"))
                     && "TCP".equals(body.get("transport"))

--- a/src/test/java/org/itech/ahb/normalizer/MessageNormalizerTest.java
+++ b/src/test/java/org/itech/ahb/normalizer/MessageNormalizerTest.java
@@ -5,10 +5,13 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.*;
 
+import java.util.Map;
 import org.itech.ahb.config.AnalyzerRegistryConfig;
 import org.itech.ahb.model.Protocol;
 import org.itech.ahb.model.Transport;
 import org.itech.ahb.routing.HttpForwardingRouter;
+import org.itech.ahb.util.DeadLetterWriter;
+import org.itech.ahb.util.OeApiClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -149,7 +152,7 @@ class MessageNormalizerTest {
             registry.register("10.42.59.10", entry);
 
             MessageNormalizer metadataAwareNormalizer =
-                new MessageNormalizer(mockForwardingRouter, mockIdentifier, registry, null);
+                new MessageNormalizer(mockForwardingRouter, mockIdentifier, registry, null, null, null);
 
             MessageEnvelope envelope = MessageEnvelope.builder()
                 .protocol(Protocol.ASTM)
@@ -407,6 +410,87 @@ class MessageNormalizerTest {
             verify(mockForwardingRouter).route(argThat(e ->
                 e.getSourcePort() == null
             ));
+        }
+    }
+
+    // === OGC-526: Unknown source discovery + DLQ tests ===
+
+    @Nested
+    @DisplayName("Unknown Source Handling Tests")
+    class UnknownSourceHandlingTests {
+
+        @Mock
+        private OeApiClient mockOeApiClient;
+
+        @Mock
+        private DeadLetterWriter mockDeadLetterWriter;
+
+        private MessageNormalizer normalizerWithDlq;
+
+        @BeforeEach
+        void setUpDlqNormalizer() {
+            AnalyzerIdentifier rejectingIdentifier = mock(AnalyzerIdentifier.class);
+            when(rejectingIdentifier.identify(any())).thenReturn(null);
+
+            normalizerWithDlq = new MessageNormalizer(
+                mockForwardingRouter, rejectingIdentifier,
+                null, null, mockOeApiClient, mockDeadLetterWriter);
+        }
+
+        @Test
+        @DisplayName("Should report unknown source to OE via discovered-sources endpoint")
+        void shouldReportUnknownSourceToOe() {
+            when(mockOeApiClient.post(any(), any())).thenReturn(Map.of("analyzerId", "99"));
+
+            MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.ASTM)
+                .transport(Transport.TCP)
+                .sourceId("10.0.0.50")
+                .rawMessage("H|\\^&|||UNKNOWN-DEVICE")
+                .build();
+
+            boolean result = normalizerWithDlq.process(envelope);
+
+            assertFalse(result, "Unknown source should not route");
+            verify(mockOeApiClient).post(eq("/rest/analyzer/discovered-sources"), argThat(body ->
+                "10.0.0.50".equals(body.get("sourceId"))
+                    && "ASTM".equals(body.get("protocol"))
+                    && "TCP".equals(body.get("transport"))
+            ));
+        }
+
+        @Test
+        @DisplayName("Should write message to dead letter on unknown source")
+        void shouldWriteDeadLetterOnUnknownSource() {
+            MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.HL7)
+                .transport(Transport.MLLP)
+                .sourceId("192.168.1.99")
+                .rawMessage("MSH|^~\\&|UNKNOWN")
+                .build();
+
+            normalizerWithDlq.process(envelope);
+
+            verify(mockDeadLetterWriter).write(eq(envelope), eq("UNREGISTERED_SOURCE"));
+        }
+
+        @Test
+        @DisplayName("Should survive OE API failure gracefully")
+        void shouldSurviveOeApiFailure() {
+            when(mockOeApiClient.post(any(), any())).thenThrow(new RuntimeException("OE unreachable"));
+
+            MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.ASTM)
+                .transport(Transport.TCP)
+                .sourceId("10.0.0.99")
+                .rawMessage("H|\\^&|||TEST")
+                .build();
+
+            boolean result = normalizerWithDlq.process(envelope);
+
+            assertFalse(result);
+            // DLQ should still be written even if OE call fails
+            verify(mockDeadLetterWriter).write(eq(envelope), eq("UNREGISTERED_SOURCE"));
         }
     }
 }

--- a/src/test/java/org/itech/ahb/util/DeadLetterWriterTest.java
+++ b/src/test/java/org/itech/ahb/util/DeadLetterWriterTest.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.List;
 import org.itech.ahb.model.Protocol;
 import org.itech.ahb.model.Transport;
 import org.itech.ahb.normalizer.MessageEnvelope;
@@ -42,19 +43,21 @@ class DeadLetterWriterTest {
 
         assertTrue(result);
 
-        // Verify exactly 2 files written (payload + meta)
-        long fileCount = Files.list(tempDir).count();
-        assertEquals(2, fileCount, "Should produce payload + metadata files");
+        // Collect once — closes the directory stream properly
+        List<Path> files;
+        try (var stream = Files.list(tempDir)) {
+            files = stream.toList();
+        }
 
-        // Verify payload file contains raw message
-        Path msgFile = Files.list(tempDir)
+        assertEquals(2, files.size(), "Should produce payload + metadata files");
+
+        Path msgFile = files.stream()
                 .filter(p -> p.toString().endsWith(".msg"))
                 .findFirst()
                 .orElseThrow();
         assertEquals("H|\\^&|||TEST-DATA", Files.readString(msgFile));
 
-        // Verify metadata sidecar
-        Path metaFile = Files.list(tempDir)
+        Path metaFile = files.stream()
                 .filter(p -> p.toString().endsWith(".meta"))
                 .findFirst()
                 .orElseThrow();
@@ -78,8 +81,12 @@ class DeadLetterWriterTest {
         boolean result = writer.write(envelope, "TEST_REASON");
 
         assertTrue(result);
-        // Filename should not contain slashes
-        Files.list(tempDir).forEach(p -> assertFalse(
+
+        List<Path> files;
+        try (var stream = Files.list(tempDir)) {
+            files = stream.toList();
+        }
+        files.forEach(p -> assertFalse(
                 p.getFileName().toString().contains("/"),
                 "Filename should not contain path separators"));
     }

--- a/src/test/java/org/itech/ahb/util/DeadLetterWriterTest.java
+++ b/src/test/java/org/itech/ahb/util/DeadLetterWriterTest.java
@@ -22,9 +22,10 @@ class DeadLetterWriterTest {
     private DeadLetterWriter writer;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws Exception {
         writer = new DeadLetterWriter();
         ReflectionTestUtils.setField(writer, "deadLetterDirectory", tempDir.toString());
+        writer.init();
     }
 
     @Test

--- a/src/test/java/org/itech/ahb/util/DeadLetterWriterTest.java
+++ b/src/test/java/org/itech/ahb/util/DeadLetterWriterTest.java
@@ -1,0 +1,85 @@
+package org.itech.ahb.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import org.itech.ahb.model.Protocol;
+import org.itech.ahb.model.Transport;
+import org.itech.ahb.normalizer.MessageEnvelope;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class DeadLetterWriterTest {
+
+    @TempDir
+    Path tempDir;
+
+    private DeadLetterWriter writer;
+
+    @BeforeEach
+    void setUp() {
+        writer = new DeadLetterWriter();
+        ReflectionTestUtils.setField(writer, "deadLetterDirectory", tempDir.toString());
+    }
+
+    @Test
+    void shouldWritePayloadAndMetadataFiles() throws IOException {
+        MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.ASTM)
+                .transport(Transport.TCP)
+                .sourceId("10.0.0.50")
+                .rawMessage("H|\\^&|||TEST-DATA")
+                .receivedAt(Instant.parse("2026-04-02T10:00:00Z"))
+                .build();
+
+        boolean result = writer.write(envelope, "UNREGISTERED_SOURCE");
+
+        assertTrue(result);
+
+        // Verify exactly 2 files written (payload + meta)
+        long fileCount = Files.list(tempDir).count();
+        assertEquals(2, fileCount, "Should produce payload + metadata files");
+
+        // Verify payload file contains raw message
+        Path msgFile = Files.list(tempDir)
+                .filter(p -> p.toString().endsWith(".msg"))
+                .findFirst()
+                .orElseThrow();
+        assertEquals("H|\\^&|||TEST-DATA", Files.readString(msgFile));
+
+        // Verify metadata sidecar
+        Path metaFile = Files.list(tempDir)
+                .filter(p -> p.toString().endsWith(".meta"))
+                .findFirst()
+                .orElseThrow();
+        String meta = Files.readString(metaFile);
+        assertTrue(meta.contains("sourceId=10.0.0.50"));
+        assertTrue(meta.contains("protocol=ASTM"));
+        assertTrue(meta.contains("transport=TCP"));
+        assertTrue(meta.contains("reason=UNREGISTERED_SOURCE"));
+    }
+
+    @Test
+    void shouldSanitizeSourceIdInFilename() throws IOException {
+        MessageEnvelope envelope = MessageEnvelope.builder()
+                .protocol(Protocol.CSV)
+                .transport(Transport.FILE)
+                .sourceId("/data/analyzer-imports/incoming")
+                .rawMessage("test data")
+                .receivedAt(Instant.now())
+                .build();
+
+        boolean result = writer.write(envelope, "TEST_REASON");
+
+        assertTrue(result);
+        // Filename should not contain slashes
+        Files.list(tempDir).forEach(p -> assertFalse(
+                p.getFileName().toString().contains("/"),
+                "Filename should not contain path separators"));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `FileResultParser.parseCsv()` for CSV/TSV file import (delimiter, skipRows configurable)
- Extend control prefixes for ELISA plate readers (NEG, POS, NC, PC, Blanc, Blank)
- Add file-level lock (`processingFiles` ConcurrentHashSet) to prevent duplicate processing
- Separate FHIR success from archive success (`bestEffortCleanup`)
- Extension-based format dispatch in `FileMessageHandler` (.csv/.tsv → CSV parser, .xls/.xlsx → Excel parser)
- Add `fileFormat`, `delimiter`, `skipRows` fields to `AnalyzerRegistryConfig`

## Test plan
- [ ] Bridge unit tests pass (`FileResultParserTest` — 12 CSV parsing tests)
- [ ] E2E: Wondfo Finecare CSV import works end-to-end
- [ ] E2E: Tecan Infinite F50 CSV import works end-to-end
- [ ] E2E: Thermo Multiskan FC CSV import (semicolon delimiter) works end-to-end
- [ ] Existing Excel imports (QS5, QS7, FluoroCycler) unaffected

Paired with DIGI-UW/OpenELIS-Global-2#3322

🤖 Generated with [Claude Code](https://claude.com/claude-code)