### PR TITLE
feat(bridge): corroborate analyzer identity (source IP × in-message sender)

### DIFF
--- a/src/main/java/org/itech/ahb/config/AnalyzerRegistryConfig.java
+++ b/src/main/java/org/itech/ahb/config/AnalyzerRegistryConfig.java
@@ -1,6 +1,8 @@
 package org.itech.ahb.config;
 
+import lombok.AccessLevel;
 import lombok.Data;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
@@ -15,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 /**
@@ -267,6 +270,37 @@ public class AnalyzerRegistryConfig {
          * pattern OE matches with — see {@code MessageNormalizer}.
          */
         private String identifierPattern;
+
+        /**
+         * Compiled form of {@link #identifierPattern}, built once when the pattern is
+         * set so {@code MessageNormalizer} reuses it on every inbound message instead
+         * of recompiling the regex per message. {@code null} when no pattern is set, or
+         * when the supplied regex was invalid — registration/sync validation decides
+         * whether an invalid pattern is rejected (register → 400) or ignored (sync).
+         */
+        @Setter(AccessLevel.NONE)
+        private transient Pattern compiledIdentifierPattern;
+
+        /**
+         * Custom setter (Lombok skips generating one): also (re)compiles
+         * {@link #compiledIdentifierPattern} with {@code CASE_INSENSITIVE}. An invalid
+         * regex leaves the compiled form {@code null} without throwing, so the caller
+         * can detect it via {@link #getCompiledIdentifierPattern()} and choose to reject
+         * or ignore. This is the single place a pattern string is turned into a Pattern.
+         */
+        public void setIdentifierPattern(String identifierPattern) {
+            this.identifierPattern = identifierPattern;
+            Pattern compiled = null;
+            if (identifierPattern != null && !identifierPattern.isBlank()) {
+                try {
+                    compiled = Pattern.compile(identifierPattern, Pattern.CASE_INSENSITIVE);
+                } catch (PatternSyntaxException e) {
+                    // Leave compiled null; the registration/sync path validates and
+                    // rejects (register) or ignores (sync) the bad pattern.
+                }
+            }
+            this.compiledIdentifierPattern = compiled;
+        }
 
         /**
          * Column mappings for FILE protocol (spreadsheet column name → semantic field).

--- a/src/main/java/org/itech/ahb/config/AnalyzerRegistryConfig.java
+++ b/src/main/java/org/itech/ahb/config/AnalyzerRegistryConfig.java
@@ -261,6 +261,14 @@ public class AnalyzerRegistryConfig {
         private String filePattern;
 
         /**
+         * Regex OE uses to identify an inbound message by its sender (HL7 MSH-3/4,
+         * ASTM H-record). Pushed from OE's {@code Analyzer.identifierPattern} so the
+         * bridge corroborates the source-IP identity against the same authoritative
+         * pattern OE matches with — see {@code MessageNormalizer}.
+         */
+        private String identifierPattern;
+
+        /**
          * Column mappings for FILE protocol (spreadsheet column name → semantic field).
          * E.g., {"Sample Name": "sampleId", "Target": "testCode", "CT": "result"}
          * Synced from OE's Analyzer entity at registration time.

--- a/src/main/java/org/itech/ahb/controller/AnalyzerRegistrationController.java
+++ b/src/main/java/org/itech/ahb/controller/AnalyzerRegistrationController.java
@@ -60,6 +60,15 @@ public class AnalyzerRegistrationController {
         entry.setExpectedProtocol(request.protocol);
         entry.setFilePattern(request.filePattern);
         entry.setIdentifierPattern(request.identifierPattern);
+        // Validate the regex once, here, rather than letting an invalid pattern
+        // persist and warn on every inbound message in MessageNormalizer. The
+        // setter compiled it (or left it null on a syntax error).
+        if (request.identifierPattern != null && !request.identifierPattern.isBlank()
+                && entry.getCompiledIdentifierPattern() == null) {
+            return ResponseEntity.badRequest().body(Map.of(
+                    "registered", false,
+                    "error", "identifierPattern is not a valid regex: " + request.identifierPattern));
+        }
         entry.setColumnMappings(request.columnMappings);
         entry.setFileFormat(request.fileFormat);
         entry.setDelimiter(request.delimiter != null ? request.delimiter : ",");
@@ -155,6 +164,16 @@ public class AnalyzerRegistrationController {
             entry.setExpectedProtocol(req.protocol);
             entry.setFilePattern(req.filePattern);
             entry.setIdentifierPattern(req.identifierPattern);
+            // A bulk full-state sync must not fail wholesale on one bad regex:
+            // ignore an invalid identifierPattern (clear it so the entry falls back
+            // to normalized name/id matching) and warn once here instead of on every
+            // inbound message.
+            if (req.identifierPattern != null && !req.identifierPattern.isBlank()
+                    && entry.getCompiledIdentifierPattern() == null) {
+                log.warn("Ignoring invalid identifierPattern '{}' for analyzer '{}' during sync",
+                        req.identifierPattern, req.oeAnalyzerId);
+                entry.setIdentifierPattern(null);
+            }
             entry.setColumnMappings(req.columnMappings);
             entry.setFileFormat(req.fileFormat);
             entry.setDelimiter(req.delimiter != null ? req.delimiter : ",");

--- a/src/main/java/org/itech/ahb/controller/AnalyzerRegistrationController.java
+++ b/src/main/java/org/itech/ahb/controller/AnalyzerRegistrationController.java
@@ -59,6 +59,7 @@ public class AnalyzerRegistrationController {
         entry.setName(request.name);
         entry.setExpectedProtocol(request.protocol);
         entry.setFilePattern(request.filePattern);
+        entry.setIdentifierPattern(request.identifierPattern);
         entry.setColumnMappings(request.columnMappings);
         entry.setFileFormat(request.fileFormat);
         entry.setDelimiter(request.delimiter != null ? request.delimiter : ",");
@@ -153,6 +154,7 @@ public class AnalyzerRegistrationController {
             entry.setName(req.name);
             entry.setExpectedProtocol(req.protocol);
             entry.setFilePattern(req.filePattern);
+            entry.setIdentifierPattern(req.identifierPattern);
             entry.setColumnMappings(req.columnMappings);
             entry.setFileFormat(req.fileFormat);
             entry.setDelimiter(req.delimiter != null ? req.delimiter : ",");
@@ -215,6 +217,9 @@ public class AnalyzerRegistrationController {
         public String name;
         public String protocol;
         public String filePattern;
+        // The regex OE uses to identify a message by its sender (MSH-3/4 for HL7,
+        // H-record for ASTM). Used to corroborate the source-IP identity.
+        public String identifierPattern;
         public java.util.Map<String, String> columnMappings;
         public String fileFormat;
         public String delimiter;

--- a/src/main/java/org/itech/ahb/metrics/MetricsService.java
+++ b/src/main/java/org/itech/ahb/metrics/MetricsService.java
@@ -24,6 +24,23 @@ public class MetricsService {
         ).increment();
     }
 
+    /**
+     * Records the outcome of cross-checking the two analyzer-identity signals —
+     * the connection source IP ({@code resolvedAnalyzerId}) and the in-message
+     * sender ({@code protocolHint}). {@code mode} is one of {@code corroborated}
+     * (both agree), {@code mismatch} (both present, disagree), or
+     * {@code degraded_content_only} (IP did not resolve, routing on content
+     * alone). Identity outcomes never gate routing — this is observability so
+     * the content-only fallback (which silently masked delivery bugs) is visible.
+     */
+    public void recordIdentityMismatch(String protocol, String transport, String mode) {
+        registry.counter("bridge.identity.mismatch",
+            "protocol", protocol,
+            "transport", transport,
+            "mode", mode
+        ).increment();
+    }
+
     public void recordRouted(Timer.Sample sample, String protocol, String transport, boolean success) {
         String result = success ? "success" : "failure";
 

--- a/src/main/java/org/itech/ahb/normalizer/MessageNormalizer.java
+++ b/src/main/java/org/itech/ahb/normalizer/MessageNormalizer.java
@@ -4,6 +4,8 @@ import io.micrometer.core.instrument.Timer;
 import lombok.extern.slf4j.Slf4j;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 import org.itech.ahb.config.AnalyzerRegistryConfig;
 import org.itech.ahb.metrics.MetricsService;
 import org.itech.ahb.model.Protocol;
@@ -312,6 +314,24 @@ public class MessageNormalizer implements MessageRouter {
             return false;
         }
 
+        // Primary: corroborate against the SAME regex OE uses to identify the
+        // sender (Analyzer.identifierPattern). This is authoritative and keeps the
+        // two identity signals consistent — it matches ASTM caret-delimited
+        // senders ("GENEXPERT^GeneXpert^4.6.0") and HL7 MSH-3/4 hints alike,
+        // without the false-positive risk of a manufacturer-substring heuristic.
+        String idPattern = registryEntry.getIdentifierPattern();
+        if (idPattern != null && !idPattern.isBlank()) {
+            try {
+                if (Pattern.compile(idPattern, Pattern.CASE_INSENSITIVE).matcher(protocolHint).find()) {
+                    return true;
+                }
+            } catch (PatternSyntaxException e) {
+                log.warn("Invalid identifierPattern '{}' for analyzer '{}': {}",
+                    idPattern, registryEntry.getName(), e.getMessage());
+            }
+        }
+
+        // Fallback for analyzers registered without a pattern: normalized name/id.
         String normalizedHint = normalizeIdentityToken(protocolHint);
         String normalizedName = normalizeIdentityToken(registryEntry.getName());
         String normalizedId = normalizeIdentityToken(registryEntry.getId());

--- a/src/main/java/org/itech/ahb/normalizer/MessageNormalizer.java
+++ b/src/main/java/org/itech/ahb/normalizer/MessageNormalizer.java
@@ -196,18 +196,33 @@ public class MessageNormalizer implements MessageRouter {
             ? registry.findAnalyzerEntry(envelope.getSourceId()).orElse(null)
             : null;
 
-        // Policy: protocol hints are diagnostic evidence only. Routing remains bound to the
-        // source-registered OpenELIS analyzer ID when present; when not present, OE resolves
+        // Corroborate the two analyzer-identity signals: the connection source IP
+        // (resolvedAnalyzerId) and the in-message sender (protocolHint). Identity
+        // NEVER gates routing — the transparent-pipe rule above stands — this only
+        // surfaces a warning + metric so a silent content-only fallback can't hide
+        // delivery bugs the way it hid the analyzer-demo flake. Routing remains
+        // bound to the IP-resolved analyzer when present; otherwise OE resolves
         // from the FHIR Device resource carrying the same hint.
-        if (resolvedAnalyzerId != null && protocolHint != null && !protocolHint.equals(resolvedAnalyzerId)) {
-            if (registryEntry != null && protocolHintMatchesRegistration(protocolHint, registryEntry)) {
-                log.info("Analyzer identity evidence matched registered analyzer for source '{}': resolved='{}', protocolHint='{}', registeredName='{}'",
-                    envelope.getSourceId(), resolvedAnalyzerId, protocolHint, registryEntry.getName());
+        boolean haveIp = resolvedAnalyzerId != null && !resolvedAnalyzerId.isBlank();
+        boolean haveHint = protocolHint != null && !protocolHint.isBlank();
+        if (haveIp && haveHint) {
+            boolean agrees = protocolHint.equals(resolvedAnalyzerId)
+                || (registryEntry != null && protocolHintMatchesRegistration(protocolHint, registryEntry));
+            if (agrees) {
+                recordIdentity(protocol, transport, "corroborated");
+                log.info("Analyzer identity corroborated for source '{}': resolved='{}', protocolHint='{}', registeredName='{}'",
+                    envelope.getSourceId(), resolvedAnalyzerId, protocolHint,
+                    registryEntry != null ? registryEntry.getName() : "unknown");
             } else {
-                log.warn("Analyzer identity evidence mismatch for source '{}': resolved='{}', protocolHint='{}', registeredName='{}' — routing will continue with resolved analyzer",
+                recordIdentity(protocol, transport, "mismatch");
+                log.warn("Analyzer identity mismatch for source '{}': resolved='{}', protocolHint='{}', registeredName='{}' — routing continues with the IP-resolved analyzer",
                     envelope.getSourceId(), resolvedAnalyzerId, protocolHint,
                     registryEntry != null ? registryEntry.getName() : "unknown");
             }
+        } else if (!haveIp && haveHint) {
+            recordIdentity(protocol, transport, "degraded_content_only");
+            log.warn("Analyzer identity degraded for source '{}': connection source IP did not resolve to a registered analyzer; routing on the in-message sender alone (protocolHint='{}')",
+                envelope.getSourceId(), protocolHint);
         }
 
         // Rebuild envelope with explicit canonical ID and protocol hint.
@@ -272,6 +287,12 @@ public class MessageNormalizer implements MessageRouter {
             if (trimmed.startsWith("R|")) hasR = true;
         }
         return hasQ && !hasR;
+    }
+
+    private void recordIdentity(String protocol, String transport, String mode) {
+        if (metricsService != null) {
+            metricsService.recordIdentityMismatch(protocol, transport, mode);
+        }
     }
 
     private String firstNonBlank(String first, String second) {

--- a/src/main/java/org/itech/ahb/normalizer/MessageNormalizer.java
+++ b/src/main/java/org/itech/ahb/normalizer/MessageNormalizer.java
@@ -5,7 +5,6 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
 import org.itech.ahb.config.AnalyzerRegistryConfig;
 import org.itech.ahb.metrics.MetricsService;
 import org.itech.ahb.model.Protocol;
@@ -319,16 +318,12 @@ public class MessageNormalizer implements MessageRouter {
         // two identity signals consistent — it matches ASTM caret-delimited
         // senders ("GENEXPERT^GeneXpert^4.6.0") and HL7 MSH-3/4 hints alike,
         // without the false-positive risk of a manufacturer-substring heuristic.
-        String idPattern = registryEntry.getIdentifierPattern();
-        if (idPattern != null && !idPattern.isBlank()) {
-            try {
-                if (Pattern.compile(idPattern, Pattern.CASE_INSENSITIVE).matcher(protocolHint).find()) {
-                    return true;
-                }
-            } catch (PatternSyntaxException e) {
-                log.warn("Invalid identifierPattern '{}' for analyzer '{}': {}",
-                    idPattern, registryEntry.getName(), e.getMessage());
-            }
+        // The pattern is compiled once at registration/sync time and cached on the
+        // entry (CASE_INSENSITIVE); invalid patterns are rejected/ignored there and
+        // never reach here, so this is a pure matcher().find() per message.
+        Pattern idPattern = registryEntry.getCompiledIdentifierPattern();
+        if (idPattern != null && idPattern.matcher(protocolHint).find()) {
+            return true;
         }
 
         // Fallback for analyzers registered without a pattern: normalized name/id.

--- a/src/test/java/org/itech/ahb/config/AnalyzerRegistryConfigTest.java
+++ b/src/test/java/org/itech/ahb/config/AnalyzerRegistryConfigTest.java
@@ -241,6 +241,62 @@ class AnalyzerRegistryConfigTest {
     }
 
     // -------------------------------------------------------------------------
+    // identifierPattern: compile-once + validate-on-set (Copilot #42)
+    // -------------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("AnalyzerEntry.identifierPattern compiles once on set")
+    class IdentifierPatternCompilation {
+
+        @Test
+        @DisplayName("a valid regex is compiled and cached (CASE_INSENSITIVE), reused per message")
+        void validPatternIsCompiledAndCached() {
+            AnalyzerRegistryConfig.AnalyzerEntry entry = new AnalyzerRegistryConfig.AnalyzerEntry();
+            entry.setIdentifierPattern("GENEXPERT|CEPHEID");
+
+            assertNotNull(entry.getCompiledIdentifierPattern(),
+                    "valid regex must compile to a cached Pattern");
+            // Same instance returned each call — proves it is not recompiled per access.
+            assertSame(entry.getCompiledIdentifierPattern(), entry.getCompiledIdentifierPattern());
+            // CASE_INSENSITIVE: a lowercase ASTM sender still matches.
+            assertTrue(entry.getCompiledIdentifierPattern().matcher("genexpert^GeneXpert^4.6.0").find());
+        }
+
+        @Test
+        @DisplayName("an invalid regex leaves the compiled form null (no throw) so callers can reject/ignore")
+        void invalidPatternLeavesCompiledNull() {
+            AnalyzerRegistryConfig.AnalyzerEntry entry = new AnalyzerRegistryConfig.AnalyzerEntry();
+            // Unbalanced bracket — a PatternSyntaxException source.
+            assertDoesNotThrow(() -> entry.setIdentifierPattern("MINDRAY["));
+            assertEquals("MINDRAY[", entry.getIdentifierPattern(),
+                    "the raw string is still retained for diagnostics");
+            assertNull(entry.getCompiledIdentifierPattern(),
+                    "an invalid regex must not produce a Pattern");
+        }
+
+        @Test
+        @DisplayName("null / blank pattern compiles to null")
+        void nullOrBlankPatternCompilesToNull() {
+            AnalyzerRegistryConfig.AnalyzerEntry entry = new AnalyzerRegistryConfig.AnalyzerEntry();
+            entry.setIdentifierPattern(null);
+            assertNull(entry.getCompiledIdentifierPattern());
+            entry.setIdentifierPattern("   ");
+            assertNull(entry.getCompiledIdentifierPattern());
+        }
+
+        @Test
+        @DisplayName("re-setting to a new pattern replaces the cached compiled form")
+        void resettingPatternReplacesCompiledForm() {
+            AnalyzerRegistryConfig.AnalyzerEntry entry = new AnalyzerRegistryConfig.AnalyzerEntry();
+            entry.setIdentifierPattern("AAA");
+            assertTrue(entry.getCompiledIdentifierPattern().matcher("aaa").find());
+            entry.setIdentifierPattern("BBB");
+            assertFalse(entry.getCompiledIdentifierPattern().matcher("aaa").find());
+            assertTrue(entry.getCompiledIdentifierPattern().matcher("bbb").find());
+        }
+    }
+
+    // -------------------------------------------------------------------------
     // Helper methods
     // -------------------------------------------------------------------------
 

--- a/src/test/java/org/itech/ahb/controller/AnalyzerRegistrationControllerIdentifierPatternTest.java
+++ b/src/test/java/org/itech/ahb/controller/AnalyzerRegistrationControllerIdentifierPatternTest.java
@@ -1,0 +1,103 @@
+package org.itech.ahb.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+import java.util.Map;
+import org.itech.ahb.config.AnalyzerRegistryConfig;
+import org.itech.ahb.config.AnalyzerRegistryConfig.AnalyzerEntry;
+import org.itech.ahb.controller.AnalyzerRegistrationController.RegistrationRequest;
+import org.itech.ahb.file.FileConfig;
+import org.itech.ahb.file.FileWatcher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * Validation + caching of {@code identifierPattern} at registration time
+ * (Copilot review on PR #42). An invalid regex must be caught once, here —
+ * rejected on {@code /register} (400) and ignored on a bulk {@code /sync} —
+ * rather than persisted and re-warned on every inbound message in
+ * {@link org.itech.ahb.normalizer.MessageNormalizer}. A valid pattern is
+ * compiled once and cached on the {@link AnalyzerEntry} for per-message reuse.
+ *
+ * <p>Plain JUnit + Mockito (no Spring context): the validation lives in the
+ * controller method and the registry is exercised for real.
+ */
+@DisplayName("AnalyzerRegistrationController identifierPattern validation")
+class AnalyzerRegistrationControllerIdentifierPatternTest {
+
+    private AnalyzerRegistryConfig registry;
+    private AnalyzerRegistrationController controller;
+
+    @BeforeEach
+    void setUp() {
+        registry = new AnalyzerRegistryConfig();
+        FileWatcher fileWatcher = mock(FileWatcher.class);
+        FileConfig fileConfig = mock(FileConfig.class);
+        controller = new AnalyzerRegistrationController(registry, fileWatcher, fileConfig);
+    }
+
+    private RegistrationRequest req(String sourceId, String pattern) {
+        RegistrationRequest r = new RegistrationRequest();
+        r.oeAnalyzerId = "OE-" + sourceId;
+        r.sourceId = sourceId;
+        r.name = "Analyzer " + sourceId;
+        r.protocol = "HL7"; // non-FILE: skips the file-watcher branch
+        r.identifierPattern = pattern;
+        return r;
+    }
+
+    @Test
+    @DisplayName("/register rejects an invalid identifierPattern with 400 and does not register it")
+    void registerRejectsInvalidPattern() {
+        ResponseEntity<Map<String, Object>> response = controller.register(req("10.0.0.1", "MINDRAY["));
+
+        assertEquals(400, response.getStatusCode().value());
+        assertEquals(false, response.getBody().get("registered"));
+        assertTrue(registry.getRegisteredAnalyzers().isEmpty(),
+                "an analyzer with an invalid pattern must not be registered");
+    }
+
+    @Test
+    @DisplayName("/register accepts a valid identifierPattern and caches the compiled Pattern")
+    void registerAcceptsValidPatternAndCaches() {
+        ResponseEntity<Map<String, Object>> response =
+                controller.register(req("10.0.0.2", "GENEXPERT|CEPHEID"));
+
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(true, response.getBody().get("registered"));
+
+        AnalyzerEntry entry = registry.getRegisteredAnalyzers().get("10.0.0.2");
+        assertNotNull(entry, "the analyzer must be registered");
+        assertNotNull(entry.getCompiledIdentifierPattern(),
+                "a valid pattern must be compiled and cached on the entry");
+        assertTrue(entry.getCompiledIdentifierPattern().matcher("genexpert^GeneXpert^4.6.0").find());
+    }
+
+    @Test
+    @DisplayName("/sync ignores an invalid pattern (registers without it) but keeps valid ones")
+    void syncIgnoresInvalidButKeepsValid() {
+        ResponseEntity<Map<String, Object>> response = controller.sync(List.of(
+                req("10.0.0.3", "BAD[REGEX"),
+                req("10.0.0.4", "MINDRAY.*BC.?5380")));
+
+        assertEquals(200, response.getStatusCode().value());
+
+        AnalyzerEntry bad = registry.getRegisteredAnalyzers().get("10.0.0.3");
+        assertNotNull(bad, "a bad pattern must not drop the whole analyzer from a bulk sync");
+        assertNull(bad.getIdentifierPattern(),
+                "the invalid pattern is cleared so the entry falls back to name/id matching");
+        assertNull(bad.getCompiledIdentifierPattern());
+
+        AnalyzerEntry good = registry.getRegisteredAnalyzers().get("10.0.0.4");
+        assertNotNull(good);
+        assertNotNull(good.getCompiledIdentifierPattern(),
+                "the valid pattern in the same sync batch is still compiled and cached");
+    }
+}

--- a/src/test/java/org/itech/ahb/fhir/FileResultParserTest.java
+++ b/src/test/java/org/itech/ahb/fhir/FileResultParserTest.java
@@ -40,16 +40,24 @@ class FileResultParserTest {
             "CT", "result",
             "Units", "units");
 
-    // The REAL Bruker FluoroCycler XT export headers (verified against site
-    // captures + a user-reported file), mapped to semantic fields. The parser
-    // matches headers exactly (trim only), so these must be the literal export
-    // column names.
-    private static final Map<String, String> FLUOROCYCLER_MAPPINGS = Map.of(
-            "Sample ID", "sampleId",
-            "Type", "qcTask",
-            "Calc. Conc.", "result",
-            "Result", "interpretation",
-            "testCode", "testCode");
+    // Superset FluoroCycler XT mapping: recognizes BOTH the raw Bruker instrument
+    // export (Sample ID / Calc. Conc. / Result, verified against site captures + a
+    // user-reported file) AND the standardized converter output (SampleID / CalcConc
+    // / TargetName / Interpretation, from scripts/converters/convert-fluorocycler-legacy.py).
+    // The parser matches headers exactly (trim only) and assigns a role to each
+    // header it finds, so a file in EITHER format imports without running the
+    // converter. Mirrors projects/analyzer-profiles/file/fluorocycler-xt.json.
+    private static final Map<String, String> FLUOROCYCLER_MAPPINGS = Map.ofEntries(
+            Map.entry("Sample ID", "sampleId"),
+            Map.entry("SampleID", "sampleId"),
+            Map.entry("Type", "qcTask"),
+            Map.entry("Calc. Conc.", "result"),
+            Map.entry("CalcConc", "result"),
+            Map.entry("Result", "interpretation"),
+            Map.entry("Interpretation", "interpretation"),
+            Map.entry("TargetName", "testCode"),
+            Map.entry("testCode", "testCode"),
+            Map.entry("WellPosition", "position"));
 
     // The previous (broken) profile mapping: idealized headers that match no
     // real export, so every column resolved empty and zero results imported.
@@ -97,6 +105,28 @@ class FileResultParserTest {
             // ("Sample ID"/"Calc. Conc."/"testCode") — exact matching resolves nothing.
             assertTrue(results == null || results.isEmpty(),
                     "old idealized mapping must extract nothing — proving the profile was broken");
+        }
+
+        @Test
+        @DisplayName("converter output headers parse with the same superset mapping (no converter run needed)")
+        void convertedHeadersParseWithSupersetMapping() {
+            // Headers as emitted by scripts/converters/convert-fluorocycler-legacy.py.
+            // The superset mapping recognizes these too, so a pre-converted file
+            // imports through the identical profile as the raw export.
+            String[] convertedHeaders = {"SampleID", "WellPosition", "TargetName", "CalcConc", "Interpretation", "Type"};
+            InputStream xlsx = buildXlsx("Sheet1", convertedHeaders, new Object[][] {
+                    {"DEV-PAT-002", "A1", "VL", 980.0, "Detected", "Unknown"},
+            });
+
+            List<ParsedResults> results = FileResultParser.parse(xlsx, FLUOROCYCLER_MAPPINGS);
+
+            assertNotNull(results);
+            assertFalse(results.isEmpty(),
+                    "superset mapping must extract results from the converter output format");
+            ParsedResults patient = results.stream()
+                    .filter(r -> "DEV-PAT-002".equals(r.accessionNumber())).findFirst().orElse(null);
+            assertNotNull(patient, "the converted patient row must be extracted");
+            assertEquals("VL", patient.results().get(0).testCode());
         }
     }
 

--- a/src/test/java/org/itech/ahb/fhir/FileResultParserTest.java
+++ b/src/test/java/org/itech/ahb/fhir/FileResultParserTest.java
@@ -40,6 +40,66 @@ class FileResultParserTest {
             "CT", "result",
             "Units", "units");
 
+    // The REAL Bruker FluoroCycler XT export headers (verified against site
+    // captures + a user-reported file), mapped to semantic fields. The parser
+    // matches headers exactly (trim only), so these must be the literal export
+    // column names.
+    private static final Map<String, String> FLUOROCYCLER_MAPPINGS = Map.of(
+            "Sample ID", "sampleId",
+            "Type", "qcTask",
+            "Calc. Conc.", "result",
+            "Result", "interpretation",
+            "testCode", "testCode");
+
+    // The previous (broken) profile mapping: idealized headers that match no
+    // real export, so every column resolved empty and zero results imported.
+    private static final Map<String, String> FLUOROCYCLER_OLD_BROKEN_MAPPINGS = Map.of(
+            "SampleID", "sampleId",
+            "CalcConc", "result",
+            "TargetName", "testCode",
+            "Interpretation", "interpretation");
+
+    @Nested
+    @DisplayName("FluoroCycler XT real export format (profile mapping regression)")
+    class FluoroCyclerRealFormat {
+
+        private final String[] realHeaders = {"Sample ID", "Type", "Calc. Conc.", "Result", "testCode"};
+
+        @Test
+        @DisplayName("real export headers parse with the corrected profile mapping")
+        void realHeadersParseWithCorrectedMapping() {
+            InputStream xlsx = buildXlsx("Sheet1", realHeaders, new Object[][] {
+                    {"DEV-PAT-001", "Unknown", 1520.5, "Detected", "VL"},
+                    {"STD 1E7", "Standard", null, "STD 1E7 control failed", "VL"},
+            });
+
+            List<ParsedResults> results = FileResultParser.parse(xlsx, FLUOROCYCLER_MAPPINGS);
+
+            assertNotNull(results);
+            assertFalse(results.isEmpty(),
+                    "corrected mapping must extract results from the real export format");
+            ParsedResults patient = results.stream()
+                    .filter(r -> "DEV-PAT-001".equals(r.accessionNumber())).findFirst().orElse(null);
+            assertNotNull(patient, "the patient row must be extracted");
+            assertEquals("VL", patient.results().get(0).testCode());
+        }
+
+        @Test
+        @DisplayName("the old idealized mapping extracted NOTHING from the real export (the bug)")
+        void oldMappingExtractedNothing() {
+            InputStream xlsx = buildXlsx("Sheet1", realHeaders, new Object[][] {
+                    {"DEV-PAT-001", "Unknown", 1520.5, "Detected", "VL"},
+            });
+
+            List<ParsedResults> results = FileResultParser.parse(xlsx, FLUOROCYCLER_OLD_BROKEN_MAPPINGS);
+
+            // SampleID/CalcConc/TargetName don't exist in the real export
+            // ("Sample ID"/"Calc. Conc."/"testCode") — exact matching resolves nothing.
+            assertTrue(results == null || results.isEmpty(),
+                    "old idealized mapping must extract nothing — proving the profile was broken");
+        }
+    }
+
     /**
      * Build an xlsx workbook in memory and return its bytes as an InputStream.
      */

--- a/src/test/java/org/itech/ahb/normalizer/MessageNormalizerIdentityCorroborationTest.java
+++ b/src/test/java/org/itech/ahb/normalizer/MessageNormalizerIdentityCorroborationTest.java
@@ -110,4 +110,39 @@ class MessageNormalizerIdentityCorroborationTest {
         assertEquals(1.0, identityCount("degraded_content_only"));
         verify(forwardingRouter).route(any(MessageEnvelope.class));
     }
+
+    private void registerAnalyzerWithPattern(String id, String name, String identifierPattern) {
+        AnalyzerEntry entry = new AnalyzerEntry();
+        entry.setId(id);
+        entry.setName(name);
+        entry.setIdentifierPattern(identifierPattern);
+        analyzerRegistry.register(SOURCE_IP, entry);
+    }
+
+    @Test
+    @DisplayName("ASTM caret sender corroborates via OE identifier_pattern (no false mismatch)")
+    void corroboratesViaIdentifierPattern() {
+        when(identifier.identify(any())).thenReturn("44");
+        // The display name does NOT substring-match the caret-delimited sender, so
+        // only the authoritative identifier_pattern keeps this from a false mismatch.
+        registerAnalyzerWithPattern("44", "Demo: GeneXpert ASTM", "GENEXPERT|CEPHEID");
+
+        assertTrue(normalizer.process(hl7FromSourceIp("GENEXPERT^GeneXpert^4.6.0")));
+
+        assertEquals(1.0, identityCount("corroborated"));
+        assertEquals(0.0, identityCount("mismatch"));
+    }
+
+    @Test
+    @DisplayName("identifier_pattern still flags a genuine cross-model mismatch (no over-match)")
+    void identifierPatternStillCatchesMismatch() {
+        when(identifier.identify(any())).thenReturn("93");
+        registerAnalyzerWithPattern("93", "Demo: Mindray BC-5380", "MINDRAY.*BC.?5380|BC.?5380");
+
+        // A BS-200 sender arriving on the BC-5380's source IP must NOT corroborate.
+        assertTrue(normalizer.process(hl7FromSourceIp("MINDRAY-BS-200")));
+
+        assertEquals(1.0, identityCount("mismatch"));
+        assertEquals(0.0, identityCount("corroborated"));
+    }
 }

--- a/src/test/java/org/itech/ahb/normalizer/MessageNormalizerIdentityCorroborationTest.java
+++ b/src/test/java/org/itech/ahb/normalizer/MessageNormalizerIdentityCorroborationTest.java
@@ -1,0 +1,113 @@
+package org.itech.ahb.normalizer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.itech.ahb.config.AnalyzerRegistryConfig;
+import org.itech.ahb.config.AnalyzerRegistryConfig.AnalyzerEntry;
+import org.itech.ahb.metrics.MetricsService;
+import org.itech.ahb.model.Protocol;
+import org.itech.ahb.model.Transport;
+import org.itech.ahb.routing.HttpForwardingRouter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The bridge corroborates the two analyzer-identity signals — the connection
+ * source IP (resolvedAnalyzerId, via {@link AnalyzerIdentifier}) and the
+ * in-message sender (protocolHint) — and surfaces the outcome as a
+ * {@code bridge.identity.mismatch} metric. Identity NEVER gates routing
+ * (transparent-pipe rule): a mismatch is a warning, not a rejection. These tests
+ * pin the three outcomes and that routing always proceeds.
+ */
+class MessageNormalizerIdentityCorroborationTest {
+
+    private static final String SOURCE_IP = "10.42.21.10";
+
+    private SimpleMeterRegistry meters;
+    private AnalyzerRegistryConfig analyzerRegistry;
+    private HttpForwardingRouter forwardingRouter;
+    private AnalyzerIdentifier identifier;
+    private MessageNormalizer normalizer;
+
+    @BeforeEach
+    void setUp() {
+        meters = new SimpleMeterRegistry();
+        MetricsService metrics = new MetricsService(meters);
+        analyzerRegistry = new AnalyzerRegistryConfig();
+        forwardingRouter = mock(HttpForwardingRouter.class);
+        identifier = mock(AnalyzerIdentifier.class);
+        when(forwardingRouter.route(any(MessageEnvelope.class))).thenReturn(true);
+        // Synchronous executor so any async work completes before assertions.
+        normalizer = new MessageNormalizer(
+            forwardingRouter, identifier, analyzerRegistry, metrics, null, null, Runnable::run);
+    }
+
+    private void registerAnalyzer(String id, String name) {
+        AnalyzerEntry entry = new AnalyzerEntry();
+        entry.setId(id);
+        entry.setName(name);
+        analyzerRegistry.register(SOURCE_IP, entry);
+    }
+
+    private MessageEnvelope hl7FromSourceIp(String sender) {
+        return MessageEnvelope.builder()
+            .protocol(Protocol.HL7)
+            .transport(Transport.MLLP)
+            .sourceId(SOURCE_IP)
+            .rawMessage("MSH|^~\\&|MINDRAY|BS-200|OE|LAB|20260101||ORU^R01|C1|P|2.3.1\r"
+                + "OBX|1|NM|^^^GLU||5|mg/dL\r")
+            .protocolAnalyzerHint(sender)
+            .build();
+    }
+
+    private double identityCount(String mode) {
+        Counter c = meters.find("bridge.identity.mismatch").tag("mode", mode).counter();
+        return c == null ? 0.0 : c.count();
+    }
+
+    @Test
+    @DisplayName("source IP and in-message sender agree -> corroborated; routing proceeds")
+    void corroborated() {
+        when(identifier.identify(any())).thenReturn("5");
+        registerAnalyzer("5", "Demo Mindray BS-200"); // registered name contains the sender token
+
+        assertTrue(normalizer.process(hl7FromSourceIp("MINDRAY-BS-200")));
+
+        assertEquals(1.0, identityCount("corroborated"));
+        assertEquals(0.0, identityCount("mismatch"));
+        verify(forwardingRouter).route(any(MessageEnvelope.class));
+    }
+
+    @Test
+    @DisplayName("source IP and in-message sender disagree -> mismatch; routing STILL proceeds")
+    void mismatch() {
+        when(identifier.identify(any())).thenReturn("7");
+        registerAnalyzer("7", "Abbott Architect"); // does not contain the Mindray sender token
+
+        assertTrue(normalizer.process(hl7FromSourceIp("MINDRAY-BS-200")));
+
+        assertEquals(1.0, identityCount("mismatch"));
+        assertEquals(0.0, identityCount("corroborated"));
+        // Identity is observability only — a mismatch must never gate routing.
+        verify(forwardingRouter).route(any(MessageEnvelope.class));
+    }
+
+    @Test
+    @DisplayName("source IP unresolved but sender present -> degraded_content_only; routing proceeds")
+    void degradedContentOnly() {
+        when(identifier.identify(any())).thenReturn(null); // IP signal absent
+
+        assertTrue(normalizer.process(hl7FromSourceIp("MINDRAY-BS-200")));
+
+        assertEquals(1.0, identityCount("degraded_content_only"));
+        verify(forwardingRouter).route(any(MessageEnvelope.class));
+    }
+}


### PR DESCRIPTION
## Why
The bridge identifies an inbound analyzer two ways — the connection **source IP** (`resolvedAnalyzerId`) and the **in-message sender** (`protocolHint`). The cross-check existed but was log-only, never fired when the IP failed to resolve, and emitted no metric — so a silent content-only fallback (which masked a delivery flake for months) was invisible.

## What
- `bridge.identity.mismatch` counter with `mode = corroborated | mismatch | degraded_content_only`, plus the previously-ignored case where the IP doesn't resolve but a sender hint is present. Identity is **observability only** — a mismatch warns, it never gates routing (transparent-pipe rule preserved).
- Corroborate the sender against OE's authoritative `identifier_pattern` (the same regex OE identifies with), plumbed onto `AnalyzerEntry`, before the name/id fallback. This corroborates ASTM caret senders (`GENEXPERT^GeneXpert^4.6.0`) correctly **without** the false-corroboration risk of a manufacturer substring.

## Tests
- Corroboration outcomes (match / mismatch / degraded) via `SimpleMeterRegistry`, asserting routing always proceeds.
- A BS-200 sender on the BC-5380 source IP still mismatches (no over-match).
- Full suite **582 passed**. Live: all four demo TCP analyzers log `corroborated`.

> Pairs with OpenELIS-Global-2 PR that pushes `identifier_pattern` in the registration payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)