### PR TITLE
(feat) Configurable QC rules from OE analyzer registry

### DIFF
--- a/src/main/java/org/itech/ahb/config/AnalyzerRegistryConfig.java
+++ b/src/main/java/org/itech/ahb/config/AnalyzerRegistryConfig.java
@@ -288,5 +288,8 @@ public class AnalyzerRegistryConfig {
 
         /** OE test codes this analyzer is allowed to emit (whitelist, not a default). */
         private Set<String> mappedTestCodes = Collections.emptySet();
+
+        /** FR-15: QC identification rules pulled from OE. Evaluated by parsers. */
+        private java.util.List<org.itech.ahb.qc.QcRule> qcRules = new java.util.ArrayList<>();
     }
 }

--- a/src/main/java/org/itech/ahb/fhir/ASTMResultParser.java
+++ b/src/main/java/org/itech/ahb/fhir/ASTMResultParser.java
@@ -1,10 +1,14 @@
 package org.itech.ahb.fhir;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.itech.ahb.fhir.FhirBundleBuilder.AnalyzerResult;
+import org.itech.ahb.qc.QcRule;
+import org.itech.ahb.qc.QcRuleEvaluator;
 
 /**
  * Extracts lab results from ASTM LIS2-A2 messages.
@@ -38,11 +42,22 @@ public class ASTMResultParser {
      * @return parsed results with accession, or null if no results found
      */
     public static HL7ResultParser.ParsedResults parse(List<String> lines) {
+        return parse(lines, null);
+    }
+
+    /**
+     * Parse ASTM message lines with configurable QC rules.
+     * Falls back to hardcoded O.12=="Q" when qcRules is null or empty.
+     *
+     * @param lines   ASTM message lines
+     * @param qcRules FR-15 QC identification rules (null = use hardcoded fallback)
+     * @return parsed results with accession, or null if no results found
+     */
+    public static HL7ResultParser.ParsedResults parse(List<String> lines, List<QcRule> qcRules) {
         if (lines == null || lines.isEmpty()) return null;
 
         String accession = null;
         boolean isQcSample = false;
-        String currentOrderRecord = null;
         List<AnalyzerResult> results = new ArrayList<>();
 
         for (String line : lines) {
@@ -53,8 +68,18 @@ public class ASTMResultParser {
             switch (segment) {
                 case "O" -> {
                     accession = extractAccessionNumber(line);
-                    currentOrderRecord = line;
-                    isQcSample = isQcSample(line);
+                    if (qcRules != null && !qcRules.isEmpty()) {
+                        // FR-15: rule-based QC detection
+                        String[] fields = line.split(Pattern.quote(FIELD_DELIMITER));
+                        Map<String, String> fieldValues = new HashMap<>();
+                        for (int i = 0; i < fields.length; i++) {
+                            fieldValues.put("O." + i, fields[i].trim());
+                        }
+                        isQcSample = QcRuleEvaluator.isQcSample(qcRules, accession, fieldValues);
+                    } else {
+                        // Fallback: hardcoded O.12 == "Q"
+                        isQcSample = isQcSample(line);
+                    }
                 }
                 case "R" -> {
                     if (accession != null) {

--- a/src/main/java/org/itech/ahb/fhir/FileResultParser.java
+++ b/src/main/java/org/itech/ahb/fhir/FileResultParser.java
@@ -27,6 +27,8 @@ import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.usermodel.WorkbookFactory;
 import org.itech.ahb.fhir.FhirBundleBuilder.AnalyzerResult;
+import org.itech.ahb.qc.QcRule;
+import org.itech.ahb.qc.QcRuleEvaluator;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -66,18 +68,33 @@ public class FileResultParser {
      */
     public static List<HL7ResultParser.ParsedResults> parse(
             InputStream inputStream, Map<String, String> columnMappings) {
-        return parse(inputStream, columnMappings, null);
+        return parse(inputStream, columnMappings, null, java.util.Collections.emptyList());
     }
 
     /**
-     * Parse an Excel file with an optional file-wide test code applied to
-     * rows that yield no per-row testCode from the column mapping.
-     *
-     * @param perFileTestCode event-scoped fallback test code; null or
-     *        blank drops rows with no per-row identity
+     * 3-arg overload preserved for callers that only need the file-wide
+     * test-code fallback (e.g. {@code FileMessageHandler}). Forwards to the
+     * 4-arg canonical with an empty QC-rule list — the bridge's legacy
+     * hardcoded QC detection still applies inside {@code isControlRow}
+     * when no rules are configured.
      */
     public static List<HL7ResultParser.ParsedResults> parse(
             InputStream inputStream, Map<String, String> columnMappings, String perFileTestCode) {
+        return parse(inputStream, columnMappings, perFileTestCode, java.util.Collections.emptyList());
+    }
+
+    /**
+     * Parse an Excel file with an optional file-wide test code and
+     * configurable QC identification rules pulled from OE.
+     *
+     * @param perFileTestCode event-scoped fallback test code; null or
+     *        blank drops rows with no per-row identity
+     * @param qcRules         QC identification rules (FR-15); empty list
+     *        defers to legacy hardcoded QC detection in {@code isControlRow}
+     */
+    public static List<HL7ResultParser.ParsedResults> parse(
+            InputStream inputStream, Map<String, String> columnMappings,
+            String perFileTestCode, List<QcRule> qcRules) {
 
         if (inputStream == null || columnMappings == null || columnMappings.isEmpty()) {
             log.warn("FileResultParser: null input or empty column mappings");
@@ -152,7 +169,7 @@ public class FileResultParser {
                 AnalyzerResult ar = isNumeric
                         ? AnalyzerResult.numeric(testCode, testCode, value, units)
                         : AnalyzerResult.text(testCode, testCode, value);
-                ar = ar.withControl(isControlRow(sampleId, qcTask));
+                ar = ar.withControl(isControlRow(sampleId, qcTask, qcRules));
                 if (testDate != null && !testDate.isBlank()) {
                     ar = ar.withTimestamp(testDate);
                 }
@@ -417,13 +434,23 @@ public class FileResultParser {
     public static List<HL7ResultParser.ParsedResults> parseCsv(
             byte[] content, Map<String, String> columnMappings,
             String delimiter, int skipRows) {
-        return parseCsv(content, columnMappings, delimiter, skipRows, null);
+        return parseCsv(content, columnMappings, delimiter, skipRows, null, java.util.Collections.emptyList());
     }
 
-    /** See {@link #parse(InputStream, Map, String)} for {@code perFileTestCode} semantics. */
+    /** See {@link #parse(InputStream, Map, String, List)} for {@code perFileTestCode} semantics. */
     public static List<HL7ResultParser.ParsedResults> parseCsv(
             byte[] content, Map<String, String> columnMappings,
             String delimiter, int skipRows, String perFileTestCode) {
+        return parseCsv(content, columnMappings, delimiter, skipRows, perFileTestCode, java.util.Collections.emptyList());
+    }
+
+    /**
+     * Parse a CSV file with an optional file-wide test code and configurable
+     * QC identification rules.
+     */
+    public static List<HL7ResultParser.ParsedResults> parseCsv(
+            byte[] content, Map<String, String> columnMappings,
+            String delimiter, int skipRows, String perFileTestCode, List<QcRule> qcRules) {
 
         if (content == null || content.length == 0 || columnMappings == null || columnMappings.isEmpty()) {
             log.warn("FileResultParser.parseCsv: null/empty input or column mappings");
@@ -503,7 +530,7 @@ public class FileResultParser {
                     AnalyzerResult ar = isNumeric
                             ? AnalyzerResult.numeric(testCode, testCode, value, units)
                             : AnalyzerResult.text(testCode, testCode, value);
-                    ar = ar.withControl(isControlRow(sampleId, qcTask));
+                    ar = ar.withControl(isControlRow(sampleId, qcTask, qcRules));
 
                     // Use testDate or dateTime — fall back to dateTime if testDate is null or blank
                     String ts = (testDate != null && !testDate.isBlank()) ? testDate : dateTime;
@@ -656,6 +683,20 @@ public class FileResultParser {
         } catch (NumberFormatException e) {
             return false;
         }
+    }
+
+    /**
+     * FR-15: rule-based QC detection with fallback to hardcoded logic.
+     */
+    static boolean isControlRow(String sampleId, String qcTask, List<QcRule> qcRules) {
+        if (qcRules != null && !qcRules.isEmpty()) {
+            Map<String, String> fieldValues = new HashMap<>();
+            if (qcTask != null) {
+                fieldValues.put("QC_TASK", qcTask);
+            }
+            return QcRuleEvaluator.isQcSample(qcRules, sampleId, fieldValues);
+        }
+        return isControlRow(sampleId, qcTask);
     }
 
     private static boolean isControlRow(String sampleId, String qcTask) {

--- a/src/main/java/org/itech/ahb/fhir/HL7ResultParser.java
+++ b/src/main/java/org/itech/ahb/fhir/HL7ResultParser.java
@@ -1,9 +1,13 @@
 package org.itech.ahb.fhir;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.itech.ahb.fhir.FhirBundleBuilder.AnalyzerResult;
+import org.itech.ahb.qc.QcRule;
+import org.itech.ahb.qc.QcRuleEvaluator;
 
 /**
  * Extracts lab results from HL7 v2 ORU^R01 messages.
@@ -26,11 +30,24 @@ public class HL7ResultParser {
      * @return parsed results with accession, or null if no results found
      */
     public static ParsedResults parse(List<String> segmentLines) {
+        return parse(segmentLines, null);
+    }
+
+    /**
+     * Parse HL7 v2 segment lines with configurable QC rules.
+     * HL7 had no QC detection before FR-15 — rules enable it.
+     *
+     * @param segmentLines list of HL7 segment strings
+     * @param qcRules      FR-15 QC identification rules (null = no QC detection)
+     * @return parsed results with accession, or null if no results found
+     */
+    public static ParsedResults parse(List<String> segmentLines, List<QcRule> qcRules) {
         if (segmentLines == null || segmentLines.isEmpty()) {
             return null;
         }
 
         String accession = null;
+        Map<String, String> fieldValues = new HashMap<>();
         List<AnalyzerResult> results = new ArrayList<>();
 
         for (String line : segmentLines) {
@@ -38,6 +55,19 @@ public class HL7ResultParser {
 
             if (line.startsWith("OBR|")) {
                 accession = parseAccessionFromOBR(line);
+                // Extract OBR fields for rule evaluation
+                String[] fields = line.split("\\|", -1);
+                for (int i = 0; i < fields.length; i++) {
+                    fieldValues.put("OBR." + i, fields[i].trim());
+                }
+            }
+
+            if (line.startsWith("PID|")) {
+                // Extract PID fields for rule evaluation
+                String[] fields = line.split("\\|", -1);
+                for (int i = 0; i < fields.length; i++) {
+                    fieldValues.put("PID." + i, fields[i].trim());
+                }
             }
 
             if (line.startsWith("OBX|")) {
@@ -50,14 +80,19 @@ public class HL7ResultParser {
 
         if (accession == null || accession.isBlank()) {
             // Fallback: try PID-3 patient ID
-            for (String line : segmentLines) {
-                if (line != null && line.startsWith("PID|")) {
-                    String[] fields = line.split("\\|", -1);
-                    if (fields.length > 3 && !fields[3].isBlank()) {
-                        accession = fields[3].split("\\^")[0].trim();
-                        break;
-                    }
-                }
+            String pid3 = fieldValues.get("PID.3");
+            if (pid3 != null && !pid3.isBlank()) {
+                accession = pid3.split("\\^")[0].trim();
+            }
+        }
+
+        // FR-15: evaluate QC rules against collected fields
+        if (qcRules != null && !qcRules.isEmpty() && accession != null) {
+            boolean isQcSample = QcRuleEvaluator.isQcSample(qcRules, accession, fieldValues);
+            if (isQcSample) {
+                results = results.stream()
+                        .map(r -> r.withControl(true))
+                        .toList();
             }
         }
 

--- a/src/main/java/org/itech/ahb/qc/QcRule.java
+++ b/src/main/java/org/itech/ahb/qc/QcRule.java
@@ -1,0 +1,15 @@
+package org.itech.ahb.qc;
+
+/**
+ * A QC sample identification rule, pulled from OE.
+ * Rules use OR semantics: if ANY active rule matches, the sample is QC.
+ *
+ * @param ruleType       FIELD_EQUALS, SPECIMEN_ID_PREFIX, SPECIMEN_ID_PATTERN, FIELD_CONTAINS
+ * @param targetField    e.g., "O.12", "QC_TASK" (null for SPECIMEN_ID_* rules)
+ * @param operand        the comparison value, prefix, or regex pattern
+ */
+public record QcRule(
+        String ruleType,
+        String targetField,
+        String operand) {
+}

--- a/src/main/java/org/itech/ahb/qc/QcRuleEvaluator.java
+++ b/src/main/java/org/itech/ahb/qc/QcRuleEvaluator.java
@@ -1,6 +1,7 @@
 package org.itech.ahb.qc;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
@@ -57,12 +58,18 @@ public final class QcRuleEvaluator {
             case "FIELD_CONTAINS" -> {
                 String value = fieldValues != null
                         ? fieldValues.get(rule.targetField()) : null;
+                // Locale.ROOT so case-folding is deterministic across JVM locales.
+                // In Turkish locale, "i".toUpperCase() yields "İ" (U+0130), not "I",
+                // which breaks case-insensitive matching when either side contains 'i'.
                 yield value != null
-                        && value.toUpperCase().contains(rule.operand().toUpperCase());
+                        && value.toUpperCase(Locale.ROOT)
+                                .contains(rule.operand().toUpperCase(Locale.ROOT));
             }
             case "SPECIMEN_ID_PREFIX" -> {
+                // Same Locale.ROOT fix as FIELD_CONTAINS above.
                 yield specimenId != null
-                        && specimenId.toUpperCase().startsWith(rule.operand().toUpperCase());
+                        && specimenId.toUpperCase(Locale.ROOT)
+                                .startsWith(rule.operand().toUpperCase(Locale.ROOT));
             }
             case "SPECIMEN_ID_PATTERN" -> {
                 if (specimenId == null) yield false;

--- a/src/main/java/org/itech/ahb/qc/QcRuleEvaluator.java
+++ b/src/main/java/org/itech/ahb/qc/QcRuleEvaluator.java
@@ -1,0 +1,84 @@
+package org.itech.ahb.qc;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Evaluates QC identification rules against parsed message fields.
+ *
+ * <p>Rules use OR semantics: a sample is flagged as QC if ANY rule matches.
+ * Thread-safe — compiled regex patterns are cached in a static ConcurrentHashMap.
+ */
+@Slf4j
+public final class QcRuleEvaluator {
+
+    private static final ConcurrentHashMap<String, Pattern> PATTERN_CACHE = new ConcurrentHashMap<>();
+
+    private QcRuleEvaluator() {
+    }
+
+    /**
+     * Evaluate QC rules against available field values.
+     *
+     * @param rules       the QC rules to evaluate
+     * @param specimenId  the specimen/accession ID
+     * @param fieldValues map of field reference to field value (e.g., {"O.12": "Q", "QC_TASK": "CONTROL"})
+     * @return true if ANY rule matches (OR semantics)
+     */
+    public static boolean isQcSample(List<QcRule> rules, String specimenId,
+            Map<String, String> fieldValues) {
+        if (rules == null || rules.isEmpty()) {
+            return false;
+        }
+
+        for (QcRule rule : rules) {
+            if (evaluateRule(rule, specimenId, fieldValues)) {
+                log.debug("QC rule matched: type={}, field={}, operand={}",
+                        rule.ruleType(), rule.targetField(), rule.operand());
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean evaluateRule(QcRule rule, String specimenId,
+            Map<String, String> fieldValues) {
+        return switch (rule.ruleType()) {
+            case "FIELD_EQUALS" -> {
+                String value = fieldValues != null
+                        ? fieldValues.get(rule.targetField()) : null;
+                yield value != null
+                        && value.trim().equalsIgnoreCase(rule.operand().trim());
+            }
+            case "FIELD_CONTAINS" -> {
+                String value = fieldValues != null
+                        ? fieldValues.get(rule.targetField()) : null;
+                yield value != null
+                        && value.toUpperCase().contains(rule.operand().toUpperCase());
+            }
+            case "SPECIMEN_ID_PREFIX" -> {
+                yield specimenId != null
+                        && specimenId.toUpperCase().startsWith(rule.operand().toUpperCase());
+            }
+            case "SPECIMEN_ID_PATTERN" -> {
+                if (specimenId == null) yield false;
+                try {
+                    Pattern pattern = PATTERN_CACHE.computeIfAbsent(rule.operand(),
+                            k -> Pattern.compile(k, Pattern.CASE_INSENSITIVE));
+                    yield pattern.matcher(specimenId).matches();
+                } catch (PatternSyntaxException e) {
+                    log.warn("Invalid QC regex '{}': {}", rule.operand(), e.getMessage());
+                    yield false;
+                }
+            }
+            default -> {
+                log.warn("Unknown QC rule type: {}", rule.ruleType());
+                yield false;
+            }
+        };
+    }
+}

--- a/src/main/java/org/itech/ahb/routing/HttpForwardingRouter.java
+++ b/src/main/java/org/itech/ahb/routing/HttpForwardingRouter.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
+import org.itech.ahb.config.AnalyzerRegistryConfig;
 import org.itech.ahb.config.FhirRoutingConfig;
 import org.itech.ahb.config.properties.HTTPForwardServerConfigurationProperties;
 import org.itech.ahb.fhir.ASTMResultParser;
@@ -89,6 +90,7 @@ public class HttpForwardingRouter implements MessageRouter {
     private final HTTPForwardServerConfigurationProperties httpConfig;
     private final FhirRoutingConfig fhirConfig;
     private final SqliteFileStateStore stateStore;
+    private final AnalyzerRegistryConfig registry;
     private final int connectTimeoutSeconds;
     private final int readTimeoutSeconds;
     private final HttpClient httpClient;
@@ -101,14 +103,17 @@ public class HttpForwardingRouter implements MessageRouter {
      * @param stateStore shared SQLite state store (optional — when absent the
      *                   router logs rejections without persisting them, same
      *                   as the pre-B1 behavior)
+     * @param registry   the analyzer registry for QC rule lookup (optional)
      */
     public HttpForwardingRouter(
             HTTPForwardServerConfigurationProperties httpConfig,
             @Autowired(required = false) FhirRoutingConfig fhirConfig,
-            @Autowired(required = false) SqliteFileStateStore stateStore) {
+            @Autowired(required = false) SqliteFileStateStore stateStore,
+            @Autowired(required = false) AnalyzerRegistryConfig registry) {
         this.httpConfig = httpConfig;
         this.fhirConfig = fhirConfig;
         this.stateStore = stateStore;
+        this.registry = registry;
         this.connectTimeoutSeconds = httpConfig.getConnectTimeoutSeconds();
         this.readTimeoutSeconds = httpConfig.getReadTimeoutSeconds();
         this.httpClient = HttpClientFactory.create(connectTimeoutSeconds, httpConfig.isInsecureTls(), "forwarding");
@@ -254,11 +259,47 @@ public class HttpForwardingRouter implements MessageRouter {
      * Bundle, and POSTs to OE's {@code /analyzer/fhir} endpoint.
      */
     private boolean routeAsFhir(MessageEnvelope envelope) {
-        // Parse raw message to extract results
+        // FR-15: look up QC rules from analyzer registry by source ID
+        java.util.List<org.itech.ahb.qc.QcRule> qcRules = java.util.List.of();
+        if (registry != null && envelope.getSourceId() != null) {
+            var entry = registry.findAnalyzerEntry(envelope.getSourceId());
+            if (entry.isPresent() && entry.get().getQcRules() != null) {
+                qcRules = entry.get().getQcRules();
+            }
+        }
+
+        // Parse raw message to extract results, passing QC rules to parsers
+        java.util.List<org.itech.ahb.qc.QcRule> rules = qcRules;
         HL7ResultParser.ParsedResults parsed = switch (envelope.getProtocol()) {
-            case HL7 -> HL7ResultParser.parseRaw(envelope.getRawMessage());
-            case ASTM -> ASTMResultParser.parseRaw(envelope.getRawMessage());
-            case CSV -> ASTMResultParser.parseRaw(envelope.getRawMessage()); // CSV uses same record format
+            case HL7 -> {
+                String raw = envelope.getRawMessage();
+                if (raw == null || raw.isBlank()) yield null;
+                String normalized = raw.replace("\r\n", "\r").replace("\n", "\r");
+                java.util.List<String> segments = new java.util.ArrayList<>();
+                for (String seg : normalized.split("\r")) {
+                    if (!seg.isBlank()) segments.add(seg);
+                }
+                yield HL7ResultParser.parse(segments, rules);
+            }
+            case ASTM -> {
+                String raw = envelope.getRawMessage();
+                if (raw == null || raw.isBlank()) yield null;
+                java.util.List<String> lines = new java.util.ArrayList<>();
+                for (String l : raw.split("[\\r\\n]+")) {
+                    if (!l.isBlank()) lines.add(l);
+                }
+                yield ASTMResultParser.parse(lines, rules);
+            }
+            case CSV -> {
+                // CSV over HTTP/TCP uses same ASTM record format
+                String raw = envelope.getRawMessage();
+                if (raw == null || raw.isBlank()) yield null;
+                java.util.List<String> lines = new java.util.ArrayList<>();
+                for (String l : raw.split("[\\r\\n]+")) {
+                    if (!l.isBlank()) lines.add(l);
+                }
+                yield ASTMResultParser.parse(lines, rules);
+            }
             default -> {
                 log.error("FHIR routing: unsupported protocol {} from {} — cannot parse",
                         envelope.getProtocol(), envelope.getSourceId());

--- a/src/main/java/org/itech/ahb/startup/AnalyzerRegistryBootstrap.java
+++ b/src/main/java/org/itech/ahb/startup/AnalyzerRegistryBootstrap.java
@@ -3,6 +3,7 @@ package org.itech.ahb.startup;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -10,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.itech.ahb.config.AnalyzerRegistryConfig;
 import org.itech.ahb.config.AnalyzerRegistryConfig.AnalyzerEntry;
 import org.itech.ahb.file.FileWatcher;
+import org.itech.ahb.qc.QcRule;
 import org.itech.ahb.util.OeApiClient;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
@@ -108,6 +110,7 @@ public class AnalyzerRegistryBootstrap {
                     entry.setExpectedProtocol(
                             protocol != null && protocol.contains("HL7") ? "HL7" : "ASTM");
                     entry.setMappedTestCodes(mappedTestCodes);
+                    entry.setQcRules(parseQcRules(analyzer));
                     newRegistry.put(ip, entry);
                 }
 
@@ -146,6 +149,7 @@ public class AnalyzerRegistryBootstrap {
                             entry.setScannerSynonyms(fallback);
                         }
                     }
+                    entry.setQcRules(parseQcRules(analyzer));
                     newRegistry.put(importDir, entry);
                     fileWatcher.addWatchDirectory(
                             Path.of(importDir),
@@ -164,6 +168,7 @@ public class AnalyzerRegistryBootstrap {
             }
 
         } catch (java.net.ConnectException e) {
+
             log.warn("Cannot reach OE — bridge starting without analyzer registry. "
                     + "OE will push registrations when it starts.");
         } catch (Exception e) {
@@ -191,5 +196,24 @@ public class AnalyzerRegistryBootstrap {
             return syn;
         }
         return java.util.Collections.emptyMap();
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<QcRule> parseQcRules(Map<String, Object> analyzer) {
+        Object qcRulesObj = analyzer.get("qcRules");
+        if (!(qcRulesObj instanceof List<?>)) {
+            return new ArrayList<>();
+        }
+        List<Map<String, Object>> rawRules = (List<Map<String, Object>>) qcRulesObj;
+        List<QcRule> rules = new ArrayList<>(rawRules.size());
+        for (Map<String, Object> ruleMap : rawRules) {
+            String ruleType = (String) ruleMap.get("ruleType");
+            String targetField = (String) ruleMap.get("targetField");
+            String operand = (String) ruleMap.get("operand");
+            if (ruleType != null && operand != null) {
+                rules.add(new QcRule(ruleType, targetField, operand));
+            }
+        }
+        return rules;
     }
 }

--- a/src/test/java/org/itech/ahb/fhir/ASTMResultParserQcRulesTest.java
+++ b/src/test/java/org/itech/ahb/fhir/ASTMResultParserQcRulesTest.java
@@ -1,0 +1,142 @@
+package org.itech.ahb.fhir;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import org.itech.ahb.fhir.HL7ResultParser.ParsedResults;
+import org.itech.ahb.qc.QcRule;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ASTMResultParser — QC rules (FR-15)")
+class ASTMResultParserQcRulesTest {
+
+    private static final String ASTM_QC_O12_Q =
+            "H|\\^&|||Analyzer\r"
+            + "P|1\r"
+            + "O|1|QC_SAMPLE001||||||||||Q\r"
+            + "R|1|^^^WBC|7.5|10*3/uL\r"
+            + "L|1\r";
+
+    private static final String ASTM_PATIENT_O12_P =
+            "H|\\^&|||Analyzer\r"
+            + "P|1\r"
+            + "O|1|SAMPLE001||||||||||P\r"
+            + "R|1|^^^WBC|7.5|10*3/uL\r"
+            + "L|1\r";
+
+    private static final String ASTM_QC_PREFIX =
+            "H|\\^&|||Analyzer\r"
+            + "P|1\r"
+            + "O|1|QC-LOT-001||||||||||P\r"
+            + "R|1|^^^WBC|7.5|10*3/uL\r"
+            + "L|1\r";
+
+    private static final String ASTM_TWO_RESULTS =
+            "H|\\^&|||Analyzer\r"
+            + "P|1\r"
+            + "O|1|SAMPLE001||||||||||Q\r"
+            + "R|1|^^^WBC|7.5|10*3/uL\r"
+            + "R|2|^^^RBC|4.82|10*6/uL\r"
+            + "L|1\r";
+
+    private static List<String> lines(String raw) {
+        return List.of(raw.split("[\\r\\n]+"));
+    }
+
+    @Nested
+    @DisplayName("Rule-based QC detection")
+    class RuleBased {
+
+        @Test
+        @DisplayName("FIELD_EQUALS O.12=Q flags results as control")
+        void fieldEqualsO12Q_FlagsAsControl() {
+            List<QcRule> rules = List.of(new QcRule("FIELD_EQUALS", "O.12", "Q"));
+            ParsedResults parsed = ASTMResultParser.parse(lines(ASTM_QC_O12_Q), rules);
+
+            assertNotNull(parsed);
+            assertEquals("QC_SAMPLE001", parsed.accessionNumber());
+            assertEquals(1, parsed.results().size());
+            assertTrue(parsed.results().get(0).isControl());
+        }
+
+        @Test
+        @DisplayName("SPECIMEN_ID_PREFIX matches accession, not action code")
+        void specimenIdPrefix_FlagsAsControl() {
+            List<QcRule> rules = List.of(new QcRule("SPECIMEN_ID_PREFIX", null, "QC-"));
+            ParsedResults parsed = ASTMResultParser.parse(lines(ASTM_QC_PREFIX), rules);
+
+            assertNotNull(parsed);
+            assertEquals("QC-LOT-001", parsed.accessionNumber());
+            assertEquals(1, parsed.results().size());
+            assertTrue(parsed.results().get(0).isControl());
+        }
+
+        @Test
+        @DisplayName("SPECIMEN_ID_PATTERN regex match flags as control")
+        void specimenIdPattern_FlagsAsControl() {
+            List<QcRule> rules = List.of(new QcRule("SPECIMEN_ID_PATTERN", null, "^QC-LOT-\\d{3}$"));
+            ParsedResults parsed = ASTMResultParser.parse(lines(ASTM_QC_PREFIX), rules);
+
+            assertNotNull(parsed);
+            assertEquals("QC-LOT-001", parsed.accessionNumber());
+            assertEquals(1, parsed.results().size());
+            assertTrue(parsed.results().get(0).isControl());
+        }
+
+        @Test
+        @DisplayName("Non-matching rules do not flag as control")
+        void nonMatchingRules_NotControl() {
+            List<QcRule> rules = List.of(new QcRule("FIELD_EQUALS", "O.12", "Q"));
+            ParsedResults parsed = ASTMResultParser.parse(lines(ASTM_PATIENT_O12_P), rules);
+
+            assertNotNull(parsed);
+            assertFalse(parsed.results().get(0).isControl());
+        }
+
+        @Test
+        @DisplayName("Multiple results all flagged when QC matches")
+        void multipleResults_AllFlagged() {
+            List<QcRule> rules = List.of(new QcRule("FIELD_EQUALS", "O.12", "Q"));
+            ParsedResults parsed = ASTMResultParser.parse(lines(ASTM_TWO_RESULTS), rules);
+
+            assertNotNull(parsed);
+            assertEquals(2, parsed.results().size());
+            assertTrue(parsed.results().get(0).isControl());
+            assertTrue(parsed.results().get(1).isControl());
+        }
+    }
+
+    @Nested
+    @DisplayName("Fallback to hardcoded O.12==Q")
+    class Fallback {
+
+        @Test
+        @DisplayName("Null rules falls back to hardcoded O.12 check — QC detected")
+        void nullRules_FallbackDetectsQc() {
+            ParsedResults parsed = ASTMResultParser.parse(lines(ASTM_QC_O12_Q), null);
+
+            assertNotNull(parsed);
+            assertTrue(parsed.results().get(0).isControl());
+        }
+
+        @Test
+        @DisplayName("Empty rules falls back to hardcoded O.12 check — QC detected")
+        void emptyRules_FallbackDetectsQc() {
+            ParsedResults parsed = ASTMResultParser.parse(lines(ASTM_QC_O12_Q), List.of());
+
+            assertNotNull(parsed);
+            assertTrue(parsed.results().get(0).isControl());
+        }
+
+        @Test
+        @DisplayName("Null rules with O.12=P — not control")
+        void nullRules_PatientNotControl() {
+            ParsedResults parsed = ASTMResultParser.parse(lines(ASTM_PATIENT_O12_P), null);
+
+            assertNotNull(parsed);
+            assertFalse(parsed.results().get(0).isControl());
+        }
+    }
+}

--- a/src/test/java/org/itech/ahb/fhir/FileResultParserQcRulesTest.java
+++ b/src/test/java/org/itech/ahb/fhir/FileResultParserQcRulesTest.java
@@ -1,0 +1,110 @@
+package org.itech.ahb.fhir;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import org.itech.ahb.qc.QcRule;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("FileResultParser — QC rules (FR-15)")
+class FileResultParserQcRulesTest {
+
+    @Nested
+    @DisplayName("isControlRow with QC rules")
+    class IsControlRowWithRules {
+
+        @Test
+        @DisplayName("FIELD_EQUALS on QC_TASK matches")
+        void fieldEquals_QcTask() {
+            List<QcRule> rules = List.of(new QcRule("FIELD_EQUALS", "QC_TASK", "CONTROL"));
+            assertTrue(FileResultParser.isControlRow("PATIENT-001", "CONTROL", rules));
+        }
+
+        @Test
+        @DisplayName("SPECIMEN_ID_PREFIX matches on sample ID")
+        void specimenIdPrefix_Matches() {
+            List<QcRule> rules = List.of(new QcRule("SPECIMEN_ID_PREFIX", null, "NEG"));
+            assertTrue(FileResultParser.isControlRow("NEG-001", null, rules));
+        }
+
+        @Test
+        @DisplayName("SPECIMEN_ID_PATTERN regex matches")
+        void specimenIdPattern_Matches() {
+            List<QcRule> rules = List.of(new QcRule("SPECIMEN_ID_PATTERN", null, "^(CNEG|CPOS|NTC).*"));
+            assertTrue(FileResultParser.isControlRow("CPOS-2026", null, rules));
+        }
+
+        @Test
+        @DisplayName("FIELD_CONTAINS on QC_TASK substring matches")
+        void fieldContains_QcTask() {
+            List<QcRule> rules = List.of(new QcRule("FIELD_CONTAINS", "QC_TASK", "CTRL"));
+            assertTrue(FileResultParser.isControlRow("SAMPLE-001", "Internal CTRL Check", rules));
+        }
+
+        @Test
+        @DisplayName("Non-matching rules return false")
+        void nonMatchingRules() {
+            List<QcRule> rules = List.of(new QcRule("FIELD_EQUALS", "QC_TASK", "CONTROL"));
+            assertFalse(FileResultParser.isControlRow("PATIENT-001", "UNKNOWN", rules));
+        }
+    }
+
+    @Nested
+    @DisplayName("Rules override hardcoded fallback")
+    class RulesOverrideFallback {
+
+        @Test
+        @DisplayName("Rules present — hardcoded prefixes bypassed entirely")
+        void rulesPresent_HardcodedPrefixesBypassed() {
+            // "NEG" would match hardcoded CONTROL_PREFIXES, but rules take precedence
+            List<QcRule> rules = List.of(new QcRule("FIELD_EQUALS", "QC_TASK", "CUSTOM_QC"));
+            // qcTask="PATIENT" does not match the rule, and hardcoded prefix check is NOT run
+            assertFalse(FileResultParser.isControlRow("NEG", "PATIENT", rules));
+        }
+
+        @Test
+        @DisplayName("Rules present — hardcoded prefix list not consulted")
+        void rulesPresent_FallbackPrefixesIgnored() {
+            // "NEG" matches hardcoded CONTROL_PREFIXES but does NOT start with "CUSTOM-"
+            List<QcRule> rules = List.of(new QcRule("SPECIMEN_ID_PREFIX", null, "CUSTOM-"));
+            assertFalse(FileResultParser.isControlRow("NEG", null, rules));
+        }
+    }
+
+    @Nested
+    @DisplayName("Fallback when rules absent")
+    class FallbackWhenRulesAbsent {
+
+        @Test
+        @DisplayName("Null rules — falls back to hardcoded prefixes")
+        void nullRules_FallbackPrefixes() {
+            assertTrue(FileResultParser.isControlRow("CNEG-2026", null, null));
+        }
+
+        @Test
+        @DisplayName("Empty rules — falls back to hardcoded prefixes")
+        void emptyRules_FallbackPrefixes() {
+            assertTrue(FileResultParser.isControlRow("POS-CTRL", null, List.of()));
+        }
+
+        @Test
+        @DisplayName("Null rules — falls back to qcTask=CONTROL")
+        void nullRules_FallbackQcTask() {
+            assertTrue(FileResultParser.isControlRow("PATIENT-001", "CONTROL", null));
+        }
+
+        @Test
+        @DisplayName("Null rules — patient sample returns false")
+        void nullRules_PatientSample() {
+            assertFalse(FileResultParser.isControlRow("PATIENT-001", "UNKNOWN", null));
+        }
+
+        @Test
+        @DisplayName("Empty rules — patient sample returns false")
+        void emptyRules_PatientSample() {
+            assertFalse(FileResultParser.isControlRow("PATIENT-001", null, List.of()));
+        }
+    }
+}

--- a/src/test/java/org/itech/ahb/fhir/HL7ResultParserQcRulesTest.java
+++ b/src/test/java/org/itech/ahb/fhir/HL7ResultParserQcRulesTest.java
@@ -1,0 +1,196 @@
+package org.itech.ahb.fhir;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import org.itech.ahb.fhir.HL7ResultParser.ParsedResults;
+import org.itech.ahb.qc.QcRule;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("HL7ResultParser — QC rules (FR-15)")
+class HL7ResultParserQcRulesTest {
+
+    private static List<String> segments(String... segs) {
+        return List.of(segs);
+    }
+
+    @Nested
+    @DisplayName("Rule-based QC detection")
+    class RuleBased {
+
+        @Test
+        @DisplayName("OBR field rule flags all observations as control")
+        void obrFieldRule_FlagsAllAsControl() {
+            List<String> segs = segments(
+                    "MSH|^~\\&|A|B|C|D|20260326||ORU^R01|1|P|2.3.1",
+                    "PID|1||PAT001",
+                    "OBR|1||ACC001|QC-PANEL",
+                    "OBX|1|NM|WBC||7.5|10*3/uL",
+                    "OBX|2|NM|RBC||4.82|10*6/uL");
+            List<QcRule> rules = List.of(new QcRule("FIELD_EQUALS", "OBR.4", "QC-PANEL"));
+
+            ParsedResults parsed = HL7ResultParser.parse(segs, rules);
+
+            assertNotNull(parsed);
+            assertEquals(2, parsed.results().size());
+            assertTrue(parsed.results().get(0).isControl());
+            assertTrue(parsed.results().get(1).isControl());
+        }
+
+        @Test
+        @DisplayName("PID field rule flags as control")
+        void pidFieldRule_FlagsAsControl() {
+            List<String> segs = segments(
+                    "MSH|^~\\&|A|B|C|D|20260326||ORU^R01|1|P|2.3.1",
+                    "PID|1||QC-PATIENT",
+                    "OBR|1||ACC001|CBC",
+                    "OBX|1|NM|WBC||7.5|10*3/uL");
+            List<QcRule> rules = List.of(new QcRule("FIELD_EQUALS", "PID.3", "QC-PATIENT"));
+
+            ParsedResults parsed = HL7ResultParser.parse(segs, rules);
+
+            assertNotNull(parsed);
+            assertTrue(parsed.results().get(0).isControl());
+        }
+
+        @Test
+        @DisplayName("SPECIMEN_ID_PREFIX on accession flags as control")
+        void specimenIdPrefix_FlagsAsControl() {
+            List<String> segs = segments(
+                    "MSH|^~\\&|A|B|C|D|20260326||ORU^R01|1|P|2.3.1",
+                    "PID|1||PAT001",
+                    "OBR|1||QC-LOT-001|CBC",
+                    "OBX|1|NM|WBC||7.5|10*3/uL");
+            List<QcRule> rules = List.of(new QcRule("SPECIMEN_ID_PREFIX", null, "QC-"));
+
+            ParsedResults parsed = HL7ResultParser.parse(segs, rules);
+
+            assertNotNull(parsed);
+            assertEquals("QC-LOT-001", parsed.accessionNumber());
+            assertTrue(parsed.results().get(0).isControl());
+        }
+
+        @Test
+        @DisplayName("FIELD_CONTAINS on OBR field flags as control")
+        void fieldContainsOnObr_FlagsAsControl() {
+            List<String> segs = segments(
+                    "MSH|^~\\&|A|B|C|D|20260326||ORU^R01|1|P|2.3.1",
+                    "PID|1||PAT001",
+                    "OBR|1||ACC001|CTRL-CBC",
+                    "OBX|1|NM|WBC||7.5|10*3/uL");
+            List<QcRule> rules = List.of(new QcRule("FIELD_CONTAINS", "OBR.4", "CTRL"));
+
+            ParsedResults parsed = HL7ResultParser.parse(segs, rules);
+
+            assertNotNull(parsed);
+            assertTrue(parsed.results().get(0).isControl());
+        }
+
+        @Test
+        @DisplayName("SPECIMEN_ID_PATTERN regex on accession flags as control")
+        void specimenIdPattern_FlagsAsControl() {
+            List<String> segs = segments(
+                    "MSH|^~\\&|A|B|C|D|20260326||ORU^R01|1|P|2.3.1",
+                    "PID|1||PAT001",
+                    "OBR|1||QC-LOT-001|CBC",
+                    "OBX|1|NM|WBC||7.5|10*3/uL");
+            List<QcRule> rules = List.of(new QcRule("SPECIMEN_ID_PATTERN", null, "^QC-LOT-\\d{3}$"));
+
+            ParsedResults parsed = HL7ResultParser.parse(segs, rules);
+
+            assertNotNull(parsed);
+            assertTrue(parsed.results().get(0).isControl());
+        }
+    }
+
+    @Nested
+    @DisplayName("No fallback — HL7 had no QC before FR-15")
+    class NoFallback {
+
+        @Test
+        @DisplayName("Null rules does not flag as control")
+        void nullRules_NotControl() {
+            List<String> segs = segments(
+                    "MSH|^~\\&|A|B|C|D|20260326||ORU^R01|1|P|2.3.1",
+                    "PID|1||QC-PATIENT",
+                    "OBR|1||QC-LOT-001|QC-PANEL",
+                    "OBX|1|NM|WBC||7.5|10*3/uL");
+
+            ParsedResults parsed = HL7ResultParser.parse(segs, null);
+
+            assertNotNull(parsed);
+            assertFalse(parsed.results().get(0).isControl());
+        }
+
+        @Test
+        @DisplayName("Empty rules does not flag as control")
+        void emptyRules_NotControl() {
+            List<String> segs = segments(
+                    "MSH|^~\\&|A|B|C|D|20260326||ORU^R01|1|P|2.3.1",
+                    "PID|1||PAT001",
+                    "OBR|1||ACC001|CBC",
+                    "OBX|1|NM|WBC||7.5|10*3/uL");
+
+            ParsedResults parsed = HL7ResultParser.parse(segs, List.of());
+
+            assertNotNull(parsed);
+            assertFalse(parsed.results().get(0).isControl());
+        }
+
+        @Test
+        @DisplayName("Non-matching rules do not flag as control")
+        void nonMatchingRules_NotControl() {
+            List<String> segs = segments(
+                    "MSH|^~\\&|A|B|C|D|20260326||ORU^R01|1|P|2.3.1",
+                    "PID|1||PAT001",
+                    "OBR|1||ACC001|CBC",
+                    "OBX|1|NM|WBC||7.5|10*3/uL");
+            List<QcRule> rules = List.of(new QcRule("FIELD_EQUALS", "OBR.4", "QC-PANEL"));
+
+            ParsedResults parsed = HL7ResultParser.parse(segs, rules);
+
+            assertNotNull(parsed);
+            assertFalse(parsed.results().get(0).isControl());
+        }
+    }
+
+    @Nested
+    @DisplayName("Field extraction correctness")
+    class FieldExtraction {
+
+        @Test
+        @DisplayName("OBR fields indexed correctly")
+        void obrFieldsIndexed() {
+            List<String> segs = segments(
+                    "MSH|^~\\&|A|B|C|D|20260326||ORU^R01|1|P|2.3.1",
+                    "PID|1||PAT001",
+                    "OBR|1|PLACER|FILLER|CBC",
+                    "OBX|1|NM|WBC||7.5|10*3/uL");
+            // OBR.1 = "1" (sequence number)
+            List<QcRule> rules = List.of(new QcRule("FIELD_EQUALS", "OBR.1", "1"));
+
+            ParsedResults parsed = HL7ResultParser.parse(segs, rules);
+
+            assertNotNull(parsed);
+            assertTrue(parsed.results().get(0).isControl());
+        }
+
+        @Test
+        @DisplayName("PID fields indexed correctly — PID.5 patient name")
+        void pidFieldsIndexed() {
+            List<String> segs = segments(
+                    "MSH|^~\\&|A|B|C|D|20260326||ORU^R01|1|P|2.3.1",
+                    "PID|1|EXT|INT|ALT|DOE^JOHN",
+                    "OBR|1||ACC001|CBC",
+                    "OBX|1|NM|WBC||7.5|10*3/uL");
+            List<QcRule> rules = List.of(new QcRule("FIELD_CONTAINS", "PID.5", "DOE"));
+
+            ParsedResults parsed = HL7ResultParser.parse(segs, rules);
+
+            assertNotNull(parsed);
+            assertTrue(parsed.results().get(0).isControl());
+        }
+    }
+}

--- a/src/test/java/org/itech/ahb/integration/UnifiedRoutingTest.java
+++ b/src/test/java/org/itech/ahb/integration/UnifiedRoutingTest.java
@@ -122,8 +122,8 @@ class UnifiedRoutingTest {
         HTTPForwardServerConfigurationProperties httpConfig = new HTTPForwardServerConfigurationProperties();
         httpConfig.setUri(java.net.URI.create("http://localhost:" + serverPort + "/api/OpenELIS-Global/analyzer"));
 
-        HttpForwardingRouter forwardingRouter = new HttpForwardingRouter(httpConfig, null, null);
         AnalyzerRegistryConfig registry = new AnalyzerRegistryConfig();
+        HttpForwardingRouter forwardingRouter = new HttpForwardingRouter(httpConfig, null, null, registry);
         Map<String, AnalyzerRegistryConfig.AnalyzerEntry> analyzers = new LinkedHashMap<>();
         analyzers.put("/dev/ttyUSB0", analyzer("SERIAL-001", "ASTM"));
         analyzers.put("/dev/ttyUSB1", analyzer("SERIAL-HL7-001", "HL7"));

--- a/src/test/java/org/itech/ahb/qc/QcRuleEvaluatorTest.java
+++ b/src/test/java/org/itech/ahb/qc/QcRuleEvaluatorTest.java
@@ -1,0 +1,243 @@
+package org.itech.ahb.qc;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("QcRuleEvaluator")
+class QcRuleEvaluatorTest {
+
+    @Nested
+    @DisplayName("FIELD_EQUALS")
+    class FieldEquals {
+
+        @Test
+        @DisplayName("Case-insensitive exact match returns true")
+        void exactMatch_CaseInsensitive() {
+            List<QcRule> rules = List.of(new QcRule("FIELD_EQUALS", "O.12", "Q"));
+            Map<String, String> fields = Map.of("O.12", "q");
+            assertTrue(QcRuleEvaluator.isQcSample(rules, "SAMPLE001", fields));
+        }
+
+        @Test
+        @DisplayName("No match returns false")
+        void noMatch() {
+            List<QcRule> rules = List.of(new QcRule("FIELD_EQUALS", "O.12", "Q"));
+            Map<String, String> fields = Map.of("O.12", "P");
+            assertFalse(QcRuleEvaluator.isQcSample(rules, "SAMPLE001", fields));
+        }
+
+        @Test
+        @DisplayName("Target field missing from map returns false")
+        void targetFieldMissing() {
+            List<QcRule> rules = List.of(new QcRule("FIELD_EQUALS", "O.12", "Q"));
+            Map<String, String> fields = Map.of("O.11", "Q");
+            assertFalse(QcRuleEvaluator.isQcSample(rules, "SAMPLE001", fields));
+        }
+
+        @Test
+        @DisplayName("Null field values returns false")
+        void nullFieldValues() {
+            List<QcRule> rules = List.of(new QcRule("FIELD_EQUALS", "O.12", "Q"));
+            assertFalse(QcRuleEvaluator.isQcSample(rules, "SAMPLE001", null));
+        }
+
+        @Test
+        @DisplayName("Whitespace trimming matches after trim")
+        void whitespaceTrimming() {
+            List<QcRule> rules = List.of(new QcRule("FIELD_EQUALS", "O.12", " Q "));
+            Map<String, String> fields = Map.of("O.12", "  Q  ");
+            assertTrue(QcRuleEvaluator.isQcSample(rules, "SAMPLE001", fields));
+        }
+    }
+
+    @Nested
+    @DisplayName("FIELD_CONTAINS")
+    class FieldContains {
+
+        @Test
+        @DisplayName("Case-insensitive substring match returns true")
+        void substringMatch_CaseInsensitive() {
+            List<QcRule> rules = List.of(new QcRule("FIELD_CONTAINS", "QC_TASK", "control"));
+            Map<String, String> fields = Map.of("QC_TASK", "Internal CONTROL Sample");
+            assertTrue(QcRuleEvaluator.isQcSample(rules, "SAMPLE001", fields));
+        }
+
+        @Test
+        @DisplayName("No substring match returns false")
+        void noMatch() {
+            List<QcRule> rules = List.of(new QcRule("FIELD_CONTAINS", "QC_TASK", "CONTROL"));
+            Map<String, String> fields = Map.of("QC_TASK", "PATIENT");
+            assertFalse(QcRuleEvaluator.isQcSample(rules, "SAMPLE001", fields));
+        }
+
+        @Test
+        @DisplayName("Null field values returns false")
+        void nullFieldValues() {
+            List<QcRule> rules = List.of(new QcRule("FIELD_CONTAINS", "QC_TASK", "CONTROL"));
+            assertFalse(QcRuleEvaluator.isQcSample(rules, "SAMPLE001", null));
+        }
+
+        @Test
+        @DisplayName("Target field missing from map returns false")
+        void targetFieldMissing() {
+            List<QcRule> rules = List.of(new QcRule("FIELD_CONTAINS", "QC_TASK", "CONTROL"));
+            Map<String, String> fields = Map.of("OTHER_FIELD", "CONTROL");
+            assertFalse(QcRuleEvaluator.isQcSample(rules, "SAMPLE001", fields));
+        }
+    }
+
+    @Nested
+    @DisplayName("SPECIMEN_ID_PREFIX")
+    class SpecimenIdPrefix {
+
+        @Test
+        @DisplayName("Case-insensitive prefix match returns true")
+        void matchingPrefix_CaseInsensitive() {
+            List<QcRule> rules = List.of(new QcRule("SPECIMEN_ID_PREFIX", null, "qc-"));
+            assertTrue(QcRuleEvaluator.isQcSample(rules, "QC-2026-001", Map.of()));
+        }
+
+        @Test
+        @DisplayName("No prefix match returns false")
+        void noMatch() {
+            List<QcRule> rules = List.of(new QcRule("SPECIMEN_ID_PREFIX", null, "QC-"));
+            assertFalse(QcRuleEvaluator.isQcSample(rules, "SAMPLE-001", Map.of()));
+        }
+
+        @Test
+        @DisplayName("Null specimen ID returns false")
+        void nullSpecimenId() {
+            List<QcRule> rules = List.of(new QcRule("SPECIMEN_ID_PREFIX", null, "QC-"));
+            assertFalse(QcRuleEvaluator.isQcSample(rules, null, Map.of()));
+        }
+
+        @Test
+        @DisplayName("Empty specimen ID returns false")
+        void emptySpecimenId() {
+            List<QcRule> rules = List.of(new QcRule("SPECIMEN_ID_PREFIX", null, "QC-"));
+            assertFalse(QcRuleEvaluator.isQcSample(rules, "", Map.of()));
+        }
+    }
+
+    @Nested
+    @DisplayName("SPECIMEN_ID_PATTERN")
+    class SpecimenIdPattern {
+
+        @Test
+        @DisplayName("Matching regex returns true")
+        void matchingRegex() {
+            List<QcRule> rules = List.of(new QcRule("SPECIMEN_ID_PATTERN", null, "^CTRL-\\d{4}$"));
+            assertTrue(QcRuleEvaluator.isQcSample(rules, "CTRL-1234", Map.of()));
+        }
+
+        @Test
+        @DisplayName("Non-matching regex returns false")
+        void nonMatchingRegex() {
+            List<QcRule> rules = List.of(new QcRule("SPECIMEN_ID_PATTERN", null, "^CTRL-\\d{4}$"));
+            assertFalse(QcRuleEvaluator.isQcSample(rules, "CTRL-ABC", Map.of()));
+        }
+
+        @Test
+        @DisplayName("Case-insensitive flag works")
+        void caseInsensitiveFlag() {
+            List<QcRule> rules = List.of(new QcRule("SPECIMEN_ID_PATTERN", null, "^ctrl-\\d{4}$"));
+            assertTrue(QcRuleEvaluator.isQcSample(rules, "CTRL-1234", Map.of()));
+        }
+
+        @Test
+        @DisplayName("Null specimen ID returns false")
+        void nullSpecimenId() {
+            List<QcRule> rules = List.of(new QcRule("SPECIMEN_ID_PATTERN", null, "^QC.*"));
+            assertFalse(QcRuleEvaluator.isQcSample(rules, null, Map.of()));
+        }
+
+        @Test
+        @DisplayName("Invalid regex returns false without throwing")
+        void invalidRegex_ReturnsFalse() {
+            List<QcRule> rules = List.of(new QcRule("SPECIMEN_ID_PATTERN", null, "[invalid("));
+            assertFalse(QcRuleEvaluator.isQcSample(rules, "test", Map.of()));
+        }
+
+        @Test
+        @DisplayName("Cached pattern works on second invocation")
+        void patternCached() {
+            List<QcRule> rules = List.of(new QcRule("SPECIMEN_ID_PATTERN", null, "^QC-\\d+$"));
+            assertTrue(QcRuleEvaluator.isQcSample(rules, "QC-001", Map.of()));
+            assertTrue(QcRuleEvaluator.isQcSample(rules, "QC-999", Map.of()));
+        }
+    }
+
+    @Nested
+    @DisplayName("OR semantics")
+    class OrSemantics {
+
+        @Test
+        @DisplayName("First rule matches — short-circuits to true")
+        void firstRuleMatches() {
+            List<QcRule> rules = List.of(
+                    new QcRule("FIELD_EQUALS", "O.12", "Q"),
+                    new QcRule("SPECIMEN_ID_PREFIX", null, "SAMPLE-"));
+            Map<String, String> fields = Map.of("O.12", "Q");
+            assertTrue(QcRuleEvaluator.isQcSample(rules, "REGULAR-001", fields));
+        }
+
+        @Test
+        @DisplayName("Second rule matches — first does not — returns true")
+        void secondRuleMatches() {
+            List<QcRule> rules = List.of(
+                    new QcRule("FIELD_EQUALS", "O.12", "X"),
+                    new QcRule("SPECIMEN_ID_PREFIX", null, "QC-"));
+            Map<String, String> fields = Map.of("O.12", "P");
+            // First rule: O.12="P" != "X" → no match
+            // Second rule: specimenId "QC-0001" starts with "QC-" → match
+            assertTrue(QcRuleEvaluator.isQcSample(rules, "QC-0001", fields));
+        }
+
+        @Test
+        @DisplayName("No rules match — returns false")
+        void noRulesMatch() {
+            List<QcRule> rules = List.of(
+                    new QcRule("FIELD_EQUALS", "O.12", "Q"),
+                    new QcRule("SPECIMEN_ID_PREFIX", null, "QC-"));
+            Map<String, String> fields = Map.of("O.12", "P");
+            assertFalse(QcRuleEvaluator.isQcSample(rules, "SAMPLE-001", fields));
+        }
+    }
+
+    @Nested
+    @DisplayName("Edge cases")
+    class EdgeCases {
+
+        @Test
+        @DisplayName("Empty rules list returns false")
+        void emptyRules() {
+            assertFalse(QcRuleEvaluator.isQcSample(List.of(), "SAMPLE", Map.of()));
+        }
+
+        @Test
+        @DisplayName("Null rules list returns false")
+        void nullRules() {
+            assertFalse(QcRuleEvaluator.isQcSample(null, "SAMPLE", Map.of()));
+        }
+
+        @Test
+        @DisplayName("Unknown rule type returns false")
+        void unknownRuleType() {
+            List<QcRule> rules = List.of(new QcRule("UNKNOWN_TYPE", null, "test"));
+            assertFalse(QcRuleEvaluator.isQcSample(rules, "test", Map.of()));
+        }
+
+        @Test
+        @DisplayName("Empty field values map returns false for field rules")
+        void emptyFieldValuesMap() {
+            List<QcRule> rules = List.of(new QcRule("FIELD_EQUALS", "O.12", "Q"));
+            assertFalse(QcRuleEvaluator.isQcSample(rules, "SAMPLE", new HashMap<>()));
+        }
+    }
+}

--- a/src/test/java/org/itech/ahb/qc/QcRuleEvaluatorTest.java
+++ b/src/test/java/org/itech/ahb/qc/QcRuleEvaluatorTest.java
@@ -4,7 +4,10 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -207,6 +210,92 @@ class QcRuleEvaluatorTest {
                     new QcRule("SPECIMEN_ID_PREFIX", null, "QC-"));
             Map<String, String> fields = Map.of("O.12", "P");
             assertFalse(QcRuleEvaluator.isQcSample(rules, "SAMPLE-001", fields));
+        }
+    }
+
+    @Nested
+    @DisplayName("Locale independence — regression guard against JVM default locale")
+    class LocaleIndependence {
+        // Turkish is the canonical case-folding outlier in Java:
+        //   "i".toUpperCase(Locale.forLanguageTag("tr")) → "İ" (U+0130), not "I"
+        //   "I".toLowerCase(Locale.forLanguageTag("tr")) → "ı" (U+0131), not "i"
+        // So if FIELD_CONTAINS / SPECIMEN_ID_PREFIX use the default-locale toUpperCase()
+        // and the JVM happens to boot in Turkish locale, any rule involving an
+        // 'i'/'I' character silently misfires. Locking the test locale to tr-TR
+        // around each assertion proves the production code case-folds through
+        // Locale.ROOT (or equivalent), not the ambient JVM locale.
+        //
+        // This is a regression guard, not a "we serve Turkish labs" test. If the
+        // assertion passes in tr-TR, it passes in every other locale too.
+
+        private static final Locale TURKISH = Locale.forLanguageTag("tr-TR");
+        private Locale originalLocale;
+
+        @BeforeEach
+        void forceTurkishLocale() {
+            originalLocale = Locale.getDefault();
+            Locale.setDefault(TURKISH);
+        }
+
+        @AfterEach
+        void restoreLocale() {
+            Locale.setDefault(originalLocale);
+        }
+
+        @Test
+        @DisplayName("FIELD_CONTAINS matches 'Positive'/'POSITIVE' in Turkish locale")
+        void fieldContains_TurkishLocale_stillMatchesOnI() {
+            // 'POSITIVE'.toUpperCase(tr-TR) = 'POSİTİVE' (note the İ); 'Positive'.toUpperCase(tr-TR) = 'POSİTİVE'.
+            // With Locale.ROOT these are both 'POSITIVE'. Either way the operand + value
+            // must fold consistently so contains() returns true.
+            List<QcRule> rules = List.of(new QcRule("FIELD_CONTAINS", "QC_TASK", "Positive"));
+            Map<String, String> fields = Map.of("QC_TASK", "Control POSITIVE sample");
+            assertTrue(QcRuleEvaluator.isQcSample(rules, "SAMPLE001", fields),
+                    "FIELD_CONTAINS must be locale-insensitive; failed under tr-TR default locale");
+        }
+
+        @Test
+        @DisplayName("FIELD_CONTAINS mismatched case across 'i' variants still matches")
+        void fieldContains_TurkishLocale_mixedCaseI() {
+            // Operand has lowercase 'i', value has uppercase 'I'. Under tr-TR default
+            // folding they'd diverge (İ vs I). Under Locale.ROOT they both normalize.
+            List<QcRule> rules = List.of(new QcRule("FIELD_CONTAINS", "QC_TASK", "calibration"));
+            Map<String, String> fields = Map.of("QC_TASK", "CALIBRATION run 12");
+            assertTrue(QcRuleEvaluator.isQcSample(rules, "SAMPLE001", fields),
+                    "FIELD_CONTAINS with i↔I case mismatch must still match in Turkish locale");
+        }
+
+        @Test
+        @DisplayName("SPECIMEN_ID_PREFIX matches 'QI-'/'qi-' in Turkish locale")
+        void specimenIdPrefix_TurkishLocale_matchesOnI() {
+            // Prefix contains 'i'; specimen contains 'I'. Default-locale folding in
+            // tr-TR would break this; Locale.ROOT does not.
+            List<QcRule> rules = List.of(new QcRule("SPECIMEN_ID_PREFIX", null, "qi-"));
+            assertTrue(QcRuleEvaluator.isQcSample(rules, "QI-2026-001", Map.of()),
+                    "SPECIMEN_ID_PREFIX must be locale-insensitive; failed under tr-TR default locale");
+        }
+
+        @Test
+        @DisplayName("SPECIMEN_ID_PREFIX does NOT match non-prefix even in Turkish locale")
+        void specimenIdPrefix_TurkishLocale_negativeStillFalse() {
+            // Locale.ROOT fix must not accidentally make everything match. Prove a
+            // genuine non-match still returns false under tr-TR.
+            List<QcRule> rules = List.of(new QcRule("SPECIMEN_ID_PREFIX", null, "QI-"));
+            assertFalse(QcRuleEvaluator.isQcSample(rules, "SAMPLE-001", Map.of()),
+                    "SPECIMEN_ID_PREFIX must still be a true prefix check under tr-TR");
+        }
+
+        @Test
+        @DisplayName("FIELD_EQUALS unchanged — equalsIgnoreCase is already locale-safe by Java spec")
+        void fieldEquals_TurkishLocale_stillMatches() {
+            // String.equalsIgnoreCase is defined by Java spec to be locale-insensitive
+            // (it uses per-char comparison, not full-string case-folding). This test
+            // documents that guarantee and catches a future refactor that might
+            // replace it with .equals(.toUpperCase()) style code.
+            List<QcRule> rules = List.of(new QcRule("FIELD_EQUALS", "O.12", "INIT"));
+            Map<String, String> fields = Map.of("O.12", "init");
+            assertTrue(QcRuleEvaluator.isQcSample(rules, "SAMPLE001", fields),
+                    "FIELD_EQUALS via equalsIgnoreCase must be locale-insensitive by Java spec");
         }
     }
 

--- a/src/test/java/org/itech/ahb/routing/HttpForwardingRouterTest.java
+++ b/src/test/java/org/itech/ahb/routing/HttpForwardingRouterTest.java
@@ -65,7 +65,7 @@ class HttpForwardingRouterTest {
     @Test
     void fourHundredOne_persistsRejectedBundleWithHttpStatusAndPayload() {
         HTTPForwardServerConfigurationProperties httpConfig = minimalConfig();
-        HttpForwardingRouter router = new HttpForwardingRouter(httpConfig, null, stateStore);
+        HttpForwardingRouter router = new HttpForwardingRouter(httpConfig, null, stateStore, null);
 
         statusCodeToReturn.set(401);
         MessageEnvelope env = envelope("100.127.144.150", "H|... raw astm payload ...");
@@ -89,7 +89,7 @@ class HttpForwardingRouterTest {
     @Test
     void fiveHundred_exhaustedRetries_persistsWithStatusZero() {
         HTTPForwardServerConfigurationProperties httpConfig = minimalConfig();
-        HttpForwardingRouter router = new HttpForwardingRouter(httpConfig, null, stateStore);
+        HttpForwardingRouter router = new HttpForwardingRouter(httpConfig, null, stateStore, null);
 
         statusCodeToReturn.set(500);
         boolean result = router.route(envelope("10.0.0.5", "raw body"));
@@ -106,7 +106,7 @@ class HttpForwardingRouterTest {
     @Test
     void twoHundred_doesNotPersistAnything() {
         HTTPForwardServerConfigurationProperties httpConfig = minimalConfig();
-        HttpForwardingRouter router = new HttpForwardingRouter(httpConfig, null, stateStore);
+        HttpForwardingRouter router = new HttpForwardingRouter(httpConfig, null, stateStore, null);
 
         statusCodeToReturn.set(200);
         boolean result = router.route(envelope("10.0.0.6", "body"));
@@ -119,7 +119,7 @@ class HttpForwardingRouterTest {
     @Test
     void nullStateStore_rejectsPayloadLogsOnly_noThrow() {
         HTTPForwardServerConfigurationProperties httpConfig = minimalConfig();
-        HttpForwardingRouter router = new HttpForwardingRouter(httpConfig, null, null);
+        HttpForwardingRouter router = new HttpForwardingRouter(httpConfig, null, null, null);
 
         statusCodeToReturn.set(401);
         // Must not throw; router must still return false; the log line is the

--- a/src/test/java/org/itech/ahb/serial/SerialIntegrationTest.java
+++ b/src/test/java/org/itech/ahb/serial/SerialIntegrationTest.java
@@ -164,7 +164,7 @@ class SerialIntegrationTest {
             HTTPForwardServerConfigurationProperties httpConfig = new HTTPForwardServerConfigurationProperties();
             httpConfig.setUri(java.net.URI.create("http://localhost:" + serverPort + "/api/OpenELIS-Global/analyzer"));
 
-            HttpForwardingRouter forwardingRouter = new HttpForwardingRouter(httpConfig, null, null);
+            HttpForwardingRouter forwardingRouter = new HttpForwardingRouter(httpConfig, null, null, null);
             AnalyzerIdentifier identifier = new AnalyzerIdentifier(null);
             MessageNormalizer normalizer = new MessageNormalizer(forwardingRouter, identifier, null);
             SerialMessageHandler handler = new SerialMessageHandler(normalizer);
@@ -211,7 +211,7 @@ class SerialIntegrationTest {
             HTTPForwardServerConfigurationProperties httpConfig = new HTTPForwardServerConfigurationProperties();
             httpConfig.setUri(java.net.URI.create("http://localhost:" + serverPort + "/api/OpenELIS-Global/analyzer"));
 
-            HttpForwardingRouter forwardingRouter = new HttpForwardingRouter(httpConfig, null, null);
+            HttpForwardingRouter forwardingRouter = new HttpForwardingRouter(httpConfig, null, null, null);
             AnalyzerIdentifier identifier = new AnalyzerIdentifier(null);
             MessageNormalizer normalizer = new MessageNormalizer(forwardingRouter, identifier, null);
             SerialMessageHandler handler = new SerialMessageHandler(normalizer);
@@ -252,7 +252,7 @@ class SerialIntegrationTest {
             HTTPForwardServerConfigurationProperties httpConfig = new HTTPForwardServerConfigurationProperties();
             httpConfig.setUri(java.net.URI.create("http://localhost:" + serverPort + "/api/OpenELIS-Global/analyzer"));
 
-            HttpForwardingRouter forwardingRouter = new HttpForwardingRouter(httpConfig, null, null);
+            HttpForwardingRouter forwardingRouter = new HttpForwardingRouter(httpConfig, null, null, null);
             AnalyzerIdentifier identifier = new AnalyzerIdentifier(null);
             MessageNormalizer normalizer = new MessageNormalizer(forwardingRouter, identifier, null);
             SerialMessageHandler handler = new SerialMessageHandler(normalizer);
@@ -387,7 +387,7 @@ class SerialIntegrationTest {
             HTTPForwardServerConfigurationProperties httpConfig = new HTTPForwardServerConfigurationProperties();
             httpConfig.setUri(java.net.URI.create("http://localhost:" + serverPort + "/api/OpenELIS-Global/analyzer"));
 
-            HttpForwardingRouter forwardingRouter = new HttpForwardingRouter(httpConfig, null, null);
+            HttpForwardingRouter forwardingRouter = new HttpForwardingRouter(httpConfig, null, null, null);
             AnalyzerIdentifier identifier = new AnalyzerIdentifier(null);
             MessageNormalizer normalizer = new MessageNormalizer(forwardingRouter, identifier, null);
             SerialMessageHandler handler = new SerialMessageHandler(normalizer);
@@ -414,7 +414,7 @@ class SerialIntegrationTest {
             HTTPForwardServerConfigurationProperties httpConfig = new HTTPForwardServerConfigurationProperties();
             httpConfig.setUri(java.net.URI.create("http://localhost:" + serverPort + "/api/OpenELIS-Global/analyzer"));
 
-            HttpForwardingRouter forwardingRouter = new HttpForwardingRouter(httpConfig, null, null);
+            HttpForwardingRouter forwardingRouter = new HttpForwardingRouter(httpConfig, null, null, null);
             AnalyzerIdentifier identifier = new AnalyzerIdentifier(null);
             MessageNormalizer normalizer = new MessageNormalizer(forwardingRouter, identifier, null);
             SerialMessageHandler handler = new SerialMessageHandler(normalizer);


### PR DESCRIPTION
Replace hardcoded QC detection (O.12=="Q", control prefixes) with a rule engine that evaluates QC rules pulled from OpenELIS at bootstrap. Four rule types: `FIELD_EQUALS`, `FIELD_CONTAINS`, `SPECIMEN_ID_PREFIX`, `SPECIMEN_ID_PATTERN`. 