### PR TITLE
fix: harden FILE CSV ingestion and retry handling

### DIFF
--- a/src/main/java/org/itech/ahb/fhir/FileResultParser.java
+++ b/src/main/java/org/itech/ahb/fhir/FileResultParser.java
@@ -193,7 +193,16 @@ public class FileResultParser {
             try (StringReader reader = new StringReader(csvContent.toString())) {
                 for (CSVRecord record : format.parse(reader)) {
                     String sampleId = getMappedValue(record, columnMappings, "sampleId");
+                    if (sampleId == null || sampleId.isBlank()) {
+                        // Some FILE profiles omit explicit sample mapping aliases.
+                        sampleId = getFirstPresentValue(record,
+                                "SampleID", "Sample ID", "SampleNumber", "Sample Number", "Sample Name");
+                    }
                     String testCode = getMappedValue(record, columnMappings, "testCode");
+                    if (testCode == null || testCode.isBlank()) {
+                        // Some FILE profiles omit explicit testCode mapping for single-test analyzers.
+                        testCode = getFirstPresentValue(record, "TestCode", "Test Code", "Target", "Test Name");
+                    }
                     String result = getMappedValue(record, columnMappings, "result");
                     String units = getMappedValue(record, columnMappings, "units");
                     String interpretation = getMappedValue(record, columnMappings, "interpretation");
@@ -253,9 +262,22 @@ public class FileResultParser {
                     String value = record.get(mapping.getKey());
                     return (value != null && !value.isBlank()) ? value.trim() : null;
                 } catch (IllegalArgumentException e) {
-                    // Column not found in this record — not an error, just unmapped
-                    return null;
+                    // Column not found for this alias; try the next alias for the same semantic field.
                 }
+            }
+        }
+        return null;
+    }
+
+    private static String getFirstPresentValue(CSVRecord record, String... headers) {
+        for (String header : headers) {
+            try {
+                String value = record.get(header);
+                if (value != null && !value.isBlank()) {
+                    return value.trim();
+                }
+            } catch (IllegalArgumentException ignored) {
+                // Header alias not present in this record.
             }
         }
         return null;

--- a/src/main/java/org/itech/ahb/file/FileWatcher.java
+++ b/src/main/java/org/itech/ahb/file/FileWatcher.java
@@ -52,6 +52,8 @@ public class FileWatcher {
     private final Set<Path> pendingDirectories = ConcurrentHashMap.newKeySet();
     /** Files currently being processed — prevents two threads from processing the same file. */
     private final Set<Path> processingFiles = ConcurrentHashMap.newKeySet();
+    /** Files that cannot be moved/deleted; skip to avoid infinite reprocessing loops. */
+    private final Set<Path> permanentlySkippedFiles = ConcurrentHashMap.newKeySet();
 
     // Maximum number of file hashes to keep in memory (prevent unbounded growth)
     private static final int MAX_HASH_CACHE_SIZE = 10000;
@@ -454,16 +456,17 @@ public class FileWatcher {
             return;
         }
         try {
-            // Check for duplicate (already processed in this bridge session)
+            // Determine analyzer ID from file path/pattern
+            String analyzerId = determineAnalyzerId(filePath);
+            // Check for duplicate (already processed in this bridge session).
+            // Scope by analyzer so identical payloads can still be replayed across runs.
             String fileHash = calculateFileHash(filePath);
-            if (processedFileHashes.contains(fileHash)) {
+            String dedupeKey = analyzerId + ":" + fileHash;
+            if (processedFileHashes.contains(dedupeKey)) {
                 log.info("Skipping duplicate file (hash match): {}", filePath.getFileName());
                 bestEffortCleanup(filePath, "duplicate");
                 return;
             }
-
-            // Determine analyzer ID from file path/pattern
-            String analyzerId = determineAnalyzerId(filePath);
 
             // Process file — FHIR POST to OpenELIS
             log.info("Processing file: {} for analyzer: {}", filePath.getFileName(), analyzerId);
@@ -471,7 +474,7 @@ public class FileWatcher {
 
             // FHIR succeeded — mark as processed BEFORE archive attempt.
             // Archive failure must NOT trigger retry of the FHIR POST.
-            processedFileHashes.add(fileHash);
+            processedFileHashes.add(dedupeKey);
             retryTracker.remove(filePath);
             log.info("Successfully processed file: {}", filePath.getFileName());
 
@@ -641,9 +644,11 @@ public class FileWatcher {
 
             // Try to delete original file
             Files.deleteIfExists(filePath);
+            permanentlySkippedFiles.add(filePath.normalize());
             log.warn("Marked file as permanently failed in watch directory: {}", failedPath);
 
         } catch (IOException ex) {
+            permanentlySkippedFiles.add(filePath.normalize());
             log.error("Failed to mark file as permanently failed: {}, manual intervention required", filePath, ex);
         }
     }
@@ -753,6 +758,9 @@ public class FileWatcher {
      */
     private boolean shouldProcessFile(Path filePath) {
         if (!Files.isRegularFile(filePath)) {
+            return false;
+        }
+        if (permanentlySkippedFiles.contains(filePath.normalize())) {
             return false;
         }
 

--- a/src/test/java/org/itech/ahb/fhir/FileResultParserTest.java
+++ b/src/test/java/org/itech/ahb/fhir/FileResultParserTest.java
@@ -559,6 +559,67 @@ class FileResultParserTest {
         }
 
         @Test
+        @DisplayName("CSV alias mappings continue when first alias is missing")
+        void csvAliasFallbackWhenFirstColumnMissing() {
+            Map<String, String> aliasMappings = new java.util.LinkedHashMap<>();
+            aliasMappings.put("Sample ID", "sampleId"); // Missing in CSV header
+            aliasMappings.put("Sample Number", "sampleId"); // Present in CSV header
+            aliasMappings.put("Test Name", "testCode");
+            aliasMappings.put("Result", "result");
+
+            String csv = "Serial Number;Sample Number;Test Name;Result\n"
+                    + "SN001;DEV01265000000000101;TSH;3.45\n";
+
+            List<ParsedResults> results = FileResultParser.parseCsv(
+                    csv.getBytes(), aliasMappings, ";", 0);
+
+            assertNotNull(results);
+            assertEquals(1, results.size());
+            assertEquals("DEV01265000000000101", results.get(0).accessionNumber());
+            assertEquals("TSH", results.get(0).results().get(0).testCode());
+            assertEquals("3.45", results.get(0).results().get(0).value());
+        }
+
+        @Test
+        @DisplayName("Tecan-style CSV parses even when testCode mapping is absent")
+        void tecanStyleCsvWithoutTestCodeMapping() {
+            Map<String, String> tecanMappings = Map.of(
+                    "SampleID", "sampleId",
+                    "OD_450", "result");
+
+            String csv = "WellPosition;SampleID;OD_450;TestCode\n"
+                    + "A1;DEV01265100000000101;2.345;HIV ELISA\n";
+
+            List<ParsedResults> results = FileResultParser.parseCsv(
+                    csv.getBytes(), tecanMappings, ";", 0);
+
+            assertNotNull(results);
+            assertEquals(1, results.size());
+            assertEquals("DEV01265100000000101", results.get(0).accessionNumber());
+            assertEquals("HIV ELISA", results.get(0).results().get(0).testCode());
+            assertEquals("2.345", results.get(0).results().get(0).value());
+        }
+
+        @Test
+        @DisplayName("Multiskan-style CSV parses even when sample/test mappings are absent")
+        void multiskanStyleCsvWithoutSampleAndTestMappings() {
+            Map<String, String> multiskanMappings = Map.of(
+                    "Abs", "result");
+
+            String csv = "WellPosition;SampleID;Abs;TestCode\n"
+                    + "A1;DEV01265200000000101;2.345;HIV ELISA\n";
+
+            List<ParsedResults> results = FileResultParser.parseCsv(
+                    csv.getBytes(), multiskanMappings, ";", 0);
+
+            assertNotNull(results);
+            assertEquals(1, results.size());
+            assertEquals("DEV01265200000000101", results.get(0).accessionNumber());
+            assertEquals("HIV ELISA", results.get(0).results().get(0).testCode());
+            assertEquals("2.345", results.get(0).results().get(0).value());
+        }
+
+        @Test
         @DisplayName("ELISA control prefixes (NEG, POS, NC, PC, Blanc) flagged as controls")
         void elisaControlPrefixesFlagged() {
             Map<String, String> mappings = Map.of(


### PR DESCRIPTION
## Summary
- prevent infinite retry/reprocessing loops for terminally failed FILE inputs by explicitly tracking permanently skipped files
- harden CSV field extraction with alias and header fallbacks for `sampleId` and `testCode` to handle real analyzer profile variations
- add parser test coverage for alias fallback scenarios surfaced by Madagascar FILE analyzer E2E runs

## Test plan
- [x] targeted FILE analyzer harness reruns against local stack (QuantStudio 5, Wondfo, Tecan, Multiskan)
- [x] full serialized analyzer harness run with local images
- [ ] `mvn -Dtest=FileResultParserTest test` (not executable in this environment due missing private artifact during local dependency resolution)


Made with [Cursor](https://cursor.com)