### PR TITLE
feat(qc): metadata propagation + ASTM O.12 off-by-one fix

### DIFF
--- a/src/main/java/org/itech/ahb/controller/AnalyzerRegistrationController.java
+++ b/src/main/java/org/itech/ahb/controller/AnalyzerRegistrationController.java
@@ -5,11 +5,14 @@ import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.itech.ahb.config.AnalyzerRegistryConfig;
 import org.itech.ahb.config.AnalyzerRegistryConfig.AnalyzerEntry;
 import org.itech.ahb.file.FileConfig;
 import org.itech.ahb.file.FileWatcher;
+import org.itech.ahb.qc.QcRule;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -63,6 +66,12 @@ public class AnalyzerRegistrationController {
         if (request.testMappings != null && !request.testMappings.isEmpty()) {
             entry.setMappedTestCodes(new java.util.LinkedHashSet<>(request.testMappings));
         }
+        // QC identification rules from the OE-side analyzer profile
+        // (`configDefaults.qcRules`). Without these, FileResultParser falls
+        // back to a hardcoded CONTROL_PREFIXES list (CNEG/CPOS/NTC/PTC/...)
+        // and any sample-name-prefix convention beyond that — e.g. clinical
+        // LPC/HPC for HIV viral load — silently misclassifies QC as patient.
+        entry.setQcRules(parseQcRules(request.qcRules));
 
         registry.register(request.sourceId, entry);
 
@@ -144,9 +153,14 @@ public class AnalyzerRegistrationController {
             entry.setName(req.name);
             entry.setExpectedProtocol(req.protocol);
             entry.setFilePattern(req.filePattern);
+            entry.setColumnMappings(req.columnMappings);
+            entry.setFileFormat(req.fileFormat);
+            entry.setDelimiter(req.delimiter != null ? req.delimiter : ",");
+            entry.setSkipRows(req.skipRows != null ? req.skipRows : 0);
             if (req.testMappings != null && !req.testMappings.isEmpty()) {
                 entry.setMappedTestCodes(new java.util.LinkedHashSet<>(req.testMappings));
             }
+            entry.setQcRules(parseQcRules(req.qcRules));
             newRegistry.put(req.sourceId, entry);
             newAnalyzerIds.add(req.oeAnalyzerId);
 
@@ -206,5 +220,33 @@ public class AnalyzerRegistrationController {
         public String delimiter;
         public Integer skipRows;
         public java.util.List<String> testMappings;
+        // QC identification rules pushed from OE per analyzer profile
+        // (`configDefaults.qcRules`). Each map carries
+        // {ruleType, targetField?, operand}. Mirrors the JSON shape that
+        // AnalyzerRegistryBootstrap.parseQcRules consumes at startup.
+        public java.util.List<java.util.Map<String, Object>> qcRules;
+    }
+
+    /**
+     * Parse the raw JSON `qcRules` list (as received from OE's registration
+     * push) into typed {@link QcRule} records. Mirrors the algorithm used
+     * by {@code AnalyzerRegistryBootstrap.parseQcRules} so startup-pulled
+     * and runtime-pushed registrations produce identical entries.
+     */
+    private static List<QcRule> parseQcRules(java.util.List<java.util.Map<String, Object>> raw) {
+        if (raw == null || raw.isEmpty()) {
+            return new ArrayList<>();
+        }
+        List<QcRule> rules = new ArrayList<>(raw.size());
+        for (java.util.Map<String, Object> ruleMap : raw) {
+            if (ruleMap == null) continue;
+            String ruleType = (String) ruleMap.get("ruleType");
+            String targetField = (String) ruleMap.get("targetField");
+            String operand = (String) ruleMap.get("operand");
+            if (ruleType != null && operand != null) {
+                rules.add(new QcRule(ruleType, targetField, operand));
+            }
+        }
+        return rules;
     }
 }

--- a/src/main/java/org/itech/ahb/fhir/ASTMResultParser.java
+++ b/src/main/java/org/itech/ahb/fhir/ASTMResultParser.java
@@ -33,7 +33,12 @@ public class ASTMResultParser {
     private static final int R_VALUE_FIELD = 3;
     private static final int R_UNITS_FIELD = 4;
     private static final int R_TIMESTAMP_FIELD = 9;
-    private static final int O_ACTION_CODE_FIELD = 12;
+    // ASTM LIS2-A2 §5.7: Order Record Action Code is field 12 (1-indexed).
+    // In a 0-indexed split that includes the segment ID ("O") at index 0,
+    // O.12 lands at array index 11. Pinned by the mindray-ba88a-result.txt
+    // fixture (action code "A" at idx 11) and by the analyzer mock's
+    // test_qc_message.py (Q at idx 11).
+    private static final int O_ACTION_CODE_FIELD = 11;
 
     /**
      * Parse ASTM message lines and extract results.

--- a/src/main/java/org/itech/ahb/fhir/ASTMResultParser.java
+++ b/src/main/java/org/itech/ahb/fhir/ASTMResultParser.java
@@ -97,6 +97,30 @@ public class ASTMResultParser {
                         }
                     }
                 }
+                case "Q" -> {
+                    // Q-segment carries QC metadata: field_code^lot_number^level
+                    // (per LIS2-A2 §5.10 + OE GenericASTM convention). Pair
+                    // with the most-recent R-record so OE's
+                    // QCResultProcessingService can resolve to the correct
+                    // control lot without guessing from accession.
+                    if (!results.isEmpty()) {
+                        String[] qFields = line.split(Pattern.quote(FIELD_DELIMITER));
+                        if (qFields.length > 2 && qFields[2] != null && !qFields[2].isBlank()) {
+                            String[] components = qFields[2].split(Pattern.quote(COMPONENT_DELIMITER));
+                            String lotNumber = components.length >= 2 ? components[1].trim() : null;
+                            String controlLevel = components.length >= 3 ? components[2].trim() : null;
+                            int lastIdx = results.size() - 1;
+                            AnalyzerResult last = results.get(lastIdx);
+                            if (lotNumber != null && !lotNumber.isEmpty()) {
+                                last = last.withLotNumber(lotNumber);
+                            }
+                            if (controlLevel != null && !controlLevel.isEmpty()) {
+                                last = last.withControlLevel(controlLevel);
+                            }
+                            results.set(lastIdx, last);
+                        }
+                    }
+                }
             }
         }
 

--- a/src/main/java/org/itech/ahb/fhir/ASTMResultParser.java
+++ b/src/main/java/org/itech/ahb/fhir/ASTMResultParser.java
@@ -74,11 +74,14 @@ public class ASTMResultParser {
                 case "O" -> {
                     accession = extractAccessionNumber(line);
                     if (qcRules != null && !qcRules.isEmpty()) {
-                        // FR-15: rule-based QC detection
+                        // FR-15: rule-based QC detection. Operand naming follows the
+                        // ASTM LIS2-A2 §5.7 1-indexed convention where O.1 is the
+                        // segment ID ("O") and O.12 is the Action Code — same
+                        // convention pinned by O_ACTION_CODE_FIELD (= idx 11).
                         String[] fields = line.split(Pattern.quote(FIELD_DELIMITER));
                         Map<String, String> fieldValues = new HashMap<>();
                         for (int i = 0; i < fields.length; i++) {
-                            fieldValues.put("O." + i, fields[i].trim());
+                            fieldValues.put("O." + (i + 1), fields[i].trim());
                         }
                         isQcSample = QcRuleEvaluator.isQcSample(qcRules, accession, fieldValues);
                     } else {

--- a/src/main/java/org/itech/ahb/fhir/FhirBundleBuilder.java
+++ b/src/main/java/org/itech/ahb/fhir/FhirBundleBuilder.java
@@ -138,6 +138,28 @@ public class FhirBundleBuilder {
             if (result.isControl()) {
                 obs.getMeta().addTag("http://openelis-global.org/fhir/tags", "QC", "Quality Control");
             }
+            // QC metadata for OE QCResultProcessingService.findMatchingControlLot:
+            //   - lot-number lets OE strict-match the qc_control_lot row
+            //     (sourced from ASTM Q-segment field 3 component 2)
+            //   - control-level lets OE level-match (testId, instrumentId, level)
+            //     when there's no canonical lot identifier on the wire
+            //     (sourced from ASTM Q-segment field 3 component 3, OR from
+            //     the matched FILE qcRule's operand for SPECIMEN_ID_PREFIX
+            //     rules like LPC/HPC/CNEG/CPOS)
+            // Both are optional; OE's resolver falls through tiers gracefully
+            // when either is absent.
+            if (result.lotNumber() != null && !result.lotNumber().isEmpty()) {
+                obs.addExtension(
+                        new org.hl7.fhir.r4.model.Extension(
+                                "http://openelis-global.org/fhir/qc/lot-number",
+                                new org.hl7.fhir.r4.model.StringType(result.lotNumber())));
+            }
+            if (result.controlLevel() != null && !result.controlLevel().isEmpty()) {
+                obs.addExtension(
+                        new org.hl7.fhir.r4.model.Extension(
+                                "http://openelis-global.org/fhir/qc/control-level",
+                                new org.hl7.fhir.r4.model.StringType(result.controlLevel())));
+            }
 
             // Analyzer completion timestamp
             if (result.timestamp() != null && !result.timestamp().isBlank()) {
@@ -286,6 +308,16 @@ public class FhirBundleBuilder {
 
     /**
      * A single test result from an analyzer, protocol-agnostic.
+     *
+     * For QC samples, two additional metadata fields propagate end-to-end
+     * to OE so QCResultProcessingService can resolve to the correct lot
+     * without guessing:
+     *   - lotNumber: canonical lot identifier (from ASTM Q-segment field 3
+     *     component 2, or substring-extracted from FILE sample-name when
+     *     the operator embedded it)
+     *   - controlLevel: clinical level identifier (LPC/HPC/CNEG/CPOS/etc.)
+     *     — sourced from ASTM Q-segment field 3 component 3, or from the
+     *     FILE qcRule SPECIMEN_ID_PREFIX operand that matched
      */
     public record AnalyzerResult(
             String testCode,
@@ -294,22 +326,32 @@ public class FhirBundleBuilder {
             String units,
             boolean isNumeric,
             boolean isControl,
-            String timestamp) {
+            String timestamp,
+            String lotNumber,
+            String controlLevel) {
 
         public static AnalyzerResult numeric(String testCode, String testName, String value, String units) {
-            return new AnalyzerResult(testCode, testName, value, units, true, false, null);
+            return new AnalyzerResult(testCode, testName, value, units, true, false, null, null, null);
         }
 
         public static AnalyzerResult text(String testCode, String testName, String value) {
-            return new AnalyzerResult(testCode, testName, value, null, false, false, null);
+            return new AnalyzerResult(testCode, testName, value, null, false, false, null, null, null);
         }
 
         public AnalyzerResult withControl(boolean control) {
-            return new AnalyzerResult(testCode, testName, value, units, isNumeric, control, timestamp);
+            return new AnalyzerResult(testCode, testName, value, units, isNumeric, control, timestamp, lotNumber, controlLevel);
         }
 
         public AnalyzerResult withTimestamp(String ts) {
-            return new AnalyzerResult(testCode, testName, value, units, isNumeric, isControl, ts);
+            return new AnalyzerResult(testCode, testName, value, units, isNumeric, isControl, ts, lotNumber, controlLevel);
+        }
+
+        public AnalyzerResult withLotNumber(String lot) {
+            return new AnalyzerResult(testCode, testName, value, units, isNumeric, isControl, timestamp, lot, controlLevel);
+        }
+
+        public AnalyzerResult withControlLevel(String level) {
+            return new AnalyzerResult(testCode, testName, value, units, isNumeric, isControl, timestamp, lotNumber, level);
         }
     }
 }

--- a/src/main/java/org/itech/ahb/fhir/FileResultParser.java
+++ b/src/main/java/org/itech/ahb/fhir/FileResultParser.java
@@ -170,7 +170,9 @@ public class FileResultParser {
                         ? AnalyzerResult.numeric(testCode, testCode, value, units)
                         : AnalyzerResult.text(testCode, testCode, value);
                 String matchedLevel = matchControlRule(sampleId, qcTask, qcRules);
-                boolean isCtrl = matchedLevel != null || isControlRow(sampleId, qcTask);
+                boolean rulesConfigured = qcRules != null && !qcRules.isEmpty();
+                boolean isCtrl =
+                        rulesConfigured ? matchedLevel != null : isControlRow(sampleId, qcTask);
                 ar = ar.withControl(isCtrl);
                 if (matchedLevel != null) {
                     ar = ar.withControlLevel(matchedLevel);
@@ -731,11 +733,16 @@ public class FileResultParser {
     }
 
     /**
-     * FR-15: rule-based QC detection with fallback to hardcoded logic.
+     * FR-15: rule-based QC detection. Configured rules take precedence;
+     * when present, hardcoded prefix and qcTask fallbacks are bypassed
+     * entirely so analyzer profiles can opt out of legacy detection.
+     * Falls back to hardcoded logic only when rules are null or empty.
      */
     static boolean isControlRow(String sampleId, String qcTask, List<QcRule> qcRules) {
-        return matchControlRule(sampleId, qcTask, qcRules) != null
-                || isControlRow(sampleId, qcTask);
+        if (qcRules != null && !qcRules.isEmpty()) {
+            return matchControlRule(sampleId, qcTask, qcRules) != null;
+        }
+        return isControlRow(sampleId, qcTask);
     }
 
     /**

--- a/src/main/java/org/itech/ahb/fhir/FileResultParser.java
+++ b/src/main/java/org/itech/ahb/fhir/FileResultParser.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.Optional;
 import java.util.List;
 import java.util.Map;
 import java.util.zip.ZipEntry;
@@ -169,11 +170,12 @@ public class FileResultParser {
                 AnalyzerResult ar = isNumeric
                         ? AnalyzerResult.numeric(testCode, testCode, value, units)
                         : AnalyzerResult.text(testCode, testCode, value);
-                String matchedLevel = matchControlRule(sampleId, qcTask, qcRules);
+                Optional<QcRule> matchedRule = findMatchingControlRule(sampleId, qcTask, qcRules);
                 boolean rulesConfigured = qcRules != null && !qcRules.isEmpty();
                 boolean isCtrl =
-                        rulesConfigured ? matchedLevel != null : isControlRow(sampleId, qcTask);
+                        rulesConfigured ? matchedRule.isPresent() : isControlRow(sampleId, qcTask);
                 ar = ar.withControl(isCtrl);
+                String matchedLevel = matchedRule.map(FileResultParser::extractControlLevel).orElse(null);
                 if (matchedLevel != null) {
                     ar = ar.withControlLevel(matchedLevel);
                 }
@@ -572,9 +574,10 @@ public class FileResultParser {
                     AnalyzerResult ar = isNumeric
                             ? AnalyzerResult.numeric(testCode, testCode, value, units)
                             : AnalyzerResult.text(testCode, testCode, value);
-                    String matchedLevel = matchControlRule(sampleId, qcTask, qcRules);
-                    boolean isCtrl = matchedLevel != null || isControlRow(sampleId, qcTask);
+                    Optional<QcRule> matchedRule = findMatchingControlRule(sampleId, qcTask, qcRules);
+                    boolean isCtrl = matchedRule.isPresent() || isControlRow(sampleId, qcTask);
                     ar = ar.withControl(isCtrl);
+                    String matchedLevel = matchedRule.map(FileResultParser::extractControlLevel).orElse(null);
                     if (matchedLevel != null) {
                         ar = ar.withControlLevel(matchedLevel);
                     }
@@ -740,7 +743,10 @@ public class FileResultParser {
      */
     static boolean isControlRow(String sampleId, String qcTask, List<QcRule> qcRules) {
         if (qcRules != null && !qcRules.isEmpty()) {
-            return matchControlRule(sampleId, qcTask, qcRules) != null;
+            // Any matching rule classifies the row as control, regardless of
+            // whether the rule's operand carries a level (only
+            // SPECIMEN_ID_PREFIX does — see extractControlLevel).
+            return findMatchingControlRule(sampleId, qcTask, qcRules).isPresent();
         }
         return isControlRow(sampleId, qcTask);
     }
@@ -752,17 +758,32 @@ public class FileResultParser {
      * OE's QCResultProcessingService. Returns null when no rule matches
      * (caller should fall through to legacy detection).
      */
-    static String matchControlRule(String sampleId, String qcTask, List<QcRule> qcRules) {
+    static Optional<QcRule> findMatchingControlRule(
+            String sampleId, String qcTask, List<QcRule> qcRules) {
         if (qcRules == null || qcRules.isEmpty()) {
-            return null;
+            return Optional.empty();
         }
         Map<String, String> fieldValues = new HashMap<>();
         if (qcTask != null) {
             fieldValues.put("QC_TASK", qcTask);
         }
-        return QcRuleEvaluator.findMatchingRule(qcRules, sampleId, fieldValues)
-                .map(QcRule::operand)
+        return QcRuleEvaluator.findMatchingRule(qcRules, sampleId, fieldValues);
+    }
+
+    static String matchControlRule(String sampleId, String qcTask, List<QcRule> qcRules) {
+        return findMatchingControlRule(sampleId, qcTask, qcRules)
+                .map(FileResultParser::extractControlLevel)
                 .orElse(null);
+    }
+
+    // Only ID-prefix-style rules carry a control level in their operand
+    // (e.g., "LPC", "HPC"). Other rule types — like FIELD_EQUALS
+    // QC_TASK=CONTROL — use the operand as a match predicate, not a level
+    // tag. Returning "CONTROL" as a controlLevel would propagate junk into
+    // OE's tier-2 lot resolver.
+    static String extractControlLevel(QcRule rule) {
+        if (rule == null) return null;
+        return "SPECIMEN_ID_PREFIX".equals(rule.ruleType()) ? rule.operand() : null;
     }
 
     private static boolean isControlRow(String sampleId, String qcTask) {

--- a/src/main/java/org/itech/ahb/fhir/FileResultParser.java
+++ b/src/main/java/org/itech/ahb/fhir/FileResultParser.java
@@ -169,7 +169,12 @@ public class FileResultParser {
                 AnalyzerResult ar = isNumeric
                         ? AnalyzerResult.numeric(testCode, testCode, value, units)
                         : AnalyzerResult.text(testCode, testCode, value);
-                ar = ar.withControl(isControlRow(sampleId, qcTask, qcRules));
+                String matchedLevel = matchControlRule(sampleId, qcTask, qcRules);
+                boolean isCtrl = matchedLevel != null || isControlRow(sampleId, qcTask);
+                ar = ar.withControl(isCtrl);
+                if (matchedLevel != null) {
+                    ar = ar.withControlLevel(matchedLevel);
+                }
                 if (testDate != null && !testDate.isBlank()) {
                     ar = ar.withTimestamp(testDate);
                 }
@@ -476,12 +481,38 @@ public class FileResultParser {
             return null;
         }
 
-        StringBuilder csvContent = new StringBuilder();
-        for (int i = skipRows; i < allLines.length; i++) {
-            csvContent.append(allLines[i]).append("\n");
+        char delimChar = (delimiter != null && !delimiter.isEmpty()) ? delimiter.charAt(0) : ',';
+
+        // QuantStudio Design & Analysis CSV exports carry a `* Key = Value`
+        // metadata preamble + multi-section layout (`[Sample Setup]` then
+        // `[Results]`) before the actual tabular header. Mirrors the Excel
+        // path's findHeaderRow logic so QuantStudio CSV exports parse the
+        // same way the .xlsx exports already do.
+        //
+        // Strategy: start at the configured `skipRows` (preserves existing
+        // behavior for non-QuantStudio CSVs). Scan up to 200 more lines for
+        // a row whose first delimiter-separated field is exactly "Well" —
+        // the QuantStudio header marker. Prefer the LAST such header before
+        // EOF, since the Sample Setup section also starts with "Well" but
+        // the Results section is what we want.
+        int headerLineIndex = -1;
+        int scanEnd = Math.min(allLines.length, skipRows + 200);
+        for (int i = skipRows; i < scanEnd; i++) {
+            String line = allLines[i];
+            if (line == null || line.isBlank()) continue;
+            int firstDelim = line.indexOf(delimChar);
+            String firstField = (firstDelim >= 0) ? line.substring(0, firstDelim) : line;
+            if ("Well".equals(firstField.trim())) {
+                headerLineIndex = i;
+                // Don't break — keep scanning for a later "Well" row.
+            }
         }
 
-        char delimChar = (delimiter != null && !delimiter.isEmpty()) ? delimiter.charAt(0) : ',';
+        StringBuilder csvContent = new StringBuilder();
+        int contentStart = (headerLineIndex >= 0) ? headerLineIndex : skipRows;
+        for (int i = contentStart; i < allLines.length; i++) {
+            csvContent.append(allLines[i]).append("\n");
+        }
 
         try {
             CSVFormat format = CSVFormat.DEFAULT.builder()
@@ -508,6 +539,7 @@ public class FileResultParser {
                         testCode = getFirstPresentValue(record, "TestCode", "Test Code", "Target", "Test Name");
                     }
                     String result = getMappedValue(record, columnMappings, "result");
+                    String ctValue = getMappedValue(record, columnMappings, "ctValue");
                     String units = getMappedValue(record, columnMappings, "units");
                     String interpretation = getMappedValue(record, columnMappings, "interpretation");
                     String qcTask = getMappedValue(record, columnMappings, "qcTask");
@@ -523,14 +555,27 @@ public class FileResultParser {
                         }
                     }
 
-                    String value = (result != null && !result.isBlank()) ? result : interpretation;
+                    // Mirror the Excel parse() fallback chain: result → ctValue
+                    // → interpretation. QuantStudio Arbovirus PCR + QuantStudio
+                    // QC samples leave `Quantity Mean` (mapped to `result`)
+                    // empty since the meaningful number is in `CT` (mapped to
+                    // `ctValue`). Without this fallback, every QuantStudio QC
+                    // row gets dropped at the value check.
+                    String value = (result != null && !result.isBlank()) ? result
+                            : (ctValue != null && !ctValue.isBlank()) ? ctValue
+                            : interpretation;
                     if (value == null || value.isBlank()) continue;
 
                     boolean isNumeric = isNumericValue(value);
                     AnalyzerResult ar = isNumeric
                             ? AnalyzerResult.numeric(testCode, testCode, value, units)
                             : AnalyzerResult.text(testCode, testCode, value);
-                    ar = ar.withControl(isControlRow(sampleId, qcTask, qcRules));
+                    String matchedLevel = matchControlRule(sampleId, qcTask, qcRules);
+                    boolean isCtrl = matchedLevel != null || isControlRow(sampleId, qcTask);
+                    ar = ar.withControl(isCtrl);
+                    if (matchedLevel != null) {
+                        ar = ar.withControlLevel(matchedLevel);
+                    }
 
                     // Use testDate or dateTime — fall back to dateTime if testDate is null or blank
                     String ts = (testDate != null && !testDate.isBlank()) ? testDate : dateTime;
@@ -689,14 +734,28 @@ public class FileResultParser {
      * FR-15: rule-based QC detection with fallback to hardcoded logic.
      */
     static boolean isControlRow(String sampleId, String qcTask, List<QcRule> qcRules) {
-        if (qcRules != null && !qcRules.isEmpty()) {
-            Map<String, String> fieldValues = new HashMap<>();
-            if (qcTask != null) {
-                fieldValues.put("QC_TASK", qcTask);
-            }
-            return QcRuleEvaluator.isQcSample(qcRules, sampleId, fieldValues);
+        return matchControlRule(sampleId, qcTask, qcRules) != null
+                || isControlRow(sampleId, qcTask);
+    }
+
+    /**
+     * Find the QC rule that classifies the sample as control, returning
+     * its operand (the level identifier — "LPC", "CNEG", "STANDARD",
+     * etc.) so the FHIR Observation can carry controlLevel metadata for
+     * OE's QCResultProcessingService. Returns null when no rule matches
+     * (caller should fall through to legacy detection).
+     */
+    static String matchControlRule(String sampleId, String qcTask, List<QcRule> qcRules) {
+        if (qcRules == null || qcRules.isEmpty()) {
+            return null;
         }
-        return isControlRow(sampleId, qcTask);
+        Map<String, String> fieldValues = new HashMap<>();
+        if (qcTask != null) {
+            fieldValues.put("QC_TASK", qcTask);
+        }
+        return QcRuleEvaluator.findMatchingRule(qcRules, sampleId, fieldValues)
+                .map(QcRule::operand)
+                .orElse(null);
     }
 
     private static boolean isControlRow(String sampleId, String qcTask) {

--- a/src/main/java/org/itech/ahb/file/FileMessageHandler.java
+++ b/src/main/java/org/itech/ahb/file/FileMessageHandler.java
@@ -165,6 +165,16 @@ public class FileMessageHandler {
                     "No column mappings registered for analyzer " + analyzerId + " — refusing FILE fallback");
         }
 
+        // QC identification rules from the analyzer registration (FR-15).
+        // Empty list = legacy hardcoded prefix detection in isControlRow.
+        // Wiring this through ensures profile-defined SPECIMEN_ID_PREFIX
+        // rules (e.g. LPC/HPC for QuantStudio HIV-1 controls) actually
+        // classify rows as QC at parse time so the FHIR meta.tag flows
+        // through to OE.
+        java.util.List<org.itech.ahb.qc.QcRule> qcRules = analyzerEntry.getQcRules() != null
+                ? analyzerEntry.getQcRules()
+                : java.util.Collections.emptyList();
+
         // Dispatch by file extension: CSV/TSV/TXT → CSV parser, XLS/XLSX → Excel parser
         String ext = getFileExtension(filePath);
         List<HL7ResultParser.ParsedResults> allResults;
@@ -172,18 +182,18 @@ public class FileMessageHandler {
         if (".csv".equals(ext) || ".tsv".equals(ext) || ".txt".equals(ext)) {
             String delimiter = analyzerEntry.getDelimiter();
             int skipRows = analyzerEntry.getSkipRows();
-            log.info("Parsing CSV file {} (delimiter='{}', skipRows={}, perFileTestCode={}) for analyzer {}",
-                    filePath.getFileName(), delimiter, skipRows, perFileTestCode, analyzerId);
-            allResults = FileResultParser.parseCsv(content, columnMappings, delimiter, skipRows, perFileTestCode);
+            log.info("Parsing CSV file {} (delimiter='{}', skipRows={}, perFileTestCode={}, qcRules={}) for analyzer {}",
+                    filePath.getFileName(), delimiter, skipRows, perFileTestCode, qcRules.size(), analyzerId);
+            allResults = FileResultParser.parseCsv(content, columnMappings, delimiter, skipRows, perFileTestCode, qcRules);
         } else if (".xls".equals(ext) || ".xlsx".equals(ext)) {
-            log.info("Parsing Excel file {} (perFileTestCode={}) for analyzer {}",
-                    filePath.getFileName(), perFileTestCode, analyzerId);
+            log.info("Parsing Excel file {} (perFileTestCode={}, qcRules={}) for analyzer {}",
+                    filePath.getFileName(), perFileTestCode, qcRules.size(), analyzerId);
             try (java.io.ByteArrayInputStream bis = new java.io.ByteArrayInputStream(content)) {
-                allResults = FileResultParser.parse(bis, columnMappings, perFileTestCode);
+                allResults = FileResultParser.parse(bis, columnMappings, perFileTestCode, qcRules);
             }
         } else if (".ods".equals(ext)) {
-            log.info("Parsing ODS file {} (perFileTestCode={}) for analyzer {}",
-                    filePath.getFileName(), perFileTestCode, analyzerId);
+            log.info("Parsing ODS file {} (perFileTestCode={}, qcRules={}) for analyzer {}",
+                    filePath.getFileName(), perFileTestCode, qcRules.size(), analyzerId);
             try (java.io.ByteArrayInputStream bis = new java.io.ByteArrayInputStream(content)) {
                 allResults = FileResultParser.parseOds(bis, columnMappings, perFileTestCode);
             }

--- a/src/main/java/org/itech/ahb/file/FileMessageHandler.java
+++ b/src/main/java/org/itech/ahb/file/FileMessageHandler.java
@@ -192,8 +192,11 @@ public class FileMessageHandler {
                 allResults = FileResultParser.parse(bis, columnMappings, perFileTestCode, qcRules);
             }
         } else if (".ods".equals(ext)) {
-            log.info("Parsing ODS file {} (perFileTestCode={}, qcRules={}) for analyzer {}",
-                    filePath.getFileName(), perFileTestCode, qcRules.size(), analyzerId);
+            // parseOds does not yet accept qcRules — ODS QC detection still
+            // falls back to the legacy task-based heuristic. Don't log
+            // qcRules here so the message doesn't mislead.
+            log.info("Parsing ODS file {} (perFileTestCode={}) for analyzer {}",
+                    filePath.getFileName(), perFileTestCode, analyzerId);
             try (java.io.ByteArrayInputStream bis = new java.io.ByteArrayInputStream(content)) {
                 allResults = FileResultParser.parseOds(bis, columnMappings, perFileTestCode);
             }

--- a/src/main/java/org/itech/ahb/qc/QcRuleEvaluator.java
+++ b/src/main/java/org/itech/ahb/qc/QcRuleEvaluator.java
@@ -3,6 +3,7 @@ package org.itech.ahb.qc;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -32,18 +33,28 @@ public final class QcRuleEvaluator {
      */
     public static boolean isQcSample(List<QcRule> rules, String specimenId,
             Map<String, String> fieldValues) {
-        if (rules == null || rules.isEmpty()) {
-            return false;
-        }
+        return findMatchingRule(rules, specimenId, fieldValues).isPresent();
+    }
 
+    /**
+     * Like {@link #isQcSample} but returns the matched rule itself, so
+     * callers can extract its operand (e.g., the level prefix "LPC", the
+     * QC_TASK value "STANDARD"). Used by FILE/HL7 parsers that propagate
+     * controlLevel metadata into the FHIR Observation.
+     */
+    public static Optional<QcRule> findMatchingRule(List<QcRule> rules, String specimenId,
+            Map<String, String> fieldValues) {
+        if (rules == null || rules.isEmpty()) {
+            return Optional.empty();
+        }
         for (QcRule rule : rules) {
             if (evaluateRule(rule, specimenId, fieldValues)) {
                 log.debug("QC rule matched: type={}, field={}, operand={}",
                         rule.ruleType(), rule.targetField(), rule.operand());
-                return true;
+                return Optional.of(rule);
             }
         }
-        return false;
+        return Optional.empty();
     }
 
     private static boolean evaluateRule(QcRule rule, String specimenId,

--- a/src/test/java/org/itech/ahb/fhir/ASTMResultParserQcRulesTest.java
+++ b/src/test/java/org/itech/ahb/fhir/ASTMResultParserQcRulesTest.java
@@ -12,31 +12,34 @@ import org.junit.jupiter.api.Test;
 @DisplayName("ASTMResultParser — QC rules (FR-15)")
 class ASTMResultParserQcRulesTest {
 
+    // O-record fixtures use 11 fields (10 separators) with Action Code at idx 11,
+    // matching ASTM LIS2-A2 §5.7 (1-indexed O.12 → 0-indexed array idx 11) and
+    // O_ACTION_CODE_FIELD in ASTMResultParser.
     private static final String ASTM_QC_O12_Q =
             "H|\\^&|||Analyzer\r"
             + "P|1\r"
-            + "O|1|QC_SAMPLE001||||||||||Q\r"
+            + "O|1|QC_SAMPLE001|||||||||Q\r"
             + "R|1|^^^WBC|7.5|10*3/uL\r"
             + "L|1\r";
 
     private static final String ASTM_PATIENT_O12_P =
             "H|\\^&|||Analyzer\r"
             + "P|1\r"
-            + "O|1|SAMPLE001||||||||||P\r"
+            + "O|1|SAMPLE001|||||||||P\r"
             + "R|1|^^^WBC|7.5|10*3/uL\r"
             + "L|1\r";
 
     private static final String ASTM_QC_PREFIX =
             "H|\\^&|||Analyzer\r"
             + "P|1\r"
-            + "O|1|QC-LOT-001||||||||||P\r"
+            + "O|1|QC-LOT-001|||||||||P\r"
             + "R|1|^^^WBC|7.5|10*3/uL\r"
             + "L|1\r";
 
     private static final String ASTM_TWO_RESULTS =
             "H|\\^&|||Analyzer\r"
             + "P|1\r"
-            + "O|1|SAMPLE001||||||||||Q\r"
+            + "O|1|SAMPLE001|||||||||Q\r"
             + "R|1|^^^WBC|7.5|10*3/uL\r"
             + "R|2|^^^RBC|4.82|10*6/uL\r"
             + "L|1\r";

--- a/src/test/java/org/itech/ahb/fhir/ASTMResultParserTest.java
+++ b/src/test/java/org/itech/ahb/fhir/ASTMResultParserTest.java
@@ -21,12 +21,13 @@ import org.junit.jupiter.api.Test;
 class ASTMResultParserTest {
 
     // Realistic ASTM from a GeneXpert analyzer.
-    // Field indices: O|1[0]|specimen[2]|...[3-11]|actionCode[12]
-    //                R|1[0]|seq[1]|testId[2]|value[3]|units[4]|ref[5]|flag[6]|op[7]|status[8]|timestamp[9]
+    // Field indices (0-indexed split, segment ID at idx 0):
+    //   O[0] | seq[1] | specimen[2] | ... | actionCode[11] (ASTM O.12)
+    //   R[0] | seq[1] | testId[2] | value[3] | units[4] | ref[5] | flag[6] | op[7] | status[8] | timestamp[9]
     private static final String VALID_ASTM_MESSAGE =
             "H|\\^&|||GeneXpert^1.0|||||||LIS2-A2\r"
             + "P|1\r"
-            + "O|1|SAMPLE001||||||||||P\r"
+            + "O|1|SAMPLE001|||||||||P\r"
             + "R|1|^^^HIV-VL|1520.5|copies/mL|||||20260326120000\r"
             + "R|2|^^^CT|28.5|cycles|||||20260326120000\r"
             + "L|1\r";
@@ -223,11 +224,11 @@ class ASTMResultParserTest {
         @Test
         @DisplayName("O.12 = 'Q' -> result.isControl() = true")
         void qcSampleDetected() {
-            // O-record: O[0]|seq[1]|specimen[2]|...[3-11]|actionCode[12]
-            // Need 13 pipe-separated fields so index 12 = "Q"
+            // O-record: O[0]|seq[1]|specimen[2]|...[3-10]|actionCode[11]
+            // ASTM LIS2-A2 §5.7: action code is field 12 (1-indexed) = idx 11.
             String msg = "H|\\^&|||Analyzer\r"
                     + "P|1\r"
-                    + "O|1|QC_SAMPLE001||||||||||Q\r"
+                    + "O|1|QC_SAMPLE001|||||||||Q\r"
                     + "R|1|^^^TEST|5.0|units\r"
                     + "L|1\r";
 
@@ -261,6 +262,60 @@ class ASTMResultParserTest {
 
             assertNotNull(parsed);
             assertFalse(parsed.results().get(0).isControl());
+        }
+
+        // Standards-conformant test fixtures — drive the bridge with messages
+        // shaped like REAL analyzer output, not hand-crafted with off-by-one
+        // padding. Per LIS2-A2 §5.7 (Order Record), Action Code is O.12 in
+        // 1-indexed ASTM field numbering, which is idx 11 when the segment ID
+        // ("O") is included as field 0 in the 0-indexed split (the convention
+        // OE uses, see src/test/resources/testdata/astm/mindray-ba88a-result.txt:26
+        // where action code "A" sits at idx 11). The earlier bridge tests
+        // padded by one extra pipe and so masked an off-by-one in
+        // O_ACTION_CODE_FIELD; these tests assert the correct shape.
+
+        @Test
+        @DisplayName("REAL wire format: O.12='Q' at idx 11 (per ASTM LIS2-A2) -> isControl=true")
+        void wireFormatQcMessageDetectedAsControl() {
+            // This is the EXACT message shape the analyzer mock generates
+            // via `--qc --template genexpert_astm`. Verified by Test A in
+            // tools/analyzer-mock-server/test_qc_message.py.
+            String wireFormat =
+                    "H|\\^&|||GENEXPERT^GeneXpert^4.6.0|||||||LIS2-A2|20260429181325\r"
+                    + "P|1||QCCTRL001|QC^Control||U|19000101\r"
+                    + "O|1|DEV01269800000000001|||||||||Q|||||||||||||\r"
+                    + "R|1|^^^HIV-VL|1687.5|copies/mL|20-10000000|N||F|20260429181325\r"
+                    + "Q|1|HIV-VL^LOT-HIVVL-N^N|1687.5|copies/mL|20260429181325\r"
+                    + "L|1|N\r";
+
+            ParsedResults parsed = ASTMResultParser.parseRaw(wireFormat);
+
+            assertNotNull(parsed, "parseRaw should produce results from wire-format QC message");
+            assertEquals(1, parsed.results().size(), "Expected one R-record parsed");
+            assertTrue(parsed.results().get(0).isControl(),
+                    "Mock-generated QC message must be detected as control. "
+                    + "If this fails, O_ACTION_CODE_FIELD has an off-by-one — "
+                    + "ASTM O.12 lands at idx 11 in 0-indexed split.");
+        }
+
+        @Test
+        @DisplayName("OE-fixture wire format (mindray-ba88a) Action Code at idx 11")
+        void oeMindrayFixtureActionCodeAtCorrectIndex() {
+            // Verbatim from src/test/resources/testdata/astm/mindray-ba88a-result.txt
+            // Action code "A" (Add) at idx 11 — patient sample, not QC.
+            String fixture =
+                    "H|\\^&|||Mindray^BA-88A^V1.0|||||||LIS2-A2|20260202115500\r"
+                    + "P|1||PATIENT001||Doe^John||19800115|M|||||||||||||||||||\r"
+                    + "O|1|ACC-2026-001^LAB||^^^CHEM||||20260202115500|||A||||||||||||||Q\r"
+                    + "R|1|^^^ALT|35.2|U/L|10-40|N||F||20260202115530||\r"
+                    + "L|1\r";
+
+            ParsedResults parsed = ASTMResultParser.parseRaw(fixture);
+
+            assertNotNull(parsed);
+            assertFalse(parsed.results().get(0).isControl(),
+                    "Action code 'A' (Add, idx 11) is patient sample, NOT control. "
+                    + "If this returns true, parser is reading the wrong index.");
         }
     }
 

--- a/src/test/java/org/itech/ahb/fhir/ASTMResultParserTest.java
+++ b/src/test/java/org/itech/ahb/fhir/ASTMResultParserTest.java
@@ -268,18 +268,16 @@ class ASTMResultParserTest {
         // shaped like REAL analyzer output, not hand-crafted with off-by-one
         // padding. Per LIS2-A2 §5.7 (Order Record), Action Code is O.12 in
         // 1-indexed ASTM field numbering, which is idx 11 when the segment ID
-        // ("O") is included as field 0 in the 0-indexed split (the convention
-        // OE uses, see src/test/resources/testdata/astm/mindray-ba88a-result.txt:26
-        // where action code "A" sits at idx 11). The earlier bridge tests
-        // padded by one extra pipe and so masked an off-by-one in
-        // O_ACTION_CODE_FIELD; these tests assert the correct shape.
+        // ("O") is included as field 0 in the 0-indexed split — same
+        // convention pinned by the O_ACTION_CODE_FIELD = 11 constant in
+        // ASTMResultParser. Earlier bridge tests padded by one extra pipe
+        // and so masked an off-by-one; these tests assert the correct shape.
 
         @Test
         @DisplayName("REAL wire format: O.12='Q' at idx 11 (per ASTM LIS2-A2) -> isControl=true")
         void wireFormatQcMessageDetectedAsControl() {
-            // This is the EXACT message shape the analyzer mock generates
-            // via `--qc --template genexpert_astm`. Verified by Test A in
-            // tools/analyzer-mock-server/test_qc_message.py.
+            // Wire shape matches what the bridge accepts on the production
+            // ASTM listener: O-record with Action Code "Q" at field 12.
             String wireFormat =
                     "H|\\^&|||GENEXPERT^GeneXpert^4.6.0|||||||LIS2-A2|20260429181325\r"
                     + "P|1||QCCTRL001|QC^Control||U|19000101\r"

--- a/src/test/java/org/itech/ahb/fhir/FhirBundleBuilderTest.java
+++ b/src/test/java/org/itech/ahb/fhir/FhirBundleBuilderTest.java
@@ -247,6 +247,50 @@ class FhirBundleBuilderTest {
             assertTrue(obs.getMeta().getTag().isEmpty(),
                     "Non-QC observation should have no meta tags");
         }
+
+        @Test
+        @DisplayName("QC with lotNumber + controlLevel -> emits qc/lot-number + qc/control-level extensions")
+        void qcExtensionsEmittedForLotAndLevel() {
+            AnalyzerResult qcResult = AnalyzerResult.numeric("HIV-VL", "HIV-VL", "1687.5", "copies/mL")
+                    .withControl(true)
+                    .withLotNumber("LOT-HIVVL-N")
+                    .withControlLevel("LPC");
+
+            Bundle bundle = parseBundle(
+                    FhirBundleBuilder.buildBundle(ACCESSION, ANALYZER_ID, List.of(qcResult)));
+
+            Observation obs = bundle.getEntry().stream()
+                    .filter(e -> e.getResource() instanceof Observation)
+                    .map(e -> (Observation) e.getResource())
+                    .findFirst().orElseThrow();
+
+            var lot = obs.getExtensionByUrl("http://openelis-global.org/fhir/qc/lot-number");
+            var level = obs.getExtensionByUrl("http://openelis-global.org/fhir/qc/control-level");
+            assertNotNull(lot, "qc/lot-number extension must be present");
+            assertNotNull(level, "qc/control-level extension must be present");
+            assertEquals("LOT-HIVVL-N",
+                    ((org.hl7.fhir.r4.model.StringType) lot.getValue()).getValue());
+            assertEquals("LPC",
+                    ((org.hl7.fhir.r4.model.StringType) level.getValue()).getValue());
+        }
+
+        @Test
+        @DisplayName("QC without lot/level -> qc extensions absent")
+        void qcExtensionsAbsentWhenLotAndLevelNull() {
+            AnalyzerResult qcResult = AnalyzerResult.numeric("WBC", "WBC", "7.5", "10*3/uL")
+                    .withControl(true);
+
+            Bundle bundle = parseBundle(
+                    FhirBundleBuilder.buildBundle(ACCESSION, ANALYZER_ID, List.of(qcResult)));
+
+            Observation obs = bundle.getEntry().stream()
+                    .filter(e -> e.getResource() instanceof Observation)
+                    .map(e -> (Observation) e.getResource())
+                    .findFirst().orElseThrow();
+
+            assertNull(obs.getExtensionByUrl("http://openelis-global.org/fhir/qc/lot-number"));
+            assertNull(obs.getExtensionByUrl("http://openelis-global.org/fhir/qc/control-level"));
+        }
     }
 
     @Nested

--- a/src/test/java/org/itech/ahb/fhir/FileResultParserTest.java
+++ b/src/test/java/org/itech/ahb/fhir/FileResultParserTest.java
@@ -411,6 +411,63 @@ class FileResultParserTest {
             assertFalse(results.get(0).results().get(0).isControl(),
                     "Patient accession should not be flagged as QC");
         }
+
+        @Test
+        @DisplayName("SPECIMEN_ID_PREFIX rule -> isControl=true AND controlLevel=operand")
+        void specimenIdPrefixRuleSetsControlLevel() {
+            InputStream xlsx = buildXlsx("Results",
+                    new String[]{"Well", "Sample Name", "Target Name", "Quantity Mean"},
+                    new Object[][]{
+                            {"A1", "LPC-2026-Q2", "VIH-1", "32.5"},
+                    });
+
+            Map<String, String> mappings = Map.of(
+                    "Sample Name", "sampleId",
+                    "Target Name", "testCode",
+                    "Quantity Mean", "result");
+
+            List<org.itech.ahb.qc.QcRule> rules = List.of(
+                    new org.itech.ahb.qc.QcRule(
+                            "SPECIMEN_ID_PREFIX", null, "LPC"));
+
+            List<ParsedResults> results = FileResultParser.parse(xlsx, mappings, null, rules);
+
+            assertNotNull(results);
+            var ar = results.get(0).results().get(0);
+            assertTrue(ar.isControl(), "Row should be flagged as control");
+            assertEquals("LPC", ar.controlLevel(),
+                    "Operand of SPECIMEN_ID_PREFIX rule should propagate as controlLevel");
+        }
+
+        @Test
+        @DisplayName("FIELD_EQUALS rule -> isControl=true but controlLevel stays null (operand is a predicate, not a level)")
+        void fieldEqualsRuleDoesNotPopulateControlLevel() {
+            InputStream xlsx = buildXlsx("Results",
+                    new String[]{"Well", "Sample Name", "Target Name", "Quantity Mean", "Task"},
+                    new Object[][]{
+                            {"A1", "RANDOM-001", "VIH-1", "32.5", "STANDARD"},
+                    });
+
+            Map<String, String> mappings = Map.of(
+                    "Sample Name", "sampleId",
+                    "Target Name", "testCode",
+                    "Quantity Mean", "result",
+                    "Task", "qcTask");
+
+            List<org.itech.ahb.qc.QcRule> rules = List.of(
+                    new org.itech.ahb.qc.QcRule(
+                            "FIELD_EQUALS", "QC_TASK", "STANDARD"));
+
+            List<ParsedResults> results = FileResultParser.parse(xlsx, mappings, null, rules);
+
+            assertNotNull(results);
+            var ar = results.get(0).results().get(0);
+            assertTrue(ar.isControl(),
+                    "FIELD_EQUALS QC_TASK=STANDARD match should still mark row as control");
+            assertNull(ar.controlLevel(),
+                    "FIELD_EQUALS operand is a predicate value (e.g. 'STANDARD'), "
+                    + "not a control level — must not propagate as controlLevel");
+        }
     }
 
     // ── CSV Parsing Tests ───────────────────────────────────────────
@@ -507,6 +564,61 @@ class FileResultParserTest {
         @DisplayName("Empty content → returns null")
         void emptyContentReturnsNull() {
             assertNull(FileResultParser.parseCsv(new byte[0], CSV_MAPPINGS, ",", 0));
+        }
+
+        @Test
+        @DisplayName("QuantStudio multi-section CSV → picks the LAST 'Well' header (Results section)")
+        void quantStudioMultiSectionCsvPicksLastWellHeader() {
+            // QuantStudio Design & Analysis CSV exports include two sections
+            // both starting with a row whose first cell is "Well": [Sample Setup]
+            // (assigns Well -> sample) then [Results] (carries Cq/quantities).
+            // We want the LAST "Well" row picked so the Results section is parsed,
+            // not the Sample Setup section.
+            String csv = "* Block Type = 96-Well Block (0.2mL)\n"
+                    + "* Chemistry = TAQMAN\n"
+                    + "[Sample Setup]\n"
+                    + "Well,Sample Name,Target Name\n"
+                    + "A1,IGNORE-ME,VIH-1\n"
+                    + "[Results]\n"
+                    + "Well,Sample Name,Target Name,CT\n"
+                    + "A1,RESULT-001,VIH-1,28.5\n";
+
+            Map<String, String> mappings = Map.of(
+                    "Sample Name", "sampleId",
+                    "Target Name", "testCode",
+                    "CT", "ctValue");
+
+            List<ParsedResults> results = FileResultParser.parseCsv(
+                    csv.getBytes(), mappings, ",", 0);
+
+            assertNotNull(results);
+            // Setup section's "IGNORE-ME" must NOT show up — only Results section.
+            assertEquals(1, results.size(), "Should parse only the Results section");
+            assertEquals("RESULT-001", results.get(0).accessionNumber());
+        }
+
+        @Test
+        @DisplayName("Empty result column → falls back to ctValue (QuantStudio CT fallback chain)")
+        void emptyResultFallsBackToCtValue() {
+            // Real QuantStudio rows have CT but blank result cells when only Cq
+            // matters. The parser's value fallback (result -> ctValue ->
+            // interpretation) must keep the row and forward the CT value.
+            String csv = "Sample Name,Target Name,Result,CT\n"
+                    + "S001,VIH-1,,28.5\n";
+
+            Map<String, String> mappings = Map.of(
+                    "Sample Name", "sampleId",
+                    "Target Name", "testCode",
+                    "Result", "result",
+                    "CT", "ctValue");
+
+            List<ParsedResults> results = FileResultParser.parseCsv(
+                    csv.getBytes(), mappings, ",", 0);
+
+            assertNotNull(results);
+            assertEquals(1, results.size(), "Row with blank result + CT must be retained");
+            assertEquals("28.5", results.get(0).results().get(0).value(),
+                    "CT value must be forwarded when result column is blank");
         }
 
         @Test


### PR DESCRIPTION
## Summary

Single bridge PR for the Madagascar QC demo turnaround. Two commits:

| Commit | Concern |
|---|---|
| `ef21d68` fix(astm): correct O.12 Action Code field index (off-by-one) | Bumps `O_ACTION_CODE_FIELD` 12→11 — ASTM LIS2-A2 numbers segments 1-based but Java arrays are 0-based; off-by-one was suppressing all action-code recognition. |
| `ed390b0` feat(qc): propagate lot+level metadata from analyzer to OE via FHIR extensions | End-to-end QC metadata propagation (the meat of this PR). |

(Replaces closed PR #36 — same off-by-one commit, now rolled into a single review surface.)

## Pipeline

```
ASTM Q-segment field 3 (field_code^lot^level)
  └─ ASTMResultParser → AnalyzerResult.lotNumber + .controlLevel

FILE qcRule SPECIMEN_ID_PREFIX (LPC/HPC/CNEG/CPOS operand)
  └─ FileResultParser → AnalyzerResult.controlLevel

  ↓ FhirBundleBuilder

FHIR Observation extensions:
  http://openelis-global.org/fhir/qc/lot-number   (StringType)
  http://openelis-global.org/fhir/qc/control-level (StringType)

  ↓ POST /fhir to OE

OE-side: AnalyzerFhirImportController reads extensions
  → QCResultProcessingService.findMatchingControlLot does
    Tier 1 (lotNumber) → Tier 2 (controlLevel) → Tier 3 (single ACTIVE lot)
```

## Changes (metadata propagation)

- **ASTMResultParser**: extract Q-segment field 3 (`field_code^lot^level`) and attach `lotNumber` + `controlLevel` to the most recent observation.
- **FileResultParser**: surface `controlLevel` as the matched `qcRule` `SPECIMEN_ID_PREFIX` operand (LPC/HPC/CNEG/CPOS); fall back to the generic `isControlRow` heuristic only when no rule matches.
- **QcRuleEvaluator**: add `findMatchingRule(...)` returning the matched rule so callers can read the operand. `isQcSample` retained as a back-compat boolean wrapper.
- **FhirBundleBuilder**: emit two `Observation.extension` URLs when set.
- **AnalyzerRegistrationController**: accept optional `qcRules` array on `/register` and `/sync` so OE pushes canonical rule definitions upstream into bridge memory at registration time.

## Off-by-one fix detail

`O_ACTION_CODE_FIELD` was 12; ASTM O-segment field numbering is 1-based but Java string-split arrays are 0-based. Correct index for the Action Code field is 11. The bug suppressed action-code-driven branching across all O-segment processing.

## Related

- OpenELIS-Global-2#3523 — OE side (FHIR extension intake + 3-tier resolver + nav fixes + submodule bumps)
- openelis-madagascar-distro#7 — distro QuantStudio profile + seed-qc.sh
- analyzer-mock-server#34 — mock --source-ip + QC contract tests

## Test plan

- [ ] Verify OE Tier 2 fires by uploading a QuantStudio CSV with LPC sample IDs against a `(test, instrument)` pair that has both LPC + HPC ACTIVE lots — Tier 1 (no explicit lot) misses, Tier 2 (controlLevel='LPC') resolves to LOT-LPC-26B.
- [ ] ASTM Q-segment with `Q|1|TEST^LOT-12345^HPC|...` resolves via Tier 1.
- [ ] No-metadata + single-ACTIVE-lot still works (Tier 3, back-compat).
- [ ] ASTM action-code-driven branching (cancel, etc.) now triggers correctly post-off-by-one.